### PR TITLE
release: bump to 1.1.1-dev post-v1.1.0

### DIFF
--- a/sandy
+++ b/sandy
@@ -17,7 +17,7 @@ set -euo pipefail
 #   sandy --agent claude,gemini   Override agent selection for this run
 # =============================================================================
 
-SANDY_VERSION="1.1.0"
+SANDY_VERSION="1.1.1-dev"
 SANDY_COMMIT=""  # baked in by install.sh; empty = detect from git at runtime
 
 # Schema contract version for --print-schema / --print-state / --validate-config.


### PR DESCRIPTION
Standard post-release version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)