### PR TITLE
docs: THREAT_MODEL.md + optional gVisor runtime sketch

### DIFF
--- a/POST_1.0_IDEAS.md
+++ b/POST_1.0_IDEAS.md
@@ -352,3 +352,98 @@ Playwright Chromium instead of baking one that goes stale when a project pins a
 different Playwright. Adopt only the headless, lazy-resolved path — both projects
 also have host-Chrome / cookie-import modes that are the opposite of sandy's
 isolation.
+
+---
+
+## Optional gVisor runtime — `SANDY_RUNTIME` (strong-isolation tier)
+
+**Target: 1.1+ (defense-in-depth; opt-in).** Filed 2026-06-11. Closes/strongly
+mitigates residual **R1** (shared host kernel) in `THREAT_MODEL.md` — the one
+boundary that matters against a *determined/jailbroken* agent rather than a
+wrong-but-not-evil one.
+
+### What
+
+Let the maintainer run the container under a stronger runtime — primarily
+**gVisor** (`runsc`), a user-space kernel that intercepts the container's syscalls
+and services them itself, so the container never touches the host kernel directly.
+A container escape then has to break *gVisor's* sandbox, not just Linux
+namespaces. Exposed as a passive-looking but **privileged-tier** config key:
+
+```sh
+SANDY_RUNTIME=runc    # default — standard runtime (today's behavior)
+SANDY_RUNTIME=runsc   # gVisor — user-space kernel, strong isolation
+# (kata-runtime / a VM runtime could be a third value later)
+```
+
+### Why privileged-tier
+
+A *committed workspace* `.sandy/config` must not be able to **downgrade** the
+runtime (e.g. force `runc` when the maintainer wanted `runsc`, or point at an
+attacker-named runtime). So `SANDY_RUNTIME` goes in `SANDY_PRIVILEGED_KEYS` and
+needs the per-workspace approval prompt, like the other isolation toggles.
+Validate the value against an allowlist (`runc`/`runsc`/`kata-runtime`) — never
+pass an arbitrary string to `docker run --runtime`.
+
+### Launcher sketch
+
+```sh
+# after config load, near the other RUN_FLAGS:
+_runtime="${SANDY_RUNTIME:-runc}"
+case "$_runtime" in runc|runsc|kata-runtime) : ;; *) error "invalid SANDY_RUNTIME"; exit 1 ;; esac
+if [ "$_runtime" != runc ]; then
+    # fail closed if the runtime the maintainer asked for isn't installed —
+    # silently falling back to runc would defeat the security intent.
+    if ! docker info 2>/dev/null | grep -qiE "Runtimes:.*\b$_runtime\b"; then
+        error "SANDY_RUNTIME=$_runtime but Docker has no '$_runtime' runtime registered."
+        error "Install gVisor (https://gvisor.dev) and 'runsc install', or set SANDY_RUNTIME=runc."
+        exit 1
+    fi
+    RUN_FLAGS+=(--runtime "$_runtime")
+fi
+```
+Everything else — the egress proxy, mounts, `--cap-drop`, `no-new-privileges`,
+read-only root — stays exactly the same and composes *on top of* the stronger
+runtime. gVisor is orthogonal to all of it.
+
+### Platform reality (the catch)
+
+- **Linux native: the real use case.** Install gVisor in the host's Docker
+  (`runsc install`), then `SANDY_RUNTIME=runsc`. This is where R1 (escape =
+  host root) is sharpest, so this is where gVisor earns its keep.
+- **macOS Docker Desktop: largely N/A.** Docker Desktop doesn't ship `runsc`, and
+  there's no supported way to register it inside its VM. macOS already has the VM
+  boundary between the container and the Mac, so the marginal value is lower.
+  Behavior: the install check above just hard-errors, which is correct — don't
+  pretend.
+
+### Compatibility caveats (the real cost — must be soak-tested)
+
+gVisor re-implements the kernel surface; not every syscall/feature is supported,
+and there's overhead. Things to verify with the `sandy-isolation-test` kit *and*
+normal agent work under `runsc` before recommending it:
+- **Networking** — gVisor has its own netstack; confirm the `--internal` bridge +
+  the proxy DNS/transparent/CONNECT path all still work (this is the load-bearing
+  check — if the proxy breaks under runsc, the feature is moot).
+- **Toolchains** — heavy builds, `node`/`go`/`rust`, FUSE, `ptrace`-based tools,
+  and anything doing exotic syscalls can break or slow down. Playwright/Chromium
+  (gstack) is a known stress case.
+- **Bind mounts / overlay** behavior under gofer.
+- **Performance** — measurable syscall overhead; fine for agent work, painful for
+  IO-heavy builds.
+
+### Test plan
+
+1. `sandy --runtime`-style smoke: launch under `runsc`, run the network/fs/priv
+   probes — isolation should still HELD, and gVisor should *narrow* the escape
+   surface (R1) without breaking R-anything.
+2. Run the existing integration suite with `SANDY_RUNTIME=runsc` on a gVisor host
+   and diff failures vs `runc` — that delta is the compatibility cost.
+3. Document the supported/unsupported matrix in `SPECIFICATION.md` Appendix D.
+
+### Effort
+
+Small *launcher* change (validate + detect + one `--runtime` flag) + the
+privileged-key metadata + docs. The real work is **compatibility soak**, not code
+— hence opt-in, Linux-first, and clearly labeled "strong-isolation tier, expect
+some workloads to need `runc`."

--- a/README.md
+++ b/README.md
@@ -292,6 +292,11 @@ No default — leaving `SANDY_SCREENSHOT_DIR` unset disables the feature entirel
 
 ## How Network Isolation Works
 
+> Network egress is one of sandy's isolation layers. For the full picture —
+> the assumed adversary, every layer, and the honest residual risks — see
+> [`THREAT_MODEL.md`](THREAT_MODEL.md). Empirical bypass attempts are in
+> [`ISOLATION_STRESS.md`](ISOLATION_STRESS.md).
+
 ### Egress proxy (`SANDY_EGRESS_PROXY`) — cross-platform isolation
 
 The egress proxy is the recommended isolation mechanism and the **only** one that works on macOS. It routes the agent through a small proxy sidecar on a Docker `--internal` network (no route off the bridge except through the proxy), so it behaves identically on macOS and Linux. It's a tri-state:

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -1,0 +1,134 @@
+# Sandy Threat Model
+
+This document states **what sandy defends against, and what it does not.**
+"How secure is sandy?" has no answer without a stated adversary; this is that
+adversary. Empirical attempts to break the boundary live in `ISOLATION_STRESS.md`
+and are an ongoing exercise via the `sandy-isolation-test` red-team kit. The
+implemented mechanisms are in `SPECIFICATION.md`; the design rationale is in
+`CLAUDE.md`.
+
+---
+
+## 1. The adversary sandy assumes
+
+Sandy runs coding agents (Claude Code, etc.) with their in-session permission
+prompts disabled, so the agent acts freely *within the box*. The box exists to
+bound the damage. The assumed adversary is, in order of how much sandy invests in
+each:
+
+1. **A wrong-but-not-evil agent (primary).** The agent is generally cooperative
+   but is *occasionally* induced to do harmful things — by **prompt injection**
+   (a malicious README, issue, web page, or tool output), a buggy skill/plugin,
+   or simply a bad task. It is not running a curated exploit chain; it does
+   plausible-looking things that happen to be dangerous. **Sandy is primarily
+   engineered against this adversary, and against it sandy is strong.**
+
+2. **A committed-config / supply-chain attacker (secondary).** A repository the
+   user opens ships a hostile `.sandy/config`, `.git/hooks`, `.github/workflows`,
+   `.envrc`, etc. — trying to weaken isolation or run on the host *before/around*
+   the agent. Sandy invests real effort here (parse-not-source config, the
+   privileged-key approval prompt, read-only protected paths).
+
+3. **A determined / jailbroken agent (partial).** The agent is *actively* trying
+   to escape — enumerating syscalls, probing the runtime, attempting kernel or
+   `runc` exploits, hunting exfil channels. Sandy raises the cost (cap-drop,
+   no-new-privs, seccomp, read-only root, no docker socket) but **does not claim
+   to stop a working kernel/runtime exploit** — the container shares the host
+   kernel. This tier is where the open hardening items below apply.
+
+### Explicitly out of scope
+- **Application-layer agent behavior.** Sandy bounds the *blast radius*; it does
+  not stop the agent from *misusing its legitimate capabilities* (writing code
+  you'll run, using its own credentials, reaching allowed hosts). Prompt-injection
+  defense at the model layer is a separate problem.
+- **A malicious host or maintainer.** Sandy protects the host *from* the agent,
+  not the agent from the host. The person running sandy is trusted.
+- **Side-channel / nation-state-grade attacks** (timing, speculative execution,
+  cache). Not modeled.
+- **Supply chain of sandy's own base images** (Docker Hub `golang`/`debian`).
+  Pinned, but ultimately a trust assumption.
+
+---
+
+## 2. Assets protected
+
+- **The host filesystem** outside the mounted workspace (config, keys, other
+  projects, system files).
+- **The host itself** — no code execution / privilege escalation on the host.
+- **Other projects' data and credentials** (per-project isolation).
+- **The host network / LAN** — the agent should not reach the LAN, the host's
+  loopback services, or cloud metadata.
+- **Credentials at rest** — session credentials should not persist where they
+  weren't meant to, and one project's creds must not leak to another.
+
+## 3. Trust boundaries
+
+```
+  HOST  (trusted)
+   │  ├─ workspace dir ........ bind-mounted RW  ◀── the agent CAN write here (intended)
+   │  ├─ protected paths ...... bind-mounted RO  ◀── shell/git/CI configs
+   │  ├─ credentials .......... ephemeral mount  ◀── this session only, never persisted
+   │  └─ everything else ...... NOT mounted      ◀── invisible to the container
+   ▼
+  CONTAINER  (untrusted: the agent)   ── shared host kernel ──┐
+   ├─ non-root, cap-drop ALL, no-new-privs, seccomp, RO root  │ ← the runtime boundary
+   └─ network: --internal sidecar ─▶ sandy-proxy ─▶ internet  │   (namespaces today)
+                                                              ▼
+                                              HOST KERNEL (the floor)
+```
+The two boundaries that matter most: the **mount scope** (only the workspace +
+explicit mounts cross from host to container) and the **runtime boundary**
+(namespaces + the hardening list, sitting on the shared kernel).
+
+## 4. Layers → threats addressed
+
+| Layer | Mechanism | Adversary it stops |
+|---|---|---|
+| Network egress | `--internal` + TCP-only proxy (permissive/strict); non-TCP dropped by topology | wrong-agent LAN/host/metadata reach; committed-config exfil widening |
+| Filesystem | RO root, ephemeral tmpfs, workspace-only mount, RO protected paths | wrong-agent host-config tamper; committed hook/workflow execution |
+| Credentials | per-project sandbox, ephemeral `.credentials.json`, RO OAuth mounts | cross-project leak; credential persistence |
+| Process/privilege | non-root + `gosu`, `--cap-drop ALL`, `no-new-privileges`, no docker socket, default seccomp/AppArmor | privilege escalation; trivial container escape |
+| Resources | `--cpus`/`--memory`/`--pids-limit`, tmpfs caps | runaway resource use |
+| Config trust-tier | parse-not-source, privileged-key approval, env-only keys | committed-config code-exec / silent isolation-disable |
+| Per-instance | per-PID networks, workspace mutex, per-project sandbox | cross-session interference |
+
+---
+
+## 5. Residual risks (honest)
+
+Judged against the **primary** adversary, these are mostly accepted; against the
+**determined** adversary they are open. Empirical detail in `ISOLATION_STRESS.md`.
+
+| # | Residual | Tier it bites | Status / mitigation |
+|---|---|---|---|
+| R1 | **Shared kernel.** Namespaces are a soft boundary; a kernel/`runc` exploit = host escape (Linux native). | determined | Open. Mitigation: optional **gVisor runtime** (see POST_1.0_IDEAS). macOS has a VM boundary to the Mac. |
+| R2 | **Prevention vs detection (filesystem).** Absent protected dirs (`.github/workflows/` …) can be *created* and persist to the host, detected only at session end. | wrong-agent / committed-config | Open. Roadmap: **fanotify `FAN_OPEN_PERM`** for true prevention. |
+| R3 | **Exfil not fully closed.** Permissive reaches any public host; strict's *allowlisted* hosts (GitHub gist, `npm publish`) are exfil channels. The agent holds its own session creds. | determined | Partial. Roadmap: **strict-mode host-relay broker** (POST_1.0). |
+| R4 | **Workspace supply-chain.** The agent can poison the project (`package.json` deps, build scripts, `Makefile`) that the *user* later runs on the host. | wrong-agent / determined | Semi-fundamental — the workspace must be writable. Mitigated only for auto-executing dotfiles. |
+| R5 | **Within-sandbox persistence.** RW persistent mounts (`cargo`/`npm`/`pip` bins on PATH, `.claude` plugins/commands) let a malicious tool fire in a later session for that project. | determined | Open; bounded to the sandbox (not the host). |
+| R6 | **Coarse resource isolation.** No disk-IO / network-bandwidth caps; tmpfs is host-RAM-backed. | wrong-agent (noisy) | Accepted for now. |
+| R7 | **Defense-in-depth left on the table.** Custom seccomp allowlist, `userns-remap`, custom AppArmor/SELinux, more `/proc` masking. | determined | Optional hardening, not yet applied. |
+
+## 6. Hardening roadmap → which residual it closes
+
+- **fanotify FAN_OPEN_PERM** (filesystem prevention) → closes **R2**. (Roadmap.)
+- **Optional gVisor runtime** (`SANDY_RUNTIME=runsc`) → strongly mitigates **R1**
+  (and raises the bar on R5/R7). See `POST_1.0_IDEAS.md`.
+- **Strict-mode host-relay broker** → closes **R3** for strict mode. (POST_1.0.)
+- **Custom seccomp + userns-remap** → hardens **R1/R7** cheaply. (Optional.)
+
+## 7. How this is validated
+
+- **`ISOLATION_STRESS.md`** — point-in-time adversarial stress tests (the April
+  2026 review found F1 host-exec-via-hooks and F2 macOS LAN reach; F2 was closed
+  by the M2.7 egress proxy).
+- **`sandy-isolation-test`** (red-team kit) — a repeatable, control-anchored
+  exercise across all seven layers, run with the proxy on/off and across models.
+  The residuals above (especially R1–R5) are testable hypotheses; let the
+  red-team confirm which are real on a given platform before investing.
+
+**Bottom line:** against a wrong-but-not-evil agent and committed-config supply
+chain, sandy's isolation is strong and the layers compose well. Against a
+determined adversary, the boundary is the **shared host kernel** — the one
+residual worth real investment if your threat model includes an actively
+malicious or jailbroken agent.


### PR DESCRIPTION
Adds an explicit **THREAT_MODEL.md** (the assumed adversary, asset/boundary map, layer→threat mapping, and the honest residual risks R1–R7 each tagged with the adversary tier + mitigation) — the companion to the empirical `ISOLATION_STRESS.md` and the `sandy-isolation-test` red-team kit. README links it.

Adds a **POST_1.0 sketch of an optional gVisor runtime** (`SANDY_RUNTIME=runsc`, privileged-tier, fail-closed detection, launcher diff, Linux-first reality, compatibility caveats, test plan) — the highest-leverage mitigation for residual **R1 (shared kernel)**. Sketch only; respects the 1.0 feature freeze.

Pure docs, no config-key change (autogen tables untouched), `regen-config-docs --check` clean.