### PR TITLE
PR 3.3: cut v0.13.0 (M3 deliverable) + default model → opus 4.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Only allowlisted `KEY=VALUE` lines are parsed (not sourced as a shell script). U
 | Variable | Default | Description |
 |---|---|---|
 | `SANDY_AGENT` | `claude` | AI agent(s) to run. Single: `claude`, `gemini`, `codex`, `opencode`. Multi (comma-separated, 2–4 panes in tmux): e.g. `claude,gemini` or `claude,gemini,codex,opencode`. Alias: `all` = `claude,gemini,codex,opencode` |
-| `SANDY_MODEL` | `claude-opus-4-6` | Claude model to use (applies whenever `claude` is in `SANDY_AGENT`) |
+| `SANDY_MODEL` | `claude-opus-4-8` | Claude model to use (applies whenever `claude` is in `SANDY_AGENT`) |
 | `GEMINI_API_KEY` | (unset) | Google API key for Gemini CLI. Put in `.sandy/.secrets` |
 | `GEMINI_MODEL` | (unset) | Gemini model override |
 | `SANDY_GEMINI_AUTH` | `auto` | Force Gemini auth path: `auto`, `api_key`, `oauth`, or `adc` |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,24 @@
+## sandy v0.13.0
+
+M3 milestone — architectural cleanup. Two refactors that pay down structural debt the 1.0 code review surfaced, plus a default-model bump. No new features, no new config keys; the only user-visible change is the default Claude model.
+
+### Architectural cleanup (M3)
+
+**PR 3.1 — `user-setup.sh` heredoc mirrored to a lintable template.** The ~860-line bash heredoc inside `generate_user_setup()` (the script that runs container-side after Docker hands off) was unshellcheckable as a string literal — 860 lines of container-side bash no static analyzer had ever seen. It's now mirrored verbatim to `templates/user-setup.sh.tmpl`, which `shellcheck` lints as a real file with zero-warning enforcement in CI. The sandy script's embedded heredoc remains the source of truth, so single-file install and `sandy --upgrade` are unaffected — the template is a derivative used only for review and lint, kept in sync by a `test/regen-template.sh` drift check. shellcheck found and fixed 4 latent issues on first run (3 style, 1 SC2155 return-value masking); all behaviorally verified equivalent.
+
+**PR 3.2 — `build_*_cmd` functions unified.** The four per-agent command builders (`build_claude_cmd`, `build_codex_cmd`, `build_opencode_cmd`, `build_gemini_cmd`) duplicated two concerns: a per-agent arg-translation loop (`-p`/`--print`/`--prompt`/`--continue` handling, which differs per agent) and an identical tmux-interactive exit-pause trailer (differing only in the agent label). Both extracted into shared helpers — `_sandy_translate_args` and `_sandy_wrap_cmd_exit_pause` — so the four agents stay in lockstep when new flags are added. Verified byte-identical output across all 80 input combinations (4 agents × 2 headless × 2 verbose × 5 arg patterns); no behavior change.
+
+### Default model: `claude-opus-4-7` → `claude-opus-4-8`
+
+The out-of-box default Claude model is now `claude-opus-4-8` (was `claude-opus-4-7`). This is an undated stable alias, so it auto-rolls forward to the latest 4.8 snapshot as Anthropic ships them; a future 4.9 will need another bump. Override per-user in `~/.sandy/config`, per-workspace in `.sandy/config`, or per-launch via `SANDY_MODEL=...` / `--model`. (README's table was also corrected — it had drifted to showing `claude-opus-4-6`.)
+
+### Documentation
+
+- **`CLAUDE.md`**: "user-setup.sh template mirror" subsection documenting the `test/regen-template.sh` workflow.
+- **`SPECIFICATION.md`** / **`SPEC_INTROSPECTION.md`**: config-key default updated to `claude-opus-4-8`.
+
+---
+
 ## sandy v0.12.0
 
 A re-baseline cut. Between `v0.11.4` (2026-04-15) and this tag (2026-05-16), the "no new features until 1.0" rule from `ROADMAP_1.0.md` quietly stopped holding — useful work landed but it cumulatively reset the stability soak that 1.0 was meant to gate on. Rather than continue and pretend the roadmap was intact, `v0.12.0` formalizes a new feature-freeze point. Every milestone downstream of here (M3 heredoc extract → M2.7 egress proxy sidecar → M4 surface stabilization → M5 14-day pre-RC soak → `1.0.0-rc1`) now targets the version one minor higher than the original plan, and the 7-day M2.3 soak clock restarts against this tag. See the updated `ROADMAP_1.0.md` "Re-baseline (2026-05-16)" section for full context.

--- a/ROADMAP_1.0.md
+++ b/ROADMAP_1.0.md
@@ -61,12 +61,13 @@ The hybrid protection model (commit `4158024`) is the natural cut point. It clos
 
 If a "new feature" idea surfaces during M2.3 onward, it goes into `POST_1.0_IDEAS.md` and waits.
 
-### Updated current state
+### Updated current state (refreshed 2026-05-30)
 
-- **Released**: `v0.12.0` (2026-05-16).
-- **On main**: `0.12.1-dev` (post-release bump, commit `430711b`).
-- **M2.3 soak**: **active** on `v0.12.0` (clock started 2026-05-16). 7 days of daily use across at least: sandy itself, one Python project with a venv, one multi-agent session, one workspace with `SANDY_SCREENSHOT_DIR` configured, one workspace using `SANDY_EXTRA_ENV`. Any surprise → fix → ship as `0.12.x` → restart clock.
-- **M3, M2.7, M4, M5**: unchanged scope, shifted version labels per the table above. M3 starts when M2.3 soak clears.
+- **Released**: `v0.12.0` (2026-05-16), `v0.13.0` (2026-05-30).
+- **On main**: `0.13.1-dev` (post-release bump).
+- **M2.3 soak**: ✓ cleared on `v0.12.0`. M3 followed.
+- **M3**: ✓ shipped as `v0.13.0`. PR 3.1 (heredoc extract, #4), PR 3.1.5 (3-day mini-soak), PR 3.2 (build_*_cmd unify, #5), PR 3.3 (version bump + default model → opus 4.8). 1.0 surface is now reviewable — the unshellcheckable container-side bash is linted, the four agent command-builders are unified.
+- **M2.7, M4, M5**: unchanged scope, shifted version labels per the table above. **M2.7 (egress proxy sidecar) is next** — targets `0.13.1` / `0.14.0-pre`, closes the F2 macOS Critical.
 
 ### Residual findings tracker (carried forward)
 
@@ -553,17 +554,17 @@ Off-roadmap feature drift (2026-04-15 → 2026-05-16)
 PR 2.3 (7-day soak on 0.12.0)    ← active; gates M3
     │
     ▼
-PR 3.1 (user-setup.sh extract)   ← must land alone
+PR 3.1 (user-setup.sh extract) ✓ (#4 merged 9178698)
     │
     ▼
-PR 3.1.5 (3-day mini-soak)       ← gates PR 3.2
+PR 3.1.5 (3-day mini-soak) ✓     ← cleared 2026-05-30
     │
     ▼
-PR 3.2 (build_*_cmd unify)
-PR 3.3 (version bump)            ← blocks on 3.1, 3.2 ──▶ tag 0.13.0
+PR 3.2 (build_*_cmd unify) ✓ (#5 merged 68b2ee1)
+PR 3.3 (version bump) ✓          ──▶ tag 0.13.0 ✓ (2026-05-30)
     │
     ▼
-M2.7 PR 2.7.1 (proxy Go binary + unit tests)
+M2.7 PR 2.7.1 (proxy Go binary + unit tests)  ← next
 M2.7 PR 2.7.2 (sandy-proxy Dockerfile + phased build)
 M2.7 PR 2.7.3 (launcher wiring + SANDY_EGRESS_PROXY opt-in)
 M2.7 PR 2.7.4 (remove macOS launch warning)
@@ -600,7 +601,7 @@ Treat each tag as a commitment: do not proceed to the next milestone until the p
 | `0.11.3` | ✓ released | M2.5 stabilization fixes (plugin install, fast-path fixtures) | Stable target for restarted M2.3 soak (never restarted) |
 | `0.11.4` | ✓ released | Empty-stub-debris cleanup hotfix | M2.5 tail closed |
 | `0.12.0` | ✓ released 2026-05-16 | Re-baseline at current `main` (introspection, opencode, /ss, SANDY_EXTRA_ENV, hybrid protected-dirs) | Feature freeze restarts here |
-| `0.13.0` | pending | M3 (heredoc extract + build unification) + 3-day mini-soak | 1.0 surface is reviewable |
+| `0.13.0` | ✓ released 2026-05-30 | M3 (heredoc extract + build unification) + 3-day mini-soak; default model → opus 4.8 | 1.0 surface is reviewable |
 | `0.13.1` or `0.14.0-pre` | pending | M2.7 (egress proxy sidecar) + 7-day soak | F2 macOS Critical finally closed |
 | `0.14.0` | pending | M4 surface locked | Stability promises are explicit |
 | `1.0.0-rc1` | pending | M5 14-day soak clean | Ready for users to form habits on |

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -164,7 +164,7 @@ The table below is generated from `sandy --print-schema` (the `_sandy_key_metada
 | `GOOGLE_API_KEY` | privileged | unset | Google API key for Vertex AI / ADC. |
 | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | privileged | unset | Enable Claude Code experimental agent-teams feature. |
 | `SANDY_AGENT` | passive | `claude` | Agent(s) to launch. Comma-separated (e.g. 'claude,codex'). 'all' = 'claude,gemini,codex,opencode'. |
-| `SANDY_MODEL` | passive | `claude-opus-4-7` | Model ID for the Claude agent. |
+| `SANDY_MODEL` | passive | `claude-opus-4-8` | Model ID for the Claude agent. |
 | `SANDY_CPUS` | passive | unset | CPU limit for container (default: auto-detected). |
 | `SANDY_MEM` | passive | unset | Memory limit for container (e.g. '8g'; default: auto-detected). |
 | `SANDY_GPU` | passive | unset | GPU passthrough: 'all', or device IDs like '0' / '0,1'. |

--- a/SPEC_INTROSPECTION.md
+++ b/SPEC_INTROSPECTION.md
@@ -92,7 +92,7 @@ All three:
         "name": "SANDY_MODEL",
         "type": "string",
         "pattern": "^[a-zA-Z0-9._-]+$",
-        "default": "claude-opus-4-7",
+        "default": "claude-opus-4-8",
         "description": "Model ID for the Claude agent.",
         "sources": ["home_config", "workspace_config", "env"]
       },
@@ -364,7 +364,7 @@ For each key, additional metadata (type, default, description, pattern) is harde
 _sandy_key_metadata() {
     cat <<'EOF'
 key	type	default	pattern	description
-SANDY_MODEL	string	claude-opus-4-7	^[a-zA-Z0-9._-]+$	Model ID for Claude agent
+SANDY_MODEL	string	claude-opus-4-8	^[a-zA-Z0-9._-]+$	Model ID for Claude agent
 SANDY_CPUS	int	2		Number of CPUs allocated to the container
 SANDY_SSH	enum:token,agent	token		SSH auth mode: token (gh CLI) or agent (forward host SSH agent)
 ...

--- a/sandy
+++ b/sandy
@@ -17,7 +17,7 @@ set -euo pipefail
 #   sandy --agent claude,gemini   Override agent selection for this run
 # =============================================================================
 
-SANDY_VERSION="0.12.1-dev"
+SANDY_VERSION="0.13.0"
 SANDY_COMMIT=""  # baked in by install.sh; empty = detect from git at runtime
 
 # Schema contract version for --print-schema / --print-state / --validate-config.
@@ -456,7 +456,7 @@ OPENAI_API_KEY|secret|||OpenAI API key for Codex CLI.
 GOOGLE_API_KEY|secret|||Google API key for Vertex AI / ADC.
 CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS|bool|||Enable Claude Code experimental agent-teams feature.
 SANDY_AGENT|agent_combo|claude||Agent(s) to launch. Comma-separated (e.g. 'claude,codex'). 'all' = 'claude,gemini,codex,opencode'.
-SANDY_MODEL|string|claude-opus-4-7|^[a-zA-Z0-9._-]+$|Model ID for the Claude agent.
+SANDY_MODEL|string|claude-opus-4-8|^[a-zA-Z0-9._-]+$|Model ID for the Claude agent.
 SANDY_CPUS|int|||CPU limit for container (default: auto-detected).
 SANDY_MEM|string|||Memory limit for container (e.g. '8g'; default: auto-detected).
 SANDY_GPU|string|||GPU passthrough: 'all', or device IDs like '0' / '0,1'.
@@ -1104,7 +1104,7 @@ Usage:
   sandy --help                   Show this help
 
 Environment variables:
-  SANDY_MODEL        Model to use (default: claude-opus-4-7)
+  SANDY_MODEL        Model to use (default: claude-opus-4-8)
   ANTHROPIC_API_KEY  API key (not needed with Claude Max / OAuth)
   SANDY_HOME         Sandy config directory (default: ~/.sandy)
   SANDY_SSH          Git SSH method: "token" (default) uses gh CLI token
@@ -2251,7 +2251,7 @@ _sandy_wrap_cmd_exit_pause() {
 }
 
 build_claude_cmd() {
-    local cmd="claude --model ${SANDY_MODEL:-claude-opus-4-7} --teammate-mode tmux"
+    local cmd="claude --model ${SANDY_MODEL:-claude-opus-4-8} --teammate-mode tmux"
     if [ "${SANDY_SKIP_PERMISSIONS:-true}" = "true" ]; then
         # Use --permission-mode (the documented modern flag) instead of the
         # legacy --dangerously-skip-permissions. Claude 2.1.x added runtime
@@ -5063,7 +5063,7 @@ RUN_FLAGS+=(-e "SANDY_WORKSPACE=$SANDY_WORKSPACE")
 RUN_FLAGS+=(-e "SANDY_PROJECT_NAME=$(basename "$WORK_DIR")")
 # Validate SANDY_MODEL — only allow alphanumeric, hyphens, dots, underscores
 if _sandy_agent_has claude; then
-    SANDY_MODEL="${SANDY_MODEL:-claude-opus-4-7}"
+    SANDY_MODEL="${SANDY_MODEL:-claude-opus-4-8}"
 else
     SANDY_MODEL="${SANDY_MODEL:-}"
 fi

--- a/templates/user-setup.sh.tmpl
+++ b/templates/user-setup.sh.tmpl
@@ -683,7 +683,7 @@ _sandy_wrap_cmd_exit_pause() {
 }
 
 build_claude_cmd() {
-    local cmd="claude --model ${SANDY_MODEL:-claude-opus-4-7} --teammate-mode tmux"
+    local cmd="claude --model ${SANDY_MODEL:-claude-opus-4-8} --teammate-mode tmux"
     if [ "${SANDY_SKIP_PERMISSIONS:-true}" = "true" ]; then
         # Use --permission-mode (the documented modern flag) instead of the
         # legacy --dangerously-skip-permissions. Claude 2.1.x added runtime

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -2236,11 +2236,15 @@ else
     fail "SANDY_VERSION defined exactly once (found: $_ver_count)"
 fi
 
-# Version string contains expected major.minor.
-if grep -q '^SANDY_VERSION="0\.12\.' "$SANDY_SCRIPT"; then
-    pass "SANDY_VERSION is 0.12.x"
+# Version string is well-formed semver (X.Y.Z, optionally with a -dev/-rc
+# suffix). Deliberately NOT pinned to a specific minor — pinning meant the
+# assertion broke on every release bump (it was stuck at 0.12.x while the
+# script moved to 0.13.0). Format-checking catches the real failure mode
+# (a malformed or accidentally-cleared version) without the maintenance tax.
+if grep -qE '^SANDY_VERSION="[0-9]+\.[0-9]+\.[0-9]+(-(dev|rc[0-9]*))?"' "$SANDY_SCRIPT"; then
+    pass "SANDY_VERSION is well-formed semver"
 else
-    fail "SANDY_VERSION is 0.12.x"
+    fail "SANDY_VERSION is well-formed semver"
 fi
 
 # ============================================================


### PR DESCRIPTION
## Summary

- Version bump `0.12.1-dev` → `0.13.0`, shipping the **M3 architectural-cleanup milestone** (PR 3.1 #4 + PR 3.2 #5, both already merged and soaked)
- Default Claude model `claude-opus-4-7` → `claude-opus-4-8` (undated stable alias; auto-rolls forward within 4.8)
- Doc sync: RELEASE_NOTES, ROADMAP (M3 marked shipped), SPECIFICATION + SPEC_INTROSPECTION + README model defaults, template re-sync

This is **PR 3.3** from `ROADMAP_1.0.md`. The 3-day mini-soak (PR 3.1.5) and the M2.3 soak both cleared, so M3 is complete with this cut.

## The one user-visible change

Default model → `claude-opus-4-8` across all four hardcoded sites (metadata heredoc, `--help`, `build_claude_cmd` default, `SANDY_MODEL` config-load default). Everything else in this PR is either the version string or behavior-preserving M3 refactors that already shipped. README's `SANDY_MODEL` row was also corrected — it had drifted to `claude-opus-4-6`, two versions stale.

## Test plan

- [x] `bash -n sandy`
- [x] `test/regen-template.sh --check` (template in sync with the model-string change in the heredoc)
- [x] `test/regen-config-docs.sh --check` (schema default propagated)
- [x] `shellcheck templates/user-setup.sh.tmpl` clean
- [x] `sandy --version` → `0.13.0`
- [ ] Full `bash test/run-tests.sh` — needs Docker; CI covers it

After merge: tag `v0.13.0`, bump main to `0.13.1-dev`, GitHub release, then M2.7 starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)