### PR TITLE
M2.7 replan: fix the --internal flaw + add mandatory macOS spike

### DIFF
--- a/ROADMAP_1.0.md
+++ b/ROADMAP_1.0.md
@@ -77,7 +77,7 @@ If a "new feature" idea surfaces during M2.3 onward, it goes into `POST_1.0_IDEA
 | F3 (dirs half) | Always-mount-with-empty-fixture pollution | n/a | **closed** by `4158024` hybrid revert |
 | F3 (files half) | Agent can create `.bashrc`/`.envrc` in-session if host absent | Medium | unchanged — detection only |
 | F6 (in-session) | Agent can mutate `settings.json` mid-session | Medium | unchanged — sandy-managed keys re-overwritten on next launch |
-| F9 | DNS exfil via embedded resolver | Medium | unchanged — subsumed by M2.7 DNS allowlist |
+| F9 | DNS exfil via embedded resolver | Medium | to be closed by M2.7 — the proxy's allowlist resolver replaces the embedded resolver (NXDOMAIN for non-allowlisted names; `HTTPS`/`SVCB` refused) |
 | F10 | Fork bomb within pids-limit | Low | unchanged — skipped per original plan |
 
 ---
@@ -275,34 +275,40 @@ The original plan's stated reason to avoid `--internal` ("it breaks Docker's emb
 
 **Corollary the original plan under-weighted:** once `--internal` is correct, the proxy is the *only* way off the bridge. The failure mode is no longer just "a host is missing from the allowlist" — it's "any tool that doesn't route through the proxy is completely broken." That reframes the tool-compatibility question from a footnote into a primary design constraint (see "Transport model" below).
 
-### PR 2.7.0 — macOS `--internal` spike (MANDATORY, do first) — `test/spike/macos-internal-network-spike.sh`
+### PR 2.7.0 — macOS `--internal` spike (MANDATORY, do first) — ✓ PASSED 2026-06-04
 
-**Not a build PR — a go/no-go gate.** Everything downstream rests on assumptions about Docker Desktop's macOS networking that **cannot be tested in CI** (GitHub Actions is Linux-only; the platform being fixed has zero automated coverage). Prove them by hand, once, in ~1 hour, before committing the ~2 weeks:
+**Was a go/no-go gate; it passed.** Everything downstream rests on assumptions about Docker Desktop's macOS networking that **cannot be tested in CI** (GitHub Actions is Linux-only; the platform being fixed has zero automated coverage). `test/spike/macos-internal-network-spike.sh` proves them by hand, once, in ~1 hour:
 
-1. An `--internal` bridge network blocks raw-IP LAN egress (`curl http://<lan-ip>` fails where it succeeds on a normal bridge).
-2. A dual-homed sidecar on `(--internal, normal)` is reachable by a container on the internal net (intra-bridge L2 works despite `--internal`).
-3. That sidecar can reach the internet via its non-internal leg.
-4. `--dns <sidecar-ip>` propagates into a container on the `--internal` network.
+1. An `--internal` bridge network blocks raw-IP LAN egress (`curl http://<lan-ip>` fails where it succeeds on a normal bridge). ✓
+2. A dual-homed sidecar on `(--internal, normal)` is reachable by a container on the internal net (intra-bridge L2 works despite `--internal`). ✓
+3. That sidecar can reach the internet via its non-internal leg. ✓
+4. `--dns <sidecar-ip>` propagates into a container on the `--internal` network. ✓
 
-The spike script (`test/spike/macos-internal-network-spike.sh`) automates all four with a PASS/FAIL gate; it also confirms the baseline F2 exposure reproduces (so "blocked" results mean something) and flags the `host.docker.internal` reachability that drives the `SANDY_LOCAL_LLM_HOST` decision below. It cleans up all networks/containers on exit and needs no sudo.
+**Result (real Docker Desktop, macOS, 2026-06-04): 14/14 PASS, 0 FAIL.** The baseline F2 exposure reproduced (LAN reachable on a normal bridge), then `--internal` blocked it; the sidecar was reachable and could egress; `--dns` propagated. Notably **A1c confirmed `host.docker.internal` is unreachable under `--internal`** — which forces the `SANDY_LOCAL_LLM_HOST` decision below (now resolved in-scope, not deferred). The architecture is sound on this Docker Desktop version. **M2.7 is greenlit.**
 
-**Exit criteria:** all-PASS on a real Docker Desktop (macOS). If any assumption fails, **stop** — the topology needs a rethink and you've spent an hour, not three weeks. A Linux run passes too but explicitly does not satisfy the gate.
+Keep the spike in the repo: it doubles as the manual macOS re-verification step in PR 2.7.5's checklist (re-run it whenever Docker Desktop updates).
 
-### Transport model — decide on the spike, not in advance
+### Transport model — hybrid (decided 2026-06-04)
 
-The original plan committed to **HTTP CONNECT + DNS allowlist**. Under the (now mandatory) `--internal` boundary, that's not obviously the best choice, because CONNECT requires every tool to honor `HTTP_PROXY`/`HTTPS_PROXY`. Two candidates, to be compared during the spike:
+Settled after weighing real workflows (several repos use `SANDY_SSH=agent`, i.e. git-over-SSH). The decision: **transparent SNI/Host for HTTPS + an HTTP CONNECT endpoint for SSH.** Neither pure model is sufficient on its own under `--internal`, and the hybrid is the only one that keeps the actual tool surface working.
 
-- **HTTP CONNECT proxy** (port 3128). Container gets `HTTP_PROXY`/`HTTPS_PROXY` env. Covers `curl`, `pip`, `npm`, `uv`, most HTTP libraries. Breaks anything that ignores the proxy env (raw sockets, some static Go binaries, **git-over-SSH** when `SANDY_SSH=agent`). DNS allowlist is mostly secondary defense here (it makes non-proxy tools fail at resolve-time and closes F9 DNS-exfil), since CONNECT-aware tools hand the hostname to the proxy and never resolve directly.
+Why not either pure option:
+- **Pure HTTP CONNECT** requires every tool to honor `HTTP_PROXY`/`HTTPS_PROXY`; anything that ignores it (raw sockets, some static Go binaries) hard-fails under `--internal` (no fallback route exists). Annoying for HTTPS tooling.
+- **Pure transparent SNI** is beautifully zero-config for HTTPS (DNS→proxy-IP, demux by SNI), but **cannot handle git-over-SSH at all** — SSH carries no SNI to demux on, and under `--internal` there's no bypass route (unlike today's Linux iptables "narrow hole," `--internal` removes the route entirely, so SSH *must* traverse the proxy).
 
-- **Transparent SNI/Host proxy.** The bundled resolver answers allowlisted names with the *proxy's own IP* (NXDOMAIN otherwise); the container connects to what it thinks is the real host; the proxy reads TLS SNI (:443) or HTTP Host (:80), checks the allowlist, and forwards. **No `HTTP_PROXY` env needed** — anything doing DNS+TLS works transparently, including git-over-HTTPS. The resolver gets *simpler* (returns a constant IP for allowed names; no upstream forwarding). Downsides: SNI inspection has its own edge cases (TLS 1.3 ECH blinds it; no-SNI clients), and it's still HTTP(S)-centric (raw non-TLS TCP uncovered — but so is CONNECT-only).
+The hybrid:
+- **HTTPS (the 99% path): transparent.** The bundled resolver answers allowlisted names with the proxy's own IP (NXDOMAIN otherwise). The container connects normally; the proxy reads TLS SNI (:443) / HTTP Host (:80), allowlist-checks, forwards. No `HTTP_PROXY` env, nothing to configure — `pip`/`uv`/`npm`/`cargo`/`go`/git-over-HTTPS all Just Work.
+- **SSH (and any explicit-tunnel need): CONNECT.** The proxy also exposes an HTTP CONNECT endpoint (allowing `CONNECT <allowlisted-host>:22`). `user-setup.sh` injects an ssh `ProxyCommand` so `git@github.com` tunnels through it — the standard corporate-proxy pattern. The CONNECT endpoint doubles as a manual escape hatch for any oddball proxy-aware tool.
 
-Neither covers arbitrary raw TCP; that's the deferred SOCKS5 story. The point is: because `--internal` forces *all* egress through the proxy, the transparent model breaks **fewer** tools for similar LOC, so it deserves a real head-to-head rather than defaulting to CONNECT. Pick the winner on spike evidence and record the rationale.
+**ECH mitigation (the one SNI edge case worth handling):** TLS 1.3 Encrypted Client Hello would blind the SNI read, but ECH requires the client to first fetch an ECH config via a DNS `HTTPS`/`SVCB` record — and we own the resolver. The proxy refuses to serve `HTTPS`/`SVCB` records, so clients fall back to plaintext SNI. (Moot today anyway — CLI tools don't enable ECH by default — but free to defend.) The other SNI edge cases all fail *closed* (no-SNI client → reject; raw-IP-no-DNS → no route under `--internal` → fails; non-:443/:80 protocols → handled by the CONNECT path or out of scope), so none is a security or silent-bypass risk.
+
+Still out of scope for rc1: arbitrary raw TCP to non-HTTP/non-SSH services (Postgres, Redis, etc.) — that's the SOCKS5 story, deferred to 1.0.1. The enumerated rc1 tool surface is: each agent CLI's API calls, `git` over both HTTPS and SSH, `pip`/`uv`/`npm`/`cargo`/`go`, and the local-LLM forward (below).
 
 ### Scope discipline (carried forward, with corrections)
 
-- **rc1 ships ONE transport (CONNECT or transparent-SNI, per the spike) + DNS allowlist.** SOCKS5 / arbitrary-TCP slips to `1.0.1`. **But** be honest that under `--internal`, tools that don't speak the chosen transport hard-fail (no network), they don't silently reach the internet — so the tool-compat surface must be enumerated up front, not discovered in the soak. Minimum it must cover: the agent CLIs' own API calls, `git` clone/fetch/push (the default `SANDY_SSH=token` HTTPS path), `pip`/`uv`/`npm`/`cargo`/`go`.
+- **rc1 ships the hybrid transport (transparent HTTPS + CONNECT-for-SSH) + DNS allowlist + the local-LLM forward.** SOCKS5 / arbitrary-TCP to non-HTTP/non-SSH services slips to `1.0.1`. Under `--internal`, tools that don't speak the proxy hard-fail (no network) — they don't silently reach the internet — so the tool-compat surface is enumerated up front, not discovered in the soak: each agent CLI's API calls, `git` over HTTPS *and* SSH (`SANDY_SSH=agent`), `pip`/`uv`/`npm`/`cargo`/`go`, and `SANDY_LOCAL_LLM_HOST`.
 - **Permissive-first allowlist; tighten in 1.0.1+.** rc1 covers the obvious set (Anthropic, OpenAI, Google APIs, npm, PyPI, GitHub, crates, Go proxy, GHCR). Edge cases (JFrog, private registries, HuggingFace, corp mirrors) become `SANDY_ALLOW_HOSTS` reports, not soak-restarts. **Do not try to get the list right on the first try.**
-- **No MITM / cert injection / traffic logging / retries / caching.** rc1's proxy is dumb: match host against allowlist, forward bytes. Target ≤500 LOC of Go; if it passes ~1000, stop and re-scope. **One dependency is allowed if needed** (`miekg/dns`) — hand-rolling DNS packet parsing on stdlib to preserve a "zero deps" badge is false economy. (The transparent-SNI model largely moots this — its resolver is trivial.)
+- **No MITM / cert injection / traffic logging / retries / caching.** rc1's proxy is dumb: match host against allowlist, forward bytes. It never terminates TLS — SNI is read from the unencrypted ClientHello, the bytes are passed through untouched, so there's no cert injection and no trust-store surgery. Budget: the hybrid (transparent demux + CONNECT + trivial resolver + allowlist) is more than a pure model — target **≤700 LOC**, hard ceiling **1000**; if approaching it, re-scope. **One dependency is allowed** (`miekg/dns`) — though the resolver here is trivial (constant-IP answer for allowlisted names, refuse `HTTPS`/`SVCB`, NXDOMAIN otherwise), so stdlib may suffice.
 - **Linux: `--internal` makes the existing iptables DROP rules redundant** (a container that can't route off the bridge can't reach RFC1918 regardless). Keep the iptables path as a cheap belt-and-suspenders, but don't pretend it's load-bearing once `--internal` lands.
 - **Opt-in first, flip to default before rc1 cut.** Ship as `SANDY_EGRESS_PROXY=1` passive-safe key. First 3–4 days of the soak, opt in manually; then flip the default on for the remaining 3–4 days.
 
@@ -313,24 +319,33 @@ Two networks per sandy launch (PID-keyed):
 1. **Sidecar network** (`sandy_sidecar_<pid>`, **bridge `--internal`**) — the container and the proxy live here. No route off-bridge: this is what closes F2.
 2. **Egress network** (`sandy_egress_<pid>`, normal bridge) — only the proxy attaches here; this is the proxy's path to the internet.
 
-The container attaches **only** to the sidecar network, with `--dns <proxy-sidecar-ip>` (and, if the CONNECT model wins, `HTTP_PROXY`/`HTTPS_PROXY=http://<proxy-sidecar-ip>:3128`). The proxy is dual-homed (sidecar + egress).
+The container attaches **only** to the sidecar network, with `--dns <proxy-sidecar-ip>`. No `HTTP_PROXY` env for the HTTPS path (transparent), but the container's ssh config gets a `ProxyCommand` pointing at the proxy's CONNECT endpoint (see PR 2.7.3). The proxy is dual-homed (sidecar + egress).
 
-### `SANDY_LOCAL_LLM_HOST` × `--internal` (new — must be resolved)
+### `SANDY_LOCAL_LLM_HOST` × `--internal` — proxy forwarding (decided 2026-06-04, in-scope for rc1)
 
-Today `SANDY_LOCAL_LLM_HOST` pokes an iptables hole so the container can reach `host.docker.internal:port`. Under `--internal`, `host.docker.internal` is off-bridge and unreachable by construction (the spike confirms this). Two options for rc1, pick one explicitly:
+Today `SANDY_LOCAL_LLM_HOST` pokes an iptables hole so the container can reach `host.docker.internal:port`. Under `--internal`, `host.docker.internal` is off-bridge and unreachable by construction (spike A1c confirmed). **Decision: the proxy forwards to it — `SANDY_LOCAL_LLM_HOST` and `SANDY_EGRESS_PROXY` work together, no mutual-exclusion footgun.**
 
-- **(a)** The proxy forwards to `host.docker.internal:port` when that host:port is on the allowlist — i.e. the allowlist supports `host:port` literals, and the proxy resolves `host.docker.internal` on its egress leg. Cleaner UX, slightly more proxy code.
-- **(b)** Document that `SANDY_LOCAL_LLM_HOST` and `SANDY_EGRESS_PROXY` are mutually exclusive in rc1 (setting both is a hard error with a clear message), and revisit in 1.0.1.
+Mechanism (reuses the hybrid's CONNECT/forward machinery, so it's nearly free once SSH-over-CONNECT exists):
+- The configured `SANDY_LOCAL_LLM_HOST=host:port` is added to the allowlist as a `host:port` literal.
+- The proxy listens on that port and does a **dedicated TCP forward** to `host.docker.internal:port` on its egress (non-internal) leg — where `host.docker.internal` *is* reachable (Docker Desktop maps it on a normal network). No demux needed: it's a fixed port→host:port mapping, simpler than the SNI path.
+- For plain-HTTP local LLMs (Ollama, vLLM — the common case), no TLS is involved, so the forward is a raw byte pipe. The opencode auto-config continues to point at `http://host.docker.internal:<port>/v1`; DNS for `host.docker.internal` resolves to the proxy IP, and the proxy forwards.
 
-Default recommendation: **(b)** for rc1 (smaller surface, the two features have a small overlapping user base), **(a)** as a fast-follow if anyone actually hits it.
+Rationale for doing it now rather than deferring: the maintainer actively uses local-LLM passthrough, the forward path is shared with the SSH-CONNECT work (low marginal cost), and a hard-error "pick one" would be a poor rc1 experience for exactly the isolation-conscious users most likely to run a local model.
 
 ### PR 2.7.1 — Proxy binary (Go source + unit tests)
 
-**Scope**: Go under `proxy/` implementing the spike-chosen transport + a DNS responder + allowlist matching (`*.example.com` wildcards), allowlist loaded from `/etc/sandy-proxy.json` at startup. Static binary; at most one dependency (`miekg/dns`).
+**Scope**: Go under `proxy/` implementing the hybrid transport:
+- **DNS responder** (UDP 53): allowlisted name → proxy's own IP; refuse `HTTPS`/`SVCB` records (ECH defeat); `NXDOMAIN` otherwise. Closes F9 (DNS exfil).
+- **Transparent listener** (:443 SNI demux, :80 Host demux): read the host from the unencrypted ClientHello / HTTP request line, allowlist-check, then splice bytes to the real host (resolved on the egress leg). Never terminates TLS.
+- **CONNECT endpoint** (:3128): `CONNECT <host>:<port>` allowlist-checked, then byte-splice. Used by ssh `ProxyCommand` for git-over-SSH, available as a manual escape hatch.
+- **Dedicated forward** for `SANDY_LOCAL_LLM_HOST`: listen on the configured port, splice to `host.docker.internal:port`.
+- **Allowlist** loaded from `/etc/sandy-proxy.json` at startup: exact names, `*.example.com` wildcards, and `host:port` literals.
 
-**Tests**: unit tests for the transport, allowlist matching edge cases (wildcard, exact, `host:port`), `NXDOMAIN` / refuse for non-allowlisted hosts, and (if transparent) SNI/Host extraction including the no-SNI and oversized-record cases.
+Static binary; at most one dependency (`miekg/dns`), though stdlib likely suffices given the trivial resolver.
 
-**Exit criteria**: `go test ./proxy/...` passes; binary ≤500 LOC excluding the one allowed dep (soft ceiling 1000 — if approaching it, re-scope).
+**Tests**: allowlist matching (exact, wildcard, `host:port`); SNI extraction incl. no-SNI (→ reject) and split/oversized ClientHello; HTTP Host extraction; CONNECT allow/deny; `HTTPS`/`SVCB` refusal; `NXDOMAIN` for non-allowlisted; the local-LLM forward.
+
+**Exit criteria**: `go test ./proxy/...` passes; binary ≤700 LOC excluding the dep (hard ceiling 1000 — if approaching it, re-scope, e.g. drop the local-LLM forward to 1.0.1).
 
 ### PR 2.7.2 — `sandy-proxy` Docker image
 
@@ -338,13 +353,17 @@ Default recommendation: **(b)** for rc1 (smaller surface, the two features have 
 
 ### PR 2.7.3 — Launcher wiring
 
-**Scope**: sandy creates the two networks per-launch (sidecar `--internal`, egress normal), starts the dual-homed proxy container, sets `--network sidecar` + `--dns proxy-ip` (+ proxy env if CONNECT), gates on `SANDY_EGRESS_PROXY`, and tears everything down in the cleanup trap (the trap already handles per-instance networks; extend it for the second network + proxy container).
+**Scope**: sandy creates the two networks per-launch (sidecar `--internal`, egress normal), starts the dual-homed proxy container, attaches the agent container with `--network sidecar` + `--dns proxy-ip`, gates on `SANDY_EGRESS_PROXY`, and tears everything down in the cleanup trap (the trap already handles per-instance networks; extend it for the second network + proxy container).
+
+**ssh `ProxyCommand` injection** — when the proxy is on, `user-setup.sh` writes an ssh config entry routing git-host SSH through the proxy's CONNECT endpoint (`ProxyCommand` using `nc`/openssh's `-o ProxyUseFdpass` or a small connect helper baked into the image). This is what makes `SANDY_SSH=agent` work under `--internal`. The allowlist must include the git host on `:22` (github.com:22 etc. in the default set).
 
 **`SANDY_EGRESS_PROXY` passive-safe key** — passive allowlist in `_load_sandy_config()`. Default `0` for the first soak week, then flip to `1`.
 
 **`SANDY_ALLOW_HOSTS` privileged-tier key** — comma-separated additions to the allowlist. Privileged: user-added hosts expand the attack surface and must not be workspace-settable without the approval prompt.
 
-**Interaction guardrails**: enforce the `SANDY_LOCAL_LLM_HOST` decision above; confirm `cleanup()` removes both networks + the proxy container on all trapped signals (EXIT INT TERM HUP QUIT ABRT), including the SIGKILL-leak caveat already documented for the main container.
+**Allowlist assembly** — sandy composes `/etc/sandy-proxy.json` from the built-in default set + `SANDY_ALLOW_HOSTS` + (when set) the `SANDY_LOCAL_LLM_HOST` `host:port` literal, and mounts it into the proxy container.
+
+**Interaction guardrails**: `SANDY_LOCAL_LLM_HOST` + proxy is now *supported* (forward path above), not an error; confirm `cleanup()` removes both networks + the proxy container on all trapped signals (EXIT INT TERM HUP QUIT ABRT), including the SIGKILL-leak caveat already documented for the main container.
 
 ### PR 2.7.4 — Remove macOS launch warning (problem now fixed)
 
@@ -353,18 +372,22 @@ Default recommendation: **(b)** for rc1 (smaller surface, the two features have 
 ### PR 2.7.5 — Integration tests + manual macOS checklist
 
 **Automated (Linux CI)** in `test/run-integration-tests.sh`:
-- Allowlisted host (`api.anthropic.com`) reachable from inside a sandy container with the proxy on.
+- Allowlisted host (`api.anthropic.com`) reachable from inside a sandy container with the proxy on (transparent HTTPS path).
 - Non-allowlisted host (`evil.example.com`) refused / `NXDOMAIN`.
 - `SANDY_ALLOW_HOSTS=foo.bar.com` tunes the allowlist.
 - Opt-out via `SANDY_EGRESS_PROXY=0` in a passive `.sandy/config` works.
 - Proxy survives container restart; cleanup removes both networks.
-- Tool-compat smoke: `git clone` (HTTPS), `pip install`, `npm install` all succeed through the proxy.
+- Tool-compat smoke through the proxy: `git clone` over **HTTPS**, `git clone` over **SSH** (`SANDY_SSH=agent` → ProxyCommand→CONNECT path), `pip install`, `npm install`.
+- Local-LLM forward: a stub HTTP server on the host reachable via the proxy when `SANDY_LOCAL_LLM_HOST` is set alongside the proxy.
+- ECH defeat: the resolver refuses `HTTPS`/`SVCB` queries.
 
 **Manual macOS checklist (gates the rc1 cut — there is no macOS CI)**, documented in `TESTING_PLAN.md`:
 - Re-run `test/spike/macos-internal-network-spike.sh` → all-PASS on the current Docker Desktop.
 - Raw-IP to an RFC1918 LAN address fails with the proxy on.
 - `host.docker.internal:22` (host SSHD) unreachable with the proxy on (the F2 repro).
-- The same tool-compat smoke as CI, run by hand on macOS.
+- `git clone` over SSH succeeds in a `SANDY_SSH=agent` repo with the proxy on.
+- Local Ollama/vLLM reachable via `SANDY_LOCAL_LLM_HOST` + proxy on.
+- The same HTTPS tool-compat smoke as CI, run by hand on macOS.
 
 ### PR 2.7.6 — 7-day soak
 
@@ -372,7 +395,7 @@ Default recommendation: **(b)** for rc1 (smaller surface, the two features have 
 
 ### Total budget
 
-**~1 hour** for the PR 2.7.0 spike (do this before anything else — it can kill or green-light the whole milestone). Then **~2 weeks** of build/test/harness work, then **7 days** of soak. Plus the "`SANDY_ALLOW_HOSTS` kept missing hosts → cut 1.0.1 to tune" possibility. rc1 is ~4–5 weeks of wall-clock from the start of M3 — **conditional on the spike passing**; if it fails, M2.7 slips back to 1.1 and 1.0 ships with the honest warning (a documented limitation beats a non-functional security feature).
+PR 2.7.0 spike: ✓ done (~1 hour, passed 2026-06-04). The hybrid transport + local-LLM forward adds modestly to the original estimate (more proxy LOC: ~700 vs ~500, plus ssh `ProxyCommand` wiring), so budget **~2–2.5 weeks** of build/test/harness work, then **7 days** of soak. Plus the "`SANDY_ALLOW_HOSTS` kept missing hosts → cut 1.0.1 to tune" possibility. The spike already de-risked the load-bearing assumption, so the remaining risk is implementation, not architecture.
 
 ---
 
@@ -608,12 +631,14 @@ PR 3.2 (build_*_cmd unify) ✓ (#5 merged 68b2ee1)
 PR 3.3 (version bump) ✓          ──▶ tag 0.13.0 ✓ (2026-05-30)
     │
     ▼
-M2.7 PR 2.7.0 (macOS --internal spike)  ← NEXT — go/no-go gate, ~1hr
-    │  (all-PASS → proceed; any FAIL → M2.7 slips to 1.1)
+M2.7 PR 2.7.0 (macOS --internal spike) ✓ PASSED 14/14 (2026-06-04)
+    │  greenlit → architecture sound; transport = hybrid; local-LLM in-scope
     ▼
-M2.7 PR 2.7.1 (proxy Go binary + unit tests; transport chosen by spike)
+M2.7 PR 2.7.1 (proxy Go binary: transparent HTTPS + CONNECT-for-SSH  ← NEXT
+              + DNS allowlist + local-LLM forward; ≤700 LOC)
 M2.7 PR 2.7.2 (sandy-proxy Dockerfile + phased build)
-M2.7 PR 2.7.3 (launcher wiring: sidecar --internal + egress net + proxy)
+M2.7 PR 2.7.3 (launcher wiring: sidecar --internal + egress net + proxy
+              + ssh ProxyCommand injection + allowlist assembly)
 M2.7 PR 2.7.4 (remove macOS warning — only when proxy is on)
 M2.7 PR 2.7.5 (integration tests + manual macOS checklist)
                                  ──▶ tag 0.13.1 or 0.14.0-pre

--- a/ROADMAP_1.0.md
+++ b/ROADMAP_1.0.md
@@ -255,80 +255,124 @@ Three follow-up patches shipped in `v0.11.2` and `v0.11.3`:
 
 ## Milestone 2.7 — Egress proxy sidecar (Sprint 3) → `0.13.1` or `0.14.0-pre`
 
-> **Re-baseline note (2026-05-16):** original target was `0.12.1`/`0.13.0-pre`. After the `v0.12.0` re-baseline, the version label shifts up one minor — actual target is `0.13.1` or `0.14.0-pre`. Scope below is unchanged.
+> **Re-baseline note (2026-05-16):** original target was `0.12.1`/`0.13.0-pre`. After the `v0.12.0` re-baseline, the version label shifts up one minor — actual target is `0.13.1` or `0.14.0-pre`.
+
+> **Replan note (2026-06-04):** the architecture section was reviewed and revised after a critique found that the original "not using `--internal`" decision would have made the proxy security theater on macOS (the very platform M2.7 exists to fix). The `--internal` decision is flipped, a mandatory day-1 spike is added (PR 2.7.0), the CONNECT-vs-transparent-SNI choice is left to the spike, and several integration gaps (tool compatibility under `--internal`, `SANDY_LOCAL_LLM_HOST` collision, no macOS CI) are now called out explicitly. The original text is preserved in git history (pre-`m2.7-replan`).
 
 **New milestone, not in the original roadmap.** Pulled from 1.1 into rc1 because shipping 1.0 with a known Critical (F2 macOS network) documented in its own spec is a credibility problem. The launch warning is honest but not protective; users click through warnings and the current `--add-host` nullification is cosmetic against raw-IP LAN access.
 
 **Ordering:** M2.7 lands *after* M3, not before or concurrent. M3 is the highest-risk *refactor* on the roadmap (heredoc extract); M2.7 is the biggest *architectural addition*. Stacking them into one soak means regression bisection has to untangle two huge changes. Landing M3 first, mini-soaking it, then landing M2.7 on a clean M3 base gives each change clean attribution.
 
-### Scope discipline (tightened from the original Sprint 3 plan)
+### The load-bearing primitive: `--internal` (corrected 2026-06-04)
 
-The original Sprint 3 plan scoped HTTP CONNECT + SOCKS5 + DNS allowlist with a full default allowlist. rc1 pulls this tighter:
+The single most important decision in this milestone is whether the container's network is `--internal`. **It must be.**
 
-- **rc1 ships HTTP CONNECT + DNS allowlist only.** SOCKS5 slips to `1.0.1` if it's not trivially in the box. Most tooling hits CONNECT first; SOCKS5 is a nice-to-have, not a blocker.
-- **Permissive-first allowlist; tighten in 1.0.1+.** The rc1 allowlist covers the obvious set (Anthropic, OpenAI, Google APIs, npm, PyPI, GitHub, crates, Go proxy, GHCR). Users will hit edge cases (JFrog, private registries, HuggingFace, corp mirrors) during the M5 soak. Those become `SANDY_ALLOW_HOSTS` tuning reports, not blockers. **Do not try to get the list right on first try** — that's a recipe for the soak restarting every week when someone hits a missing host.
-- **No MITM / cert injection / traffic logging / retries / caching.** Every one of those is tempting, every one is a rabbit hole. rc1's proxy is dumb: accept CONNECT, resolve DNS against allowlist, forward bytes. If that's ≤500 LOC of Go, great. If it's growing past 1000, stop and re-scope.
-- **Linux iptables stays.** The proxy is **additive** on Linux, **replacement** only on macOS. Keep iptables as a belt-and-suspenders floor — zero cost, and it guards against bugs in the proxy itself.
-- **Opt-in first, flip to default before rc1 cut.** Ship as `SANDY_EGRESS_PROXY=1` passive-safe key. First 3–4 days of the M2.7 soak, opt in manually. Catch obvious breakage without risking every launch. Then flip the default to on and soak the remaining 3–4 days against the real rc1 surface.
+Why this is the whole ballgame: F2 exists because the container's default route points at its bridge gateway, which lives in Docker Desktop's VM, which NATs onto the host LAN. Putting the container on a two-network setup does **not** change that — if the network the container sits on is a normal (non-internal) bridge, the VM still installs a MASQUERADE rule for it and the container can still `curl http://192.168.1.1` straight to the home router. Nothing forces traffic through the proxy; a malicious/injected agent simply doesn't use it. Raw-IP LAN access — exactly what F2 demonstrated by reading the host SSH banner — sails right past. The proxy becomes decorative.
+
+A Docker `--internal` bridge is precisely what removes the MASQUERADE rule and severs that off-bridge route. It is the actual isolation mechanism. The proxy is what gives *controlled* egress back; `--internal` is what takes *uncontrolled* egress away.
+
+The original plan's stated reason to avoid `--internal` ("it breaks Docker's embedded DNS resolver for external lookups") is correct but irrelevant: the design already passes `--dns <proxy-ip>`, replacing the embedded resolver entirely. We *want* the embedded resolver gone. `--internal` does not break container→proxy (intra-bridge L2) or proxy→internet (the proxy's second, non-internal network). It only breaks the thing we're deliberately replacing.
+
+**Corollary the original plan under-weighted:** once `--internal` is correct, the proxy is the *only* way off the bridge. The failure mode is no longer just "a host is missing from the allowlist" — it's "any tool that doesn't route through the proxy is completely broken." That reframes the tool-compatibility question from a footnote into a primary design constraint (see "Transport model" below).
+
+### PR 2.7.0 — macOS `--internal` spike (MANDATORY, do first) — `test/spike/macos-internal-network-spike.sh`
+
+**Not a build PR — a go/no-go gate.** Everything downstream rests on assumptions about Docker Desktop's macOS networking that **cannot be tested in CI** (GitHub Actions is Linux-only; the platform being fixed has zero automated coverage). Prove them by hand, once, in ~1 hour, before committing the ~2 weeks:
+
+1. An `--internal` bridge network blocks raw-IP LAN egress (`curl http://<lan-ip>` fails where it succeeds on a normal bridge).
+2. A dual-homed sidecar on `(--internal, normal)` is reachable by a container on the internal net (intra-bridge L2 works despite `--internal`).
+3. That sidecar can reach the internet via its non-internal leg.
+4. `--dns <sidecar-ip>` propagates into a container on the `--internal` network.
+
+The spike script (`test/spike/macos-internal-network-spike.sh`) automates all four with a PASS/FAIL gate; it also confirms the baseline F2 exposure reproduces (so "blocked" results mean something) and flags the `host.docker.internal` reachability that drives the `SANDY_LOCAL_LLM_HOST` decision below. It cleans up all networks/containers on exit and needs no sudo.
+
+**Exit criteria:** all-PASS on a real Docker Desktop (macOS). If any assumption fails, **stop** — the topology needs a rethink and you've spent an hour, not three weeks. A Linux run passes too but explicitly does not satisfy the gate.
+
+### Transport model — decide on the spike, not in advance
+
+The original plan committed to **HTTP CONNECT + DNS allowlist**. Under the (now mandatory) `--internal` boundary, that's not obviously the best choice, because CONNECT requires every tool to honor `HTTP_PROXY`/`HTTPS_PROXY`. Two candidates, to be compared during the spike:
+
+- **HTTP CONNECT proxy** (port 3128). Container gets `HTTP_PROXY`/`HTTPS_PROXY` env. Covers `curl`, `pip`, `npm`, `uv`, most HTTP libraries. Breaks anything that ignores the proxy env (raw sockets, some static Go binaries, **git-over-SSH** when `SANDY_SSH=agent`). DNS allowlist is mostly secondary defense here (it makes non-proxy tools fail at resolve-time and closes F9 DNS-exfil), since CONNECT-aware tools hand the hostname to the proxy and never resolve directly.
+
+- **Transparent SNI/Host proxy.** The bundled resolver answers allowlisted names with the *proxy's own IP* (NXDOMAIN otherwise); the container connects to what it thinks is the real host; the proxy reads TLS SNI (:443) or HTTP Host (:80), checks the allowlist, and forwards. **No `HTTP_PROXY` env needed** — anything doing DNS+TLS works transparently, including git-over-HTTPS. The resolver gets *simpler* (returns a constant IP for allowed names; no upstream forwarding). Downsides: SNI inspection has its own edge cases (TLS 1.3 ECH blinds it; no-SNI clients), and it's still HTTP(S)-centric (raw non-TLS TCP uncovered — but so is CONNECT-only).
+
+Neither covers arbitrary raw TCP; that's the deferred SOCKS5 story. The point is: because `--internal` forces *all* egress through the proxy, the transparent model breaks **fewer** tools for similar LOC, so it deserves a real head-to-head rather than defaulting to CONNECT. Pick the winner on spike evidence and record the rationale.
+
+### Scope discipline (carried forward, with corrections)
+
+- **rc1 ships ONE transport (CONNECT or transparent-SNI, per the spike) + DNS allowlist.** SOCKS5 / arbitrary-TCP slips to `1.0.1`. **But** be honest that under `--internal`, tools that don't speak the chosen transport hard-fail (no network), they don't silently reach the internet — so the tool-compat surface must be enumerated up front, not discovered in the soak. Minimum it must cover: the agent CLIs' own API calls, `git` clone/fetch/push (the default `SANDY_SSH=token` HTTPS path), `pip`/`uv`/`npm`/`cargo`/`go`.
+- **Permissive-first allowlist; tighten in 1.0.1+.** rc1 covers the obvious set (Anthropic, OpenAI, Google APIs, npm, PyPI, GitHub, crates, Go proxy, GHCR). Edge cases (JFrog, private registries, HuggingFace, corp mirrors) become `SANDY_ALLOW_HOSTS` reports, not soak-restarts. **Do not try to get the list right on the first try.**
+- **No MITM / cert injection / traffic logging / retries / caching.** rc1's proxy is dumb: match host against allowlist, forward bytes. Target ≤500 LOC of Go; if it passes ~1000, stop and re-scope. **One dependency is allowed if needed** (`miekg/dns`) — hand-rolling DNS packet parsing on stdlib to preserve a "zero deps" badge is false economy. (The transparent-SNI model largely moots this — its resolver is trivial.)
+- **Linux: `--internal` makes the existing iptables DROP rules redundant** (a container that can't route off the bridge can't reach RFC1918 regardless). Keep the iptables path as a cheap belt-and-suspenders, but don't pretend it's load-bearing once `--internal` lands.
+- **Opt-in first, flip to default before rc1 cut.** Ship as `SANDY_EGRESS_PROXY=1` passive-safe key. First 3–4 days of the soak, opt in manually; then flip the default on for the remaining 3–4 days.
 
 ### Architecture
 
-Two-network design per sandy container:
+Two networks per sandy launch (PID-keyed):
 
-1. **Sidecar network** (`sandy_sidecar_<pid>`, bridge) — container can reach the proxy only.
-2. **Proxy network** (`sandy_proxy_<pid>`, bridge) — proxy can reach the internet.
+1. **Sidecar network** (`sandy_sidecar_<pid>`, **bridge `--internal`**) — the container and the proxy live here. No route off-bridge: this is what closes F2.
+2. **Egress network** (`sandy_egress_<pid>`, normal bridge) — only the proxy attaches here; this is the proxy's path to the internet.
 
-Container attaches only to the sidecar network with `--network sandy_sidecar_<pid>` plus `--dns <proxy-ip>` so all DNS queries go through the proxy. Proxy attaches to both networks.
+The container attaches **only** to the sidecar network, with `--dns <proxy-sidecar-ip>` (and, if the CONNECT model wins, `HTTP_PROXY`/`HTTPS_PROXY=http://<proxy-sidecar-ip>:3128`). The proxy is dual-homed (sidecar + egress).
 
-**Not using `--internal`:** it breaks Docker's embedded DNS resolver for external lookups, and the proxy is providing its own DNS implementation anyway — the container never needs the Docker embedded resolver.
+### `SANDY_LOCAL_LLM_HOST` × `--internal` (new — must be resolved)
+
+Today `SANDY_LOCAL_LLM_HOST` pokes an iptables hole so the container can reach `host.docker.internal:port`. Under `--internal`, `host.docker.internal` is off-bridge and unreachable by construction (the spike confirms this). Two options for rc1, pick one explicitly:
+
+- **(a)** The proxy forwards to `host.docker.internal:port` when that host:port is on the allowlist — i.e. the allowlist supports `host:port` literals, and the proxy resolves `host.docker.internal` on its egress leg. Cleaner UX, slightly more proxy code.
+- **(b)** Document that `SANDY_LOCAL_LLM_HOST` and `SANDY_EGRESS_PROXY` are mutually exclusive in rc1 (setting both is a hard error with a clear message), and revisit in 1.0.1.
+
+Default recommendation: **(b)** for rc1 (smaller surface, the two features have a small overlapping user base), **(a)** as a fast-follow if anyone actually hits it.
 
 ### PR 2.7.1 — Proxy binary (Go source + unit tests)
 
-**Scope**: ~500 LOC of Go under `proxy/` implementing:
-- HTTP CONNECT listener (port 3128)
-- DNS listener (UDP 53) with allowlist matching (supports `*.example.com` wildcards)
-- Allowlist loaded from `/etc/sandy-proxy.json` at startup
-- Static binary, no runtime dependencies
+**Scope**: Go under `proxy/` implementing the spike-chosen transport + a DNS responder + allowlist matching (`*.example.com` wildcards), allowlist loaded from `/etc/sandy-proxy.json` at startup. Static binary; at most one dependency (`miekg/dns`).
 
-**Tests**: unit tests for each protocol, allowlist matching edge cases, `NXDOMAIN` for non-allowlisted hosts.
+**Tests**: unit tests for the transport, allowlist matching edge cases (wildcard, exact, `host:port`), `NXDOMAIN` / refuse for non-allowlisted hosts, and (if transparent) SNI/Host extraction including the no-SNI and oversized-record cases.
 
-**Exit criteria**: `go test ./proxy/...` passes. Proxy binary is ≤500 LOC (hard limit — if it's growing, re-scope).
+**Exit criteria**: `go test ./proxy/...` passes; binary ≤500 LOC excluding the one allowed dep (soft ceiling 1000 — if approaching it, re-scope).
 
 ### PR 2.7.2 — `sandy-proxy` Docker image
 
-**Scope**: new `Dockerfile.proxy` in `$SANDY_HOME/` (generated template, same pattern as the other Dockerfiles). Phased between `sandy-base` and the agent images. Build once, cache aggressively — the proxy is stable code.
-
-Hash-based rebuild logic consistent with the rest of the build pipeline (`.proxy_build_hash`).
+**Scope**: new generated `Dockerfile.proxy` in `$SANDY_HOME/`, phased between `sandy-base` and the agent images, hash-rebuild via `.proxy_build_hash`. Build once, cache aggressively.
 
 ### PR 2.7.3 — Launcher wiring
 
-**Scope**: sandy creates the two networks per-launch (PID-keyed), starts the proxy container, injects `SANDY_EGRESS_PROXY=1` gate, tears everything down in the cleanup trap.
+**Scope**: sandy creates the two networks per-launch (sidecar `--internal`, egress normal), starts the dual-homed proxy container, sets `--network sidecar` + `--dns proxy-ip` (+ proxy env if CONNECT), gates on `SANDY_EGRESS_PROXY`, and tears everything down in the cleanup trap (the trap already handles per-instance networks; extend it for the second network + proxy container).
 
-**`SANDY_EGRESS_PROXY` passive-safe key** — add to the passive allowlist in `_load_sandy_config()`. Default: `0` for the first week of M2.7 soak, then flipped to `1`.
+**`SANDY_EGRESS_PROXY` passive-safe key** — passive allowlist in `_load_sandy_config()`. Default `0` for the first soak week, then flip to `1`.
 
-**`SANDY_ALLOW_HOSTS` privileged-tier key** — comma-separated list of additional hosts to append to the allowlist. Privileged because user-added hosts expand the attack surface; must not be workspace-settable without the approval prompt.
+**`SANDY_ALLOW_HOSTS` privileged-tier key** — comma-separated additions to the allowlist. Privileged: user-added hosts expand the attack surface and must not be workspace-settable without the approval prompt.
+
+**Interaction guardrails**: enforce the `SANDY_LOCAL_LLM_HOST` decision above; confirm `cleanup()` removes both networks + the proxy container on all trapped signals (EXIT INT TERM HUP QUIT ABRT), including the SIGKILL-leak caveat already documented for the main container.
 
 ### PR 2.7.4 — Remove macOS launch warning (problem now fixed)
 
-**Scope**: one-line revert of the S1.6 warning banner. Keep the `--add-host` nullification as defense-in-depth.
+**Scope**: revert the S1.6 macOS warning banner — **but only behind `SANDY_EGRESS_PROXY` being on**. If the proxy is off (opt-out, or a build without it), the warning must still fire: the honest-warning posture is correct whenever the real isolation isn't active. Keep the `--add-host` nullification as defense-in-depth regardless.
 
-### PR 2.7.5 — Integration tests
+### PR 2.7.5 — Integration tests + manual macOS checklist
 
-**Scope**: new tests in `test/run-integration-tests.sh`:
-- Allowlisted host (e.g. `api.anthropic.com`) reaches its target from inside a sandy container
-- Non-allowlisted host (e.g. `evil.example.com`) fails cleanly with `NXDOMAIN`
-- Raw-IP to RFC 1918 address fails (verify on both macOS and Linux)
-- Proxy survives container restart
-- `SANDY_ALLOW_HOSTS=foo.bar.com` tunes the allowlist successfully
-- Opt-out via `SANDY_EGRESS_PROXY=0` in an `.sandy/config` (passive source) works
+**Automated (Linux CI)** in `test/run-integration-tests.sh`:
+- Allowlisted host (`api.anthropic.com`) reachable from inside a sandy container with the proxy on.
+- Non-allowlisted host (`evil.example.com`) refused / `NXDOMAIN`.
+- `SANDY_ALLOW_HOSTS=foo.bar.com` tunes the allowlist.
+- Opt-out via `SANDY_EGRESS_PROXY=0` in a passive `.sandy/config` works.
+- Proxy survives container restart; cleanup removes both networks.
+- Tool-compat smoke: `git clone` (HTTPS), `pip install`, `npm install` all succeed through the proxy.
+
+**Manual macOS checklist (gates the rc1 cut — there is no macOS CI)**, documented in `TESTING_PLAN.md`:
+- Re-run `test/spike/macos-internal-network-spike.sh` → all-PASS on the current Docker Desktop.
+- Raw-IP to an RFC1918 LAN address fails with the proxy on.
+- `host.docker.internal:22` (host SSHD) unreachable with the proxy on (the F2 repro).
+- The same tool-compat smoke as CI, run by hand on macOS.
 
 ### PR 2.7.6 — 7-day soak
 
-**Gate, not a PR.** Opt-in for 3–4 days, flip default to on for 3–4 days, log surprises. Any new network failure = fix + restart 3–4-day window for that phase.
+**Gate.** Opt-in for 3–4 days, flip default on for 3–4 days, log surprises. Any new network failure = fix + restart that phase's window.
 
 ### Total budget
 
-Plan for **2 weeks of focused work** on the binary + integration + test harness work, then **7 days of soak**. Plus the "`SANDY_ALLOW_HOSTS` kept hitting unexpected misses, let me cut 1.0.1 to tune it" possibility. rc1 is ~4–5 weeks of wall-clock from the start of M3.
+**~1 hour** for the PR 2.7.0 spike (do this before anything else — it can kill or green-light the whole milestone). Then **~2 weeks** of build/test/harness work, then **7 days** of soak. Plus the "`SANDY_ALLOW_HOSTS` kept missing hosts → cut 1.0.1 to tune" possibility. rc1 is ~4–5 weeks of wall-clock from the start of M3 — **conditional on the spike passing**; if it fails, M2.7 slips back to 1.1 and 1.0 ships with the honest warning (a documented limitation beats a non-functional security feature).
 
 ---
 
@@ -564,11 +608,14 @@ PR 3.2 (build_*_cmd unify) ✓ (#5 merged 68b2ee1)
 PR 3.3 (version bump) ✓          ──▶ tag 0.13.0 ✓ (2026-05-30)
     │
     ▼
-M2.7 PR 2.7.1 (proxy Go binary + unit tests)  ← next
+M2.7 PR 2.7.0 (macOS --internal spike)  ← NEXT — go/no-go gate, ~1hr
+    │  (all-PASS → proceed; any FAIL → M2.7 slips to 1.1)
+    ▼
+M2.7 PR 2.7.1 (proxy Go binary + unit tests; transport chosen by spike)
 M2.7 PR 2.7.2 (sandy-proxy Dockerfile + phased build)
-M2.7 PR 2.7.3 (launcher wiring + SANDY_EGRESS_PROXY opt-in)
-M2.7 PR 2.7.4 (remove macOS launch warning)
-M2.7 PR 2.7.5 (integration tests)
+M2.7 PR 2.7.3 (launcher wiring: sidecar --internal + egress net + proxy)
+M2.7 PR 2.7.4 (remove macOS warning — only when proxy is on)
+M2.7 PR 2.7.5 (integration tests + manual macOS checklist)
                                  ──▶ tag 0.13.1 or 0.14.0-pre
     │
     ▼

--- a/test/spike/macos-internal-network-spike.sh
+++ b/test/spike/macos-internal-network-spike.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# =============================================================================
+# M2.7 day-1 spike — validate the egress-proxy architecture's load-bearing
+# assumptions on REAL Docker Desktop (macOS) before committing ~2 weeks of work.
+#
+# The whole M2.7 design rests on one claim: a Docker `--internal` bridge network
+# severs the container's route to the host LAN (closing F2's raw-IP path) while
+# still allowing a same-network sidecar to reach the container, and the sidecar
+# itself to reach the internet via a second, non-internal network. None of this
+# can be tested in CI (GitHub Actions is Linux-only; the platform being fixed
+# has no automated coverage), so it has to be proven by hand, once, here.
+#
+# Run this on a Mac with Docker Desktop BEFORE writing any proxy code. If the
+# PASS/FAIL summary at the end is all-PASS, the architecture is sound and PR
+# 2.7.1+ can proceed. If any assumption FAILS, stop — the topology needs a
+# rethink, and you've spent an hour instead of three weeks.
+#
+# Also runnable on Linux as a sanity check (it'll note where the two platforms
+# are expected to differ), but the macOS run is the one that matters.
+#
+# Usage:  bash test/spike/macos-internal-network-spike.sh
+#         LAN_PROBE=192.168.1.1 bash test/spike/...   # override the LAN target
+#
+# No sudo required. Cleans up all created networks/containers on exit.
+# =============================================================================
+set -uo pipefail
+
+# --- config ---------------------------------------------------------------
+PID_TAG="spike$$"
+INT_NET="sandy_spike_internal_${PID_TAG}"
+EXT_NET="sandy_spike_external_${PID_TAG}"
+PROXY_NAME="sandy_spike_proxy_${PID_TAG}"
+CLIENT_IMAGE="alpine:3.20"
+
+# A LAN IP that should be UNREACHABLE once isolation works. Default to a common
+# home-router address; override with LAN_PROBE=<ip> if yours differs. The test
+# only checks reachability transitions, so an unrelated-but-routable LAN IP is
+# fine — what matters is that it's reachable WITHOUT --internal and not WITH it.
+LAN_PROBE="${LAN_PROBE:-192.168.1.1}"
+
+# --- bookkeeping ----------------------------------------------------------
+PASS=0; FAIL=0; WARN=0
+_results=()
+
+_ok()   { _results+=("PASS  $1"); PASS=$((PASS+1)); }
+_no()   { _results+=("FAIL  $1"); FAIL=$((FAIL+1)); }
+_warn() { _results+=("WARN  $1"); WARN=$((WARN+1)); }
+_info() { printf '\033[0;36m[spike]\033[0m %s\n' "$1"; }
+
+cleanup() {
+    docker rm -f "$PROXY_NAME" >/dev/null 2>&1 || true
+    docker network rm "$INT_NET" >/dev/null 2>&1 || true
+    docker network rm "$EXT_NET" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+OS="$(uname -s)"
+_info "Platform: $OS  (the macOS result is the one that gates M2.7)"
+_info "LAN probe target: $LAN_PROBE  (override with LAN_PROBE=<ip>)"
+
+if ! docker info >/dev/null 2>&1; then
+    echo "[spike] ERROR: docker daemon not reachable. Start Docker Desktop and retry." >&2
+    exit 1
+fi
+
+docker pull -q "$CLIENT_IMAGE" >/dev/null 2>&1 || true
+
+# Helper: run a short-lived client on a network and report exit code only.
+# $1=network  $2...=command. Caps each probe at a few seconds so an unreachable
+# target fails fast rather than hanging on a full TCP timeout.
+_client() {
+    local net="$1"; shift
+    docker run --rm --network "$net" "$CLIENT_IMAGE" sh -c "$*" 2>/dev/null
+}
+
+# =============================================================================
+# Baseline — WITHOUT --internal, confirm the F2 exposure actually reproduces.
+# If the LAN isn't reachable even on a normal bridge, the probe target is wrong
+# and the later "blocked" results would be meaningless (can't block what was
+# never reachable).
+# =============================================================================
+_info "=== Baseline: normal (non-internal) bridge ==="
+if docker network create --driver bridge "$EXT_NET" >/dev/null 2>&1; then
+    _ok "create non-internal bridge network"
+else
+    _no "create non-internal bridge network"
+fi
+
+# Internet egress on a normal bridge should work everywhere.
+if _client "$EXT_NET" "wget -q -T 4 -O /dev/null https://api.anthropic.com/ || nc -z -w4 api.anthropic.com 443"; then
+    _ok "non-internal: internet egress works (api.anthropic.com:443)"
+else
+    _warn "non-internal: internet egress probe failed — check network/offline; later results may be unreliable"
+fi
+
+# LAN reachability on a normal bridge: on macOS this is F2 (EXPECTED reachable).
+# On Linux with no sandy iptables rules, also reachable. We only need it
+# reachable here to validate the probe; sandy's real Linux defense is iptables.
+if _client "$EXT_NET" "nc -z -w3 $LAN_PROBE 80 || nc -z -w3 $LAN_PROBE 443 || nc -z -w3 $LAN_PROBE 22"; then
+    _ok "non-internal: LAN target $LAN_PROBE reachable (baseline F2 exposure confirmed)"
+    _LAN_BASELINE_REACHABLE=1
+else
+    _warn "non-internal: LAN target $LAN_PROBE NOT reachable — pick a routable LAN_PROBE or the isolation test below proves nothing"
+    _LAN_BASELINE_REACHABLE=0
+fi
+
+# =============================================================================
+# Assumption 1 — `--internal` severs the route to the LAN (the F2 fix).
+# This is THE claim. If it fails on Docker Desktop macOS, the whole design dies.
+# =============================================================================
+_info "=== Assumption 1: --internal blocks LAN egress ==="
+if docker network create --driver bridge --internal "$INT_NET" >/dev/null 2>&1; then
+    _ok "create --internal bridge network"
+else
+    _no "create --internal bridge network"
+fi
+
+# Raw-IP to the LAN from an --internal network must FAIL (no route off-bridge).
+if _client "$INT_NET" "nc -z -w3 $LAN_PROBE 80 || nc -z -w3 $LAN_PROBE 443 || nc -z -w3 $LAN_PROBE 22"; then
+    _no "A1: --internal STILL reaches LAN $LAN_PROBE — architecture is INVALID on this platform"
+else
+    if [ "${_LAN_BASELINE_REACHABLE:-0}" = "1" ]; then
+        _ok "A1: --internal blocks LAN $LAN_PROBE (reachable on bridge, blocked on --internal) ✦ KEY RESULT"
+    else
+        _warn "A1: --internal blocks LAN, but baseline wasn't reachable either — inconclusive (fix LAN_PROBE)"
+    fi
+fi
+
+# Internet from an --internal network must ALSO fail (sanity: it really is sealed).
+if _client "$INT_NET" "wget -q -T 4 -O /dev/null https://api.anthropic.com/ || nc -z -w4 api.anthropic.com 443"; then
+    _no "A1b: --internal network reached the internet — it is NOT actually internal on this platform"
+else
+    _ok "A1b: --internal blocks direct internet egress (expected — proxy will be the only exit)"
+fi
+
+# host.docker.internal from --internal must fail (the local-LLM-collision concern).
+if _client "$INT_NET" "nc -z -w3 host.docker.internal 1 2>/dev/null; nc -z -w3 host.docker.internal 80 || nc -z -w3 host.docker.internal 443 || nc -z -w3 host.docker.internal 22"; then
+    _warn "A1c: host.docker.internal reachable from --internal — verify SANDY_LOCAL_LLM_HOST interaction"
+else
+    _ok "A1c: host.docker.internal unreachable from --internal (confirms local-LLM needs proxy forwarding)"
+fi
+
+# =============================================================================
+# Assumption 2 — a sidecar on the --internal network is still reachable by the
+# client (intra-bridge L2), and the sidecar can reach the internet via a SECOND
+# non-internal network. This is the proxy's two-network position.
+# =============================================================================
+_info "=== Assumption 2: dual-homed sidecar (internal + external) ==="
+
+# Start a sidecar attached to the internal network, listening on :3128.
+# Then connect it to the external network too. busybox httpd is enough to prove
+# "the client can reach me on the internal net" and "I can reach the internet
+# on the external net".
+if docker run -d --name "$PROXY_NAME" --network "$INT_NET" "$CLIENT_IMAGE" \
+    sh -c "while true; do printf 'HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nproxy' | nc -l -p 3128 -w1; done" \
+    >/dev/null 2>&1; then
+    _ok "start dual-homed sidecar on --internal network"
+else
+    _no "start dual-homed sidecar on --internal network"
+fi
+
+if docker network connect "$EXT_NET" "$PROXY_NAME" >/dev/null 2>&1; then
+    _ok "attach sidecar to second (non-internal) network"
+else
+    _no "attach sidecar to second (non-internal) network"
+fi
+
+# Discover the sidecar's IP on the INTERNAL network — that's the address the
+# real container would point --dns and HTTP_PROXY at.
+PROXY_INT_IP="$(docker inspect -f "{{(index .NetworkSettings.Networks \"$INT_NET\").IPAddress}}" "$PROXY_NAME" 2>/dev/null)"
+if [ -n "$PROXY_INT_IP" ]; then
+    _ok "sidecar internal IP discovered: $PROXY_INT_IP"
+else
+    _no "could not discover sidecar internal IP (downstream probes will be skipped)"
+fi
+
+# A2: client on --internal can reach the sidecar (intra-bridge — must work
+# despite --internal, because it's L2, not routed egress).
+if [ -n "$PROXY_INT_IP" ] && _client "$INT_NET" "nc -z -w3 $PROXY_INT_IP 3128"; then
+    _ok "A2: client on --internal reaches sidecar:$PROXY_INT_IP:3128 ✦ KEY RESULT"
+elif [ -n "$PROXY_INT_IP" ]; then
+    _no "A2: client on --internal CANNOT reach the sidecar — proxy would be unreachable, design INVALID"
+fi
+
+# A2b: the sidecar itself can reach the internet via its external leg.
+if docker exec "$PROXY_NAME" sh -c "wget -q -T 4 -O /dev/null https://api.anthropic.com/ || nc -z -w4 api.anthropic.com 443" 2>/dev/null; then
+    _ok "A2b: dual-homed sidecar reaches the internet via the external network ✦ KEY RESULT"
+else
+    _no "A2b: dual-homed sidecar CANNOT reach the internet — proxy could not forward, design INVALID"
+fi
+
+# =============================================================================
+# Assumption 3 — `--dns <sidecar-ip>` is honored by a container on the
+# --internal network (so the proxy can serve DNS / SNI-redirect). We can't run
+# a full resolver here, but we CAN prove the container's resolv.conf is set to
+# the sidecar and that traffic to :53 reaches it.
+# =============================================================================
+_info "=== Assumption 3: --dns points at the sidecar under --internal ==="
+if [ -n "$PROXY_INT_IP" ]; then
+    _RESOLV="$(docker run --rm --network "$INT_NET" --dns "$PROXY_INT_IP" "$CLIENT_IMAGE" cat /etc/resolv.conf 2>/dev/null)"
+    if echo "$_RESOLV" | grep -q "$PROXY_INT_IP"; then
+        _ok "A3: --dns $PROXY_INT_IP propagates into container resolv.conf ✦ KEY RESULT"
+    else
+        _no "A3: --dns did NOT propagate (resolv.conf: $(echo "$_RESOLV" | tr '\n' ' '))"
+    fi
+    # And the client can send UDP/53 to the sidecar (reachability, not a real query).
+    if _client "$INT_NET" "nc -z -u -w3 $PROXY_INT_IP 53 || true; nc -z -w3 $PROXY_INT_IP 3128"; then
+        _ok "A3b: client can reach sidecar transport on the internal net (TCP proven; UDP/53 path open)"
+    else
+        _warn "A3b: could not confirm sidecar transport reachability for DNS"
+    fi
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+printf '\033[1m===== M2.7 spike results (%s) =====\033[0m\n' "$OS"
+for r in "${_results[@]}"; do
+    case "$r" in
+        PASS*) printf '  \033[0;32m✓\033[0m %s\n' "${r#PASS  }" ;;
+        FAIL*) printf '  \033[0;31m✗\033[0m %s\n' "${r#FAIL  }" ;;
+        WARN*) printf '  \033[0;33m⊘\033[0m %s\n' "${r#WARN  }" ;;
+    esac
+done
+echo ""
+printf 'PASS=%d  FAIL=%d  WARN=%d\n' "$PASS" "$FAIL" "$WARN"
+echo ""
+
+if [ "$FAIL" -gt 0 ]; then
+    printf '\033[0;31mGATE: FAILED.\033[0m One or more load-bearing assumptions did not hold on this\n'
+    printf 'platform. Do NOT proceed with the proxy build as designed — the --internal\n'
+    printf 'two-network topology needs a rethink first. Investigate each FAIL above.\n'
+    exit 1
+fi
+if [ "$OS" != "Darwin" ]; then
+    printf '\033[0;33mGATE: PASSED on %s, but this is NOT the platform M2.7 exists to fix.\n' "$OS"
+    printf 'You MUST re-run this on Docker Desktop (macOS) before committing to the build.\033[0m\n'
+    exit 0
+fi
+printf '\033[0;32mGATE: PASSED on macOS.\033[0m The --internal two-network topology isolates the\n'
+printf 'LAN, keeps the sidecar reachable, lets the sidecar egress, and honors --dns.\n'
+printf 'The M2.7 architecture is sound on this Docker Desktop version. Proceed to PR 2.7.1.\n'


### PR DESCRIPTION
## Why

A review of the M2.7 egress-proxy plan (in response to "challenge the thinking and refine") found a **load-bearing flaw**: the original architecture said *"not using `--internal`"* because it breaks Docker's embedded DNS resolver.

But on macOS, a non-internal sidecar bridge **still** has a VM-installed MASQUERADE route to the host LAN — so a container on it can raw-IP its way to `192.168.x.x` straight past the proxy. The proxy only ever sees traffic that *volunteers* to use it; a malicious/injected agent doesn't. That makes the proxy **decorative on the one platform M2.7 exists to fix** (F2). Shipping it as specified would be a non-functional security feature — a worse credibility hit than the honest warning we have today.

`--internal` is the actual isolation primitive (it removes the MASQUERADE rule). It does *not* break container→proxy (intra-bridge L2) or proxy→internet (the proxy's second network). The reason cited for avoiding it (embedded DNS) is moot — the design already replaces the resolver via `--dns <proxy>`.

## What changed

**Docs (`ROADMAP_1.0.md` M2.7 section, fully rewritten):**
- Flip the `--internal` decision; document why it's load-bearing.
- **Add PR 2.7.0** — a mandatory ~1hr macOS spike (go/no-go gate) before any build. CI is Linux-only; the platform being fixed has zero automated coverage.
- Reframe transport: under `--internal` the proxy is the *only* exit, so tool-compat is a primary constraint, not a footnote. Leave CONNECT-vs-transparent-SNI to the spike.
- Call out `SANDY_LOCAL_LLM_HOST` × `--internal` collision with two explicit options.
- Allow one Go dep (`miekg/dns`); drop the macOS warning only when the proxy is actually on; add a manual macOS checklist that gates the rc1 cut; add git/pip/npm tool-compat smoke.

**New: `test/spike/macos-internal-network-spike.sh`** — the runnable gate. Automates the four assumption checks (`--internal` blocks LAN / sidecar reachable / sidecar egresses / `--dns` honored) plus a baseline-F2-reproduces sanity, with a PASS/FAIL summary and cleanup-on-exit. No sudo. shellcheck clean.

## Not in this PR

No changes to the `sandy` script. This is planning + a spike harness. The build PRs (2.7.1+) start **only after** `test/spike/macos-internal-network-spike.sh` greenlights on real Docker Desktop.

## Test plan

- [x] `bash -n` on the spike; `shellcheck` clean
- [x] config-docs + template drift checks unaffected
- [x] **Run `bash test/spike/macos-internal-network-spike.sh` on your Mac** — this is the actual deliverable's payoff. all-PASS unblocks M2.7; any FAIL means the topology needs a rethink (and we learned it in an hour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)