### PR TITLE
M3 PR 3.2: unify build_*_cmd via _sandy_translate_args + _sandy_wrap_cmd_exit_pause

### DIFF
--- a/sandy
+++ b/sandy
@@ -2174,6 +2174,82 @@ _seed_channel discord DISCORD_BOT_TOKEN DISCORD_ALLOWED_SENDERS
 fi  # end Claude-only plugin/channel block
 
 # --- Agent command builders (used by single-agent and multi-pane launch modes) ---
+# --- Shared helpers for build_*_cmd (M3 PR 3.2) ---
+#
+# _sandy_translate_args: per-agent arg-list translation.
+#
+# Each CLI sandy wraps takes a slightly different surface — claude is the
+# native shape (-p / --continue both work directly), gemini accepts --prompt
+# instead of -p (and has no headless resume), codex/opencode take the prompt
+# as a positional arg with no flag (and have no headless resume either).
+#
+# Returns the translated args printf %q'd and space-separated (leading space
+# included so callers can `cmd+="$(...)"` cleanly). Pre-PR-3.2 each agent
+# duplicated this loop with slightly diverging logic; the test sections 28,
+# 28b, 28g lock in the expected per-agent translations.
+_sandy_translate_args() {
+    local agent="$1"; shift
+    local out=""
+    local arg
+    for arg in "$@"; do
+        case "$agent" in
+            claude)
+                # Native shape — pass everything through verbatim. Claude
+                # understands -p / --continue / etc. directly.
+                out+=" $(printf '%q' "$arg")"
+                ;;
+            gemini)
+                # -p / --print → --prompt; --continue / -c dropped.
+                case "$arg" in
+                    -p|--print)    out+=" --prompt" ;;
+                    --continue|-c) : ;;
+                    *)             out+=" $(printf '%q' "$arg")" ;;
+                esac
+                ;;
+            codex|opencode)
+                # Headless mode is a subcommand (`codex exec` / `opencode run`)
+                # with the prompt as a positional arg, so the -p flag itself
+                # is dropped (its value remains as a regular positional arg).
+                # No headless resume → --continue / -c dropped.
+                case "$arg" in
+                    -p|--print|--prompt) : ;;
+                    --continue|-c)       : ;;
+                    *)                   out+=" $(printf '%q' "$arg")" ;;
+                esac
+                ;;
+        esac
+    done
+    printf '%s' "$out"
+}
+
+# _sandy_wrap_cmd_exit_pause: append the tmux-interactive exit-pause suffix.
+#
+# When the session is interactive (tmux), the pane closes the moment the
+# agent exits, swallowing whatever final output it printed. The pause holds
+# the pane open until the user presses Enter. In headless / one-shot mode
+# (`-p`/`--print`/`--prompt`), there's no tmux to hold open — output streams
+# directly to the parent shell — so the trailer is omitted.
+#
+# Under SANDY_VERBOSE>=1, the trailer also reports the exit code so the user
+# can spot non-zero exits before they're hidden by the pause prompt.
+#
+# The `\$?` / `\$_exit` / `\"` escapes are deliberate: they're literal in the
+# returned string and only expand when bash evaluates it later (in the tmux
+# pane via user-setup.sh). The pre-PR-3.2 functions used the same escapes;
+# moving them into one place is the whole point of this helper.
+_sandy_wrap_cmd_exit_pause() {
+    local label="$1" cmd="$2"
+    if [ "$_sandy_is_headless" = "true" ]; then
+        printf '%s' "$cmd"
+        return 0
+    fi
+    if [ "${SANDY_VERBOSE:-0}" -ge 1 ]; then
+        printf '%s' "${cmd}; _exit=\$?; echo ''; echo \"[sandy] ${label} exited (code: \$_exit)\"; read -p 'Press Enter to exit...'"
+    else
+        printf '%s' "${cmd}; read -p ''"
+    fi
+}
+
 build_claude_cmd() {
     local cmd="claude --model ${SANDY_MODEL:-claude-opus-4-7} --teammate-mode tmux"
     if [ "${SANDY_SKIP_PERMISSIONS:-true}" = "true" ]; then
@@ -2223,19 +2299,8 @@ build_claude_cmd() {
             cmd+=" --resume"
         fi
     fi
-    for arg in "$@"; do
-        cmd+=" $(printf "%q" "$arg")"
-    done
-    # In interactive (tmux) mode, pause on exit so the user can see output before
-    # tmux closes. In headless mode, skip — there's no tmux to hold open.
-    if [ "$_sandy_is_headless" != "true" ]; then
-        if [ "${SANDY_VERBOSE:-0}" -ge 1 ]; then
-            cmd="$cmd; _exit=\$?; echo ''; echo \"[sandy] Claude Code exited (code: \$_exit)\"; read -p 'Press Enter to exit...'"
-        else
-            cmd="$cmd; read -p ''"
-        fi
-    fi
-    printf '%s' "$cmd"
+    cmd+="$(_sandy_translate_args claude "$@")"
+    _sandy_wrap_cmd_exit_pause "Claude Code" "$cmd"
 }
 
 build_codex_cmd() {
@@ -2256,25 +2321,8 @@ build_codex_cmd() {
     if [ -n "${CODEX_MODEL:-}" ]; then
         cmd+=" --model $(printf "%q" "$CODEX_MODEL")"
     fi
-    # Flag translation: sandy's -p/--print/--prompt all mean "run this prompt".
-    # codex exec takes the prompt as a positional arg, so drop the flag itself
-    # and pass only the value. --continue/-c → drop (codex has `codex resume`
-    # but not a headless --continue flag), matching the gemini behavior.
-    for arg in "$@"; do
-        case "$arg" in
-            -p|--print|--prompt) : ;;
-            --continue|-c)       : ;;
-            *)                   cmd+=" $(printf "%q" "$arg")" ;;
-        esac
-    done
-    if [ "$_sandy_is_headless" != "true" ]; then
-        if [ "${SANDY_VERBOSE:-0}" -ge 1 ]; then
-            cmd="$cmd; _exit=\$?; echo ''; echo \"[sandy] Codex CLI exited (code: \$_exit)\"; read -p 'Press Enter to exit...'"
-        else
-            cmd="$cmd; read -p ''"
-        fi
-    fi
-    printf '%s' "$cmd"
+    cmd+="$(_sandy_translate_args codex "$@")"
+    _sandy_wrap_cmd_exit_pause "Codex CLI" "$cmd"
 }
 
 build_opencode_cmd() {
@@ -2295,25 +2343,8 @@ build_opencode_cmd() {
     if [ -n "${OPENCODE_MODEL:-}" ]; then
         cmd+=" --model $(printf "%q" "$OPENCODE_MODEL")"
     fi
-    # Flag translation: sandy's -p/--print/--prompt all mean "run this prompt".
-    # opencode run takes the prompt as a positional arg, so drop the flag itself
-    # and pass only the value. --continue/-c → drop (opencode has no headless
-    # resume flag), matching the codex/gemini behavior.
-    for arg in "$@"; do
-        case "$arg" in
-            -p|--print|--prompt) : ;;
-            --continue|-c)       : ;;
-            *)                   cmd+=" $(printf "%q" "$arg")" ;;
-        esac
-    done
-    if [ "$_sandy_is_headless" != "true" ]; then
-        if [ "${SANDY_VERBOSE:-0}" -ge 1 ]; then
-            cmd="$cmd; _exit=\$?; echo ''; echo \"[sandy] OpenCode exited (code: \$_exit)\"; read -p 'Press Enter to exit...'"
-        else
-            cmd="$cmd; read -p ''"
-        fi
-    fi
-    printf '%s' "$cmd"
+    cmd+="$(_sandy_translate_args opencode "$@")"
+    _sandy_wrap_cmd_exit_pause "OpenCode" "$cmd"
 }
 
 build_gemini_cmd() {
@@ -2328,24 +2359,8 @@ build_gemini_cmd() {
     if [ -n "${GEMINI_MODEL:-}" ]; then
         cmd+=" --model $(printf "%q" "$GEMINI_MODEL")"
     fi
-    # Translate Claude-style flags to Gemini equivalents.
-    # -p / --print "prompt" → --prompt "prompt"  (Gemini has no -p shorthand)
-    # --continue / -c       → drop (Gemini has no headless resume flag)
-    for arg in "$@"; do
-        case "$arg" in
-            -p|--print)    cmd+=" --prompt" ;;
-            --continue|-c) : ;;
-            *)             cmd+=" $(printf "%q" "$arg")" ;;
-        esac
-    done
-    if [ "$_sandy_is_headless" != "true" ]; then
-        if [ "${SANDY_VERBOSE:-0}" -ge 1 ]; then
-            cmd="$cmd; _exit=\$?; echo ''; echo \"[sandy] Gemini CLI exited (code: \$_exit)\"; read -p 'Press Enter to exit...'"
-        else
-            cmd="$cmd; read -p ''"
-        fi
-    fi
-    printf '%s' "$cmd"
+    cmd+="$(_sandy_translate_args gemini "$@")"
+    _sandy_wrap_cmd_exit_pause "Gemini CLI" "$cmd"
 }
 
 # Detect headless / one-shot mode — bypass tmux so output reaches the parent shell.

--- a/templates/user-setup.sh.tmpl
+++ b/templates/user-setup.sh.tmpl
@@ -606,6 +606,82 @@ _seed_channel discord DISCORD_BOT_TOKEN DISCORD_ALLOWED_SENDERS
 fi  # end Claude-only plugin/channel block
 
 # --- Agent command builders (used by single-agent and multi-pane launch modes) ---
+# --- Shared helpers for build_*_cmd (M3 PR 3.2) ---
+#
+# _sandy_translate_args: per-agent arg-list translation.
+#
+# Each CLI sandy wraps takes a slightly different surface — claude is the
+# native shape (-p / --continue both work directly), gemini accepts --prompt
+# instead of -p (and has no headless resume), codex/opencode take the prompt
+# as a positional arg with no flag (and have no headless resume either).
+#
+# Returns the translated args printf %q'd and space-separated (leading space
+# included so callers can `cmd+="$(...)"` cleanly). Pre-PR-3.2 each agent
+# duplicated this loop with slightly diverging logic; the test sections 28,
+# 28b, 28g lock in the expected per-agent translations.
+_sandy_translate_args() {
+    local agent="$1"; shift
+    local out=""
+    local arg
+    for arg in "$@"; do
+        case "$agent" in
+            claude)
+                # Native shape — pass everything through verbatim. Claude
+                # understands -p / --continue / etc. directly.
+                out+=" $(printf '%q' "$arg")"
+                ;;
+            gemini)
+                # -p / --print → --prompt; --continue / -c dropped.
+                case "$arg" in
+                    -p|--print)    out+=" --prompt" ;;
+                    --continue|-c) : ;;
+                    *)             out+=" $(printf '%q' "$arg")" ;;
+                esac
+                ;;
+            codex|opencode)
+                # Headless mode is a subcommand (`codex exec` / `opencode run`)
+                # with the prompt as a positional arg, so the -p flag itself
+                # is dropped (its value remains as a regular positional arg).
+                # No headless resume → --continue / -c dropped.
+                case "$arg" in
+                    -p|--print|--prompt) : ;;
+                    --continue|-c)       : ;;
+                    *)                   out+=" $(printf '%q' "$arg")" ;;
+                esac
+                ;;
+        esac
+    done
+    printf '%s' "$out"
+}
+
+# _sandy_wrap_cmd_exit_pause: append the tmux-interactive exit-pause suffix.
+#
+# When the session is interactive (tmux), the pane closes the moment the
+# agent exits, swallowing whatever final output it printed. The pause holds
+# the pane open until the user presses Enter. In headless / one-shot mode
+# (`-p`/`--print`/`--prompt`), there's no tmux to hold open — output streams
+# directly to the parent shell — so the trailer is omitted.
+#
+# Under SANDY_VERBOSE>=1, the trailer also reports the exit code so the user
+# can spot non-zero exits before they're hidden by the pause prompt.
+#
+# The `\$?` / `\$_exit` / `\"` escapes are deliberate: they're literal in the
+# returned string and only expand when bash evaluates it later (in the tmux
+# pane via user-setup.sh). The pre-PR-3.2 functions used the same escapes;
+# moving them into one place is the whole point of this helper.
+_sandy_wrap_cmd_exit_pause() {
+    local label="$1" cmd="$2"
+    if [ "$_sandy_is_headless" = "true" ]; then
+        printf '%s' "$cmd"
+        return 0
+    fi
+    if [ "${SANDY_VERBOSE:-0}" -ge 1 ]; then
+        printf '%s' "${cmd}; _exit=\$?; echo ''; echo \"[sandy] ${label} exited (code: \$_exit)\"; read -p 'Press Enter to exit...'"
+    else
+        printf '%s' "${cmd}; read -p ''"
+    fi
+}
+
 build_claude_cmd() {
     local cmd="claude --model ${SANDY_MODEL:-claude-opus-4-7} --teammate-mode tmux"
     if [ "${SANDY_SKIP_PERMISSIONS:-true}" = "true" ]; then
@@ -655,19 +731,8 @@ build_claude_cmd() {
             cmd+=" --resume"
         fi
     fi
-    for arg in "$@"; do
-        cmd+=" $(printf "%q" "$arg")"
-    done
-    # In interactive (tmux) mode, pause on exit so the user can see output before
-    # tmux closes. In headless mode, skip — there's no tmux to hold open.
-    if [ "$_sandy_is_headless" != "true" ]; then
-        if [ "${SANDY_VERBOSE:-0}" -ge 1 ]; then
-            cmd="$cmd; _exit=\$?; echo ''; echo \"[sandy] Claude Code exited (code: \$_exit)\"; read -p 'Press Enter to exit...'"
-        else
-            cmd="$cmd; read -p ''"
-        fi
-    fi
-    printf '%s' "$cmd"
+    cmd+="$(_sandy_translate_args claude "$@")"
+    _sandy_wrap_cmd_exit_pause "Claude Code" "$cmd"
 }
 
 build_codex_cmd() {
@@ -688,25 +753,8 @@ build_codex_cmd() {
     if [ -n "${CODEX_MODEL:-}" ]; then
         cmd+=" --model $(printf "%q" "$CODEX_MODEL")"
     fi
-    # Flag translation: sandy's -p/--print/--prompt all mean "run this prompt".
-    # codex exec takes the prompt as a positional arg, so drop the flag itself
-    # and pass only the value. --continue/-c → drop (codex has `codex resume`
-    # but not a headless --continue flag), matching the gemini behavior.
-    for arg in "$@"; do
-        case "$arg" in
-            -p|--print|--prompt) : ;;
-            --continue|-c)       : ;;
-            *)                   cmd+=" $(printf "%q" "$arg")" ;;
-        esac
-    done
-    if [ "$_sandy_is_headless" != "true" ]; then
-        if [ "${SANDY_VERBOSE:-0}" -ge 1 ]; then
-            cmd="$cmd; _exit=\$?; echo ''; echo \"[sandy] Codex CLI exited (code: \$_exit)\"; read -p 'Press Enter to exit...'"
-        else
-            cmd="$cmd; read -p ''"
-        fi
-    fi
-    printf '%s' "$cmd"
+    cmd+="$(_sandy_translate_args codex "$@")"
+    _sandy_wrap_cmd_exit_pause "Codex CLI" "$cmd"
 }
 
 build_opencode_cmd() {
@@ -727,25 +775,8 @@ build_opencode_cmd() {
     if [ -n "${OPENCODE_MODEL:-}" ]; then
         cmd+=" --model $(printf "%q" "$OPENCODE_MODEL")"
     fi
-    # Flag translation: sandy's -p/--print/--prompt all mean "run this prompt".
-    # opencode run takes the prompt as a positional arg, so drop the flag itself
-    # and pass only the value. --continue/-c → drop (opencode has no headless
-    # resume flag), matching the codex/gemini behavior.
-    for arg in "$@"; do
-        case "$arg" in
-            -p|--print|--prompt) : ;;
-            --continue|-c)       : ;;
-            *)                   cmd+=" $(printf "%q" "$arg")" ;;
-        esac
-    done
-    if [ "$_sandy_is_headless" != "true" ]; then
-        if [ "${SANDY_VERBOSE:-0}" -ge 1 ]; then
-            cmd="$cmd; _exit=\$?; echo ''; echo \"[sandy] OpenCode exited (code: \$_exit)\"; read -p 'Press Enter to exit...'"
-        else
-            cmd="$cmd; read -p ''"
-        fi
-    fi
-    printf '%s' "$cmd"
+    cmd+="$(_sandy_translate_args opencode "$@")"
+    _sandy_wrap_cmd_exit_pause "OpenCode" "$cmd"
 }
 
 build_gemini_cmd() {
@@ -760,24 +791,8 @@ build_gemini_cmd() {
     if [ -n "${GEMINI_MODEL:-}" ]; then
         cmd+=" --model $(printf "%q" "$GEMINI_MODEL")"
     fi
-    # Translate Claude-style flags to Gemini equivalents.
-    # -p / --print "prompt" → --prompt "prompt"  (Gemini has no -p shorthand)
-    # --continue / -c       → drop (Gemini has no headless resume flag)
-    for arg in "$@"; do
-        case "$arg" in
-            -p|--print)    cmd+=" --prompt" ;;
-            --continue|-c) : ;;
-            *)             cmd+=" $(printf "%q" "$arg")" ;;
-        esac
-    done
-    if [ "$_sandy_is_headless" != "true" ]; then
-        if [ "${SANDY_VERBOSE:-0}" -ge 1 ]; then
-            cmd="$cmd; _exit=\$?; echo ''; echo \"[sandy] Gemini CLI exited (code: \$_exit)\"; read -p 'Press Enter to exit...'"
-        else
-            cmd="$cmd; read -p ''"
-        fi
-    fi
-    printf '%s' "$cmd"
+    cmd+="$(_sandy_translate_args gemini "$@")"
+    _sandy_wrap_cmd_exit_pause "Gemini CLI" "$cmd"
 }
 
 # Detect headless / one-shot mode — bypass tmux so output reaches the parent shell.

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1426,15 +1426,19 @@ info "28. Gemini CLI support — agent helpers and flag translation"
 SANDY_SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/sandy"
 
 # Pull the two one-line helpers and the build_gemini_cmd function body.
+# Since M3 PR 3.2, build_*_cmd functions call shared helpers — extract them too.
 _HELPERS="$(grep -E '^_sandy_has_(claude|gemini|codex|opencode)\(\)' "$SANDY_SCRIPT")"
+_BUILD_SHARED="$(sed -n '/^_sandy_translate_args()/,/^}$/p' "$SANDY_SCRIPT")
+$(sed -n '/^_sandy_wrap_cmd_exit_pause()/,/^}$/p' "$SANDY_SCRIPT")"
 _BUILD_GEMINI="$(sed -n '/^build_gemini_cmd()/,/^}$/p' "$SANDY_SCRIPT")"
 
-if [ -z "$_HELPERS" ] || [ -z "$_BUILD_GEMINI" ]; then
+if [ -z "$_HELPERS" ] || [ -z "$_BUILD_GEMINI" ] || [ -z "$_BUILD_SHARED" ]; then
     fail "could not extract gemini helpers from sandy script (did they move?)"
 else
     _gemini_script_test() {
         local desc="$1"; shift
         if bash -c "set -e; $_HELPERS
+$_BUILD_SHARED
 $_BUILD_GEMINI
 $*" >/dev/null 2>&1; then
             pass "$desc"
@@ -1479,16 +1483,67 @@ $*" >/dev/null 2>&1; then
 fi
 
 # ============================================================
+info "28a. Shared build_*_cmd helpers (M3 PR 3.2)"
+# ============================================================
+# Two helpers extracted from the four build_*_cmd functions to consolidate
+# the per-agent arg-translation loop and the tmux-interactive exit-pause
+# wrapping. Each agent's surface-specific behavior (which flags translate
+# to what, what label appears in the exit-pause message) is now in one
+# place per concern instead of duplicated four ways.
+_helper_script_test() {
+    local desc="$1"; shift
+    if bash -c "set -e; $_BUILD_SHARED
+$*" >/dev/null 2>&1; then
+        pass "$desc"
+    else
+        fail "$desc"
+    fi
+}
+
+# Translate-args contract per agent
+_helper_script_test "_sandy_translate_args claude passes -p through verbatim" \
+    'out=$(_sandy_translate_args claude -p hello); echo "$out" | grep -qE " -p( |$)"'
+_helper_script_test "_sandy_translate_args claude passes --continue through verbatim" \
+    'out=$(_sandy_translate_args claude --continue); echo "$out" | grep -q -- "--continue"'
+_helper_script_test "_sandy_translate_args gemini translates -p to --prompt" \
+    'out=$(_sandy_translate_args gemini -p hello); echo "$out" | grep -q -- "--prompt" && ! echo "$out" | grep -qE " -p( |$)"'
+_helper_script_test "_sandy_translate_args gemini translates --print to --prompt" \
+    'out=$(_sandy_translate_args gemini --print hello); echo "$out" | grep -q -- "--prompt"'
+_helper_script_test "_sandy_translate_args gemini drops --continue" \
+    'out=$(_sandy_translate_args gemini --continue); ! echo "$out" | grep -q -- "--continue"'
+_helper_script_test "_sandy_translate_args codex drops -p (positional-prompt mode)" \
+    'out=$(_sandy_translate_args codex -p hello); ! echo "$out" | grep -qE "(^| )-p( |$)"'
+_helper_script_test "_sandy_translate_args codex drops --continue" \
+    'out=$(_sandy_translate_args codex --continue); ! echo "$out" | grep -q -- "--continue"'
+_helper_script_test "_sandy_translate_args opencode drops -p (positional-prompt mode)" \
+    'out=$(_sandy_translate_args opencode -p hello); ! echo "$out" | grep -qE "(^| )-p( |$)"'
+_helper_script_test "_sandy_translate_args opencode drops --continue" \
+    'out=$(_sandy_translate_args opencode --continue); ! echo "$out" | grep -q -- "--continue"'
+_helper_script_test "_sandy_translate_args printf-quotes positional args with spaces" \
+    'out=$(_sandy_translate_args claude "hello world"); echo "$out" | grep -qE "hello.+world"'
+
+# Exit-pause contract
+_helper_script_test "_sandy_wrap_cmd_exit_pause headless mode appends nothing" \
+    '_sandy_is_headless=true out=$(_sandy_wrap_cmd_exit_pause Foo "claude --x"); [ "$out" = "claude --x" ]'
+_helper_script_test "_sandy_wrap_cmd_exit_pause interactive quiet adds read -p" \
+    '_sandy_is_headless=false SANDY_VERBOSE=0 out=$(_sandy_wrap_cmd_exit_pause Foo "claude --x"); echo "$out" | grep -q "read -p"'
+_helper_script_test "_sandy_wrap_cmd_exit_pause interactive verbose includes agent label" \
+    '_sandy_is_headless=false SANDY_VERBOSE=1 out=$(_sandy_wrap_cmd_exit_pause "OpenCode" "opencode"); echo "$out" | grep -q "OpenCode exited"'
+_helper_script_test "_sandy_wrap_cmd_exit_pause interactive verbose escapes \$_exit for later eval" \
+    '_sandy_is_headless=false SANDY_VERBOSE=1 out=$(_sandy_wrap_cmd_exit_pause Foo "claude"); echo "$out" | grep -qF "\$_exit"'
+
+# ============================================================
 info "28b. Codex CLI support — agent helpers and flag translation"
 # ============================================================
 _BUILD_CODEX="$(sed -n '/^build_codex_cmd()/,/^}$/p' "$SANDY_SCRIPT")"
 
-if [ -z "$_HELPERS" ] || [ -z "$_BUILD_CODEX" ]; then
+if [ -z "$_HELPERS" ] || [ -z "$_BUILD_CODEX" ] || [ -z "$_BUILD_SHARED" ]; then
     fail "could not extract codex helpers from sandy script (did they move?)"
 else
     _codex_script_test() {
         local desc="$1"; shift
         if bash -c "set -e; $_HELPERS
+$_BUILD_SHARED
 $_BUILD_CODEX
 $*" >/dev/null 2>&1; then
             pass "$desc"
@@ -1865,12 +1920,13 @@ info "28g. OpenCode CLI support — agent helpers and flag translation"
 # ============================================================
 _BUILD_OPENCODE="$(sed -n '/^build_opencode_cmd()/,/^}$/p' "$SANDY_SCRIPT")"
 
-if [ -z "$_HELPERS" ] || [ -z "$_BUILD_OPENCODE" ]; then
+if [ -z "$_HELPERS" ] || [ -z "$_BUILD_OPENCODE" ] || [ -z "$_BUILD_SHARED" ]; then
     fail "could not extract opencode helpers from sandy script (did they move?)"
 else
     _opencode_script_test() {
         local desc="$1"; shift
         if bash -c "set -e; $_HELPERS
+$_BUILD_SHARED
 $_BUILD_OPENCODE
 $*" >/dev/null 2>&1; then
             pass "$desc"


### PR DESCRIPTION
## Summary

- Extracts two shared helpers from the four `build_*_cmd` functions
- Refactors `build_claude_cmd`, `build_codex_cmd`, `build_opencode_cmd`, `build_gemini_cmd` to call those helpers
- No user-visible behavior change — verified byte-identical output across an 80-combo input matrix
- 14 new tests in section 28a lock in the helpers' per-agent contract; sections 28/28b/28g updated to extract the shared helpers alongside their build_*_cmd fixtures

This is M3 PR 3.2 from `ROADMAP_1.0.md`. Per the roadmap, **this PR cannot merge until PR 3.1.5 (the 3-day mini-soak on PR 3.1's merge) clears** — expected ~2026-05-30.

## What got DRY'd

Two concerns were duplicated four ways in the build_*_cmd functions, all defined inside `user-setup.sh`'s heredoc:

**1. Per-agent arg-translation loop** (`for arg in "$@"; do case ... esac done`). Three distinct translation rules:

| Agent | -p / --print / --prompt | --continue / -c |
|---|---|---|
| `claude` | pass-through | pass-through |
| `gemini` | -p/--print → --prompt | drop |
| `codex`, `opencode` | drop (prompt becomes positional) | drop |

Now in one `case "$agent"` dispatch in `_sandy_translate_args`.

**2. Exit-pause trailer** (`if [ "$_sandy_is_headless" != "true" ]; then ...`). The block was byte-identical except for the agent label ("Claude Code" / "Codex CLI" / "OpenCode" / "Gemini CLI"). Now `_sandy_wrap_cmd_exit_pause` takes the label as the first arg.

Each `build_*_cmd` now reads as:

```bash
build_<agent>_cmd() {
    local cmd="<agent-specific binary + flags>"
    # ... agent-specific preamble (model env, permission flags, ...) ...
    cmd+="$(_sandy_translate_args <agent> "$@")"
    _sandy_wrap_cmd_exit_pause "<Label>" "$cmd"
}
```

## Behavioral equivalence

Tested every combination of:
- 4 agents (claude / codex / opencode / gemini)
- 2 headless modes (true / false)
- 2 verbose modes (0 / 1)
- 5 arg patterns (none, `-p hello`, `--print world`, `--continue`, `-p hi --continue extra`)

= 80 combinations. All produce **byte-identical output** to main's pre-refactor functions.

## Test plan

- [x] Bash syntax (`bash -n sandy && bash -n test/run-tests.sh`)
- [x] shellcheck on `templates/user-setup.sh.tmpl` (zero warnings)
- [x] `test/regen-template.sh --check` (no drift)
- [x] `test/regen-config-docs.sh --check` (no drift)
- [x] 80-combo byte-for-byte equivalence vs main
- [x] Spot-check `_sandy_translate_args gemini -p hello` → ` --prompt hello`
- [x] Spot-check `_sandy_wrap_cmd_exit_pause` produces the same `$_exit` literal trailer as old code
- [ ] Full `bash test/run-tests.sh` — needs Docker (not available in the dev container); please run on host
- [ ] Manual smoke: each agent in {headless, interactive} × {quiet, verbose} (16 combinations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)