### PR TITLE
release: 1.2.0 — sandy --update-sessions + print-state additions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,39 @@
+## sandy v1.2.0
+
+**Fleet updates for daemon sessions.** Daemon sessions can stay up for days, running an ever-staler image — nothing at launch refreshes them once launches become rare. `sandy --update-sessions` closes that: one command refreshes every daemon session's images and rolling-restarts the ones that came out stale, conversations resuming automatically. Additive and backward-compatible: bare `sandy` and the `--start`/`--attach`/`--stop` lifecycle are unchanged, and the introspection `schema_version` stays `1`.
+
+### `sandy --update-sessions` (#41)
+
+A **global** maintenance command (ignores cwd — it operates on every daemon session on the host, or scope it to one with `--workspace PATH`):
+
+```bash
+sandy --update-sessions --dry-run             # show the plan, refresh images, restart nothing
+sandy --update-sessions --yes                 # restart every stale session, no prompt
+sandy --update-sessions --idle-for 30 --yes   # only restart sessions idle 30+ min (cron-friendly)
+sandy --update-sessions --rebuild --yes       # force a rebuild before checking staleness
+sandy --update-sessions --yes --workspace ~/p # scope to one session (per-session update)
+```
+
+For each session it runs that workspace's own `--build-only` (so image selection, skills, and any per-project Dockerfile resolve exactly as a normal launch would), compares the running container's image ID against the freshly-built one, and — for anything stale — does `sandy --stop` then `sandy --start`. `--dry-run` still refreshes images (so the printed plan reflects reality) but never restarts. Without `--idle-for`, every stale session is a candidate; a TTY without `--yes` gets a y/N prompt, a non-interactive run without `--yes` refuses with exit `1` (so cron must opt in). Exit `0` = all clean (including nothing to do); `1` = a failure or the non-interactive refusal. A nightly quiet-hours recipe:
+
+```cron
+0 3 * * * /path/to/sandy --update-sessions --idle-for 30 --yes >> ~/.sandy/update-sessions.log 2>&1
+```
+
+### Introspection additions (additive — `schema_version` stays 1)
+
+- **`image_stale`** (per `running_containers[]` entry, **full mode only**): `true`/`false`/`null` — whether a container is running an image older than the current build. Full mode only because it costs a `docker inspect` per container; the light-mode poll budget is unchanged. Staleness is read from the container's `.Config.Image` (the reference it was created with), not `docker ps`, so it stays correct even after a tag has been reassigned by an earlier rebuild.
+- **`updated_at`** (both modes): the `sandy.updated_at` label (ISO-8601 string, or `null`) that `--update-sessions` stamps on a container it restarted — lets a consumer (e.g. `sandy-ui`) tell a restarted-for-updates session from one the user stopped and started. Rides the existing `docker ps` read; no extra spawn.
+- `--print-schema` `cli_flags` gains `--update-sessions`.
+
+### Fixes rolled in
+
+- **Stale project image after a base upgrade** no longer serves a pre-upgrade `user-setup.sh`: the per-project image's staleness check now chains the parent image ID, so any base change triggers a one-time project rebuild. (Previously a project image built on a pre-daemon base ran the interactive tmux path inside a detached daemon container and crash-looped.)
+- **A failed `--start` tears down its own wreckage** (container + networks + lock) instead of leaving a crash-looping container running under `--restart unless-stopped`.
+- Numerous **portability and test-robustness** fixes surfaced by real macOS Docker runs: portable supervisor wait (BSD `sleep` has no `infinity`), `docker exec` daemon tmux probes run as the host uid (root can't see the gosu-dropped user's tmux socket), and the daemon + fleet-update **acceptance harnesses now run as `run-integration-tests.sh` §19/§20**, so a full integration run exercises the real container lifecycle.
+
+---
+
 ## sandy v1.1.0
 
 **Daemon mode** — a sandy session's lifetime is no longer tied to the terminal

--- a/SPEC_INTROSPECTION.md
+++ b/SPEC_INTROSPECTION.md
@@ -263,7 +263,8 @@ All three:
       "sandbox": "zork-3dfda686",
       "daemon": true,
       "attached_clients": 1,
-      "image_stale": false
+      "image_stale": false,
+      "updated_at": "2026-04-20T13:30:00Z"
     },
     {
       "id": "def456",
@@ -273,7 +274,8 @@ All three:
       "sandbox": "quux-99999999",
       "daemon": false,
       "attached_clients": null,
-      "image_stale": true
+      "image_stale": true,
+      "updated_at": null
     }
   ],
   "orphan_networks": 0
@@ -293,6 +295,17 @@ All three:
 > emit all three fields identically; a client on the pre-1.1.0 shape still
 > parses (unknown fields ignored) since `id`/`name`/`image`/`started_at` are
 > unchanged.
+
+> **`updated_at`** (per `running_containers[]` entry, added additively in
+> `1.2.0`, #44 — no `schema_version` bump). The container's `sandy.updated_at`
+> label as a JSON string (ISO-8601), or JSON `null` when the label is absent.
+> `sandy --update-sessions` stamps this label on any container it restarts
+> (DEC-U3), so a fresh timestamp means "this session was rolling-restarted for
+> an image update," while `null` means a session the user started/stopped
+> themselves. The sandy-ui reconnect flow uses it to tell an update-restart
+> (auto-reattach silently) from a user-initiated stop. Emitted identically in
+> both `--print-state` and `--print-state light` — it rides the same `docker
+> ps` label read as `sandbox`/`daemon`, so it costs no extra docker spawn.
 
 > **`image_stale`** (per `running_containers[]` entry, **FULL MODE ONLY**,
 > added additively in `1.2.0`, #41 — no `schema_version` bump; powers `sandy
@@ -376,7 +389,7 @@ Exit code: `0` on schemas that load cleanly (even with warnings), `1` on fatal e
 
 - Current: `schema_version: 1`
 - **Config-key object fields:** each key object carries `name`, `type` (+ `choices` for enums), `default` (omitted if none), `pattern` (omitted if none), `since` (introduction version, omitted if unknown), `stability` (always present: `stable` | `experimental` | `internal`), `description`, `sources`, and `passive_approval_required` (privileged keys only). `since` and `stability` were added additively in `0.15.0` (PR 4.1); per the rule below, older clients ignore them without a version bump.
-- **Additive changes** (new keys in existing objects, new flags in `cli_flags`): no version bump. Clients ignore unknown fields. Three additive changes shipped this way: `since`/`stability` on config-key objects (`0.15.0`, PR 4.1, above); in `1.1.0` (#17), three new `cli_flags` entries (`--start`, `--attach`, `--stop` — daemon-mode flags) plus three new `running_containers[]` fields (`sandbox`, `daemon`, `attached_clients` — see `--print-state` below); and, also in `1.1.0` (#26), one more `cli_flags` entry (`--prune-orphans` — reap orphaned sandy networks and exit) plus one new top-level `--print-state` field (`orphan_networks` — see above). In `1.2.0` (#41), one more `cli_flags` entry (`--update-sessions` — fleet image refresh + rolling restart across every daemon session on the host, scopeable to a single session with `--workspace PATH`) plus one new `running_containers[]` field, `image_stale` (FULL MODE ONLY — see above).
+- **Additive changes** (new keys in existing objects, new flags in `cli_flags`): no version bump. Clients ignore unknown fields. Three additive changes shipped this way: `since`/`stability` on config-key objects (`0.15.0`, PR 4.1, above); in `1.1.0` (#17), three new `cli_flags` entries (`--start`, `--attach`, `--stop` — daemon-mode flags) plus three new `running_containers[]` fields (`sandbox`, `daemon`, `attached_clients` — see `--print-state` below); and, also in `1.1.0` (#26), one more `cli_flags` entry (`--prune-orphans` — reap orphaned sandy networks and exit) plus one new top-level `--print-state` field (`orphan_networks` — see above). In `1.2.0`, one more `cli_flags` entry (`--update-sessions` — fleet image refresh + rolling restart across every daemon session on the host, scopeable to a single session with `--workspace PATH`, #41) plus two new `running_containers[]` fields: `image_stale` (FULL MODE ONLY, #41 — see above) and `updated_at` (both modes, #44 — see above).
 - **Deprecations** (existing key changes semantics): bump to `schema_version: 2`. Sandy publishes both versions in parallel via `--print-schema --schema-version 1` for one minor release, then drops v1 with a release-note callout.
 - **Compatibility range**: each sandy version declares `supported_schema_versions` and `deprecated_schema_versions` so clients can decide to warn/refuse.
 

--- a/sandy
+++ b/sandy
@@ -867,7 +867,7 @@ _sandy_emit_schema() {
 # name, "sandy.daemon" label value, "sandy.session" label value. Callable
 # from both --print-state modes so they stay in sync.
 _sandy_emit_container_daemon_fields() {
-    local _cid="$1" _cname="$2" _cdaemon="$3" _csession="$4"
+    local _cid="$1" _cname="$2" _cdaemon="$3" _csession="$4" _cupdated="${5:-}"
     local _sandbox _isdaemon _ac
 
     # sandbox: the sandy.session label when present (daemon containers),
@@ -905,6 +905,17 @@ _sandy_emit_container_daemon_fields() {
     printf ','; _json_kv sandbox "$(_json_escape "$_sandbox")"
     printf ','; printf '"daemon":%s' "$_isdaemon"
     printf ','; printf '"attached_clients":%s' "$_ac"
+    # updated_at (#44): the sandy.updated_at label, stamped by --update-sessions
+    # on a container it restarted (DEC-U3). Present only on update-restarted
+    # containers; a normally-started daemon session has no such label → null.
+    # Rides the existing `docker ps` label read — no extra docker spawn. Lets a
+    # consumer (sandy-ui reconnect) tell "restarted for updates" from a session
+    # the user stopped/started themselves.
+    if [ -n "$_cupdated" ]; then
+        printf ','; _json_kv updated_at "$(_json_escape "$_cupdated")"
+    else
+        printf ',"updated_at":null'
+    fi
 }
 
 # #41 (milestone 1.2.0) — tri-state image-staleness check, shared by
@@ -1220,19 +1231,20 @@ _sandy_emit_state() {
     if [ "$_mode" = "light" ]; then
         local _ps_out=""
         if command -v docker >/dev/null 2>&1 \
-           && _ps_out="$(docker ps --format '{{.ID}}|{{.Names}}|{{.Image}}|{{.CreatedAt}}|{{.Label "sandy.daemon"}}|{{.Label "sandy.session"}}' 2>/dev/null)"; then
+           && _ps_out="$(docker ps --format '{{.ID}}|{{.Names}}|{{.Image}}|{{.CreatedAt}}|{{.Label "sandy.daemon"}}|{{.Label "sandy.session"}}|{{.Label "sandy.updated_at"}}' 2>/dev/null)"; then
             printf ',"docker_reachable":true'
             printf ',"running_containers":['
             first=1
             while IFS= read -r _cline; do
                 [ -z "$_cline" ] && continue
-                local _cid _cname _cimg _cstarted _cdaemon _csession
+                local _cid _cname _cimg _cstarted _cdaemon _csession _cupdated
                 _cid="$(echo "$_cline"      | awk -F'|' '{print $1}')"
                 _cname="$(echo "$_cline"    | awk -F'|' '{print $2}')"
                 _cimg="$(echo "$_cline"     | awk -F'|' '{print $3}')"
                 _cstarted="$(echo "$_cline" | awk -F'|' '{print $4}')"
                 _cdaemon="$(echo "$_cline"  | awk -F'|' '{print $5}')"
                 _csession="$(echo "$_cline" | awk -F'|' '{print $6}')"
+                _cupdated="$(echo "$_cline"  | awk -F'|' '{print $7}')"
                 [ $first -eq 0 ] && printf ','
                 first=0
                 printf '{'
@@ -1240,7 +1252,7 @@ _sandy_emit_state() {
                 printf ','; _json_kv name       "$(_json_escape "$_cname")"
                 printf ','; _json_kv image      "$(_json_escape "$_cimg")"
                 printf ','; _json_kv started_at "$(_json_escape "$_cstarted")"
-                _sandy_emit_container_daemon_fields "$_cid" "$_cname" "$_cdaemon" "$_csession"
+                _sandy_emit_container_daemon_fields "$_cid" "$_cname" "$_cdaemon" "$_csession" "$_cupdated"
                 printf '}'
             done < <(printf '%s\n' "$_ps_out" | grep -E '(^|[|])sandy[_-]|[|]sandy-' || true)
             printf ']'
@@ -1269,7 +1281,7 @@ _sandy_emit_state() {
         # spawn budget, which is why light mode never touches this.
         _SANDY_IMAGE_ID_CACHE=""
         if command -v docker >/dev/null 2>&1 \
-           && _ps_out="$(docker ps --format '{{.ID}}|{{.Names}}|{{.Image}}|{{.CreatedAt}}|{{.Label "sandy.daemon"}}|{{.Label "sandy.session"}}' 2>/dev/null)"; then
+           && _ps_out="$(docker ps --format '{{.ID}}|{{.Names}}|{{.Image}}|{{.CreatedAt}}|{{.Label "sandy.daemon"}}|{{.Label "sandy.session"}}|{{.Label "sandy.updated_at"}}' 2>/dev/null)"; then
             printf ',"docker_reachable":true'
             printf ',"running_containers":['
             first=1
@@ -1278,13 +1290,14 @@ _sandy_emit_state() {
             while IFS= read -r _cline; do
                 [ -z "$_cline" ] && continue
                 # line format: id|name|image|started|daemon-label|session-label
-                local _cid _cname _cimg _cstarted _cdaemon _csession
+                local _cid _cname _cimg _cstarted _cdaemon _csession _cupdated
                 _cid="$(echo "$_cline"     | awk -F'|' '{print $1}')"
                 _cname="$(echo "$_cline"   | awk -F'|' '{print $2}')"
                 _cimg="$(echo "$_cline"    | awk -F'|' '{print $3}')"
                 _cstarted="$(echo "$_cline" | awk -F'|' '{print $4}')"
                 _cdaemon="$(echo "$_cline"  | awk -F'|' '{print $5}')"
                 _csession="$(echo "$_cline" | awk -F'|' '{print $6}')"
+                _cupdated="$(echo "$_cline"  | awk -F'|' '{print $7}')"
                 [ $first -eq 0 ] && printf ','
                 first=0
                 printf '{'
@@ -1292,7 +1305,7 @@ _sandy_emit_state() {
                 printf ','; _json_kv name       "$(_json_escape "$_cname")"
                 printf ','; _json_kv image      "$(_json_escape "$_cimg")"
                 printf ','; _json_kv started_at "$(_json_escape "$_cstarted")"
-                _sandy_emit_container_daemon_fields "$_cid" "$_cname" "$_cdaemon" "$_csession"
+                _sandy_emit_container_daemon_fields "$_cid" "$_cname" "$_cdaemon" "$_csession" "$_cupdated"
                 printf ','; printf '"image_stale":%s' "$(_sandy_image_stale "$_cid")"
                 printf '}'
             done < <(printf '%s\n' "$_ps_out" | grep -E '(^|[|])sandy[_-]|[|]sandy-' || true)

--- a/sandy
+++ b/sandy
@@ -17,7 +17,7 @@ set -euo pipefail
 #   sandy --agent claude,gemini   Override agent selection for this run
 # =============================================================================
 
-SANDY_VERSION="1.1.1-dev"
+SANDY_VERSION="1.2.0"
 SANDY_COMMIT=""  # baked in by install.sh; empty = detect from git at runtime
 
 # Schema contract version for --print-schema / --print-state / --validate-config.

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -4766,19 +4766,22 @@ echo "§68: --print-state running_containers[] daemon fields (#17) — sandbox/d
 # daemon container (probe answers "2"), a BROKEN daemon container whose
 # `docker exec ... tmux display` FAILS (mid-startup / session gone — the exact
 # shape a hung --start leaves behind), and a bare container (no labels).
-# Verifies the additive fields land correctly (join key, bool, int|null) in
-# BOTH --print-state modes, that the pre-existing id/name/image/started_at
-# fields are untouched, and — the host-found regression — that ONE broken
-# daemon container yields attached_clients:null WITHOUT killing the whole
-# emission via the set -eE introspection ERR trap.
+# Verifies the additive fields land correctly (join key, bool, int|null,
+# updated_at string|null #44) in BOTH --print-state modes, that the pre-existing
+# id/name/image/started_at fields are untouched, and — the host-found
+# regression — that ONE broken daemon container yields attached_clients:null
+# WITHOUT killing the whole emission via the set -eE introspection ERR trap.
 _DF_BIN="$(mktemp -d)"
 cat > "$_DF_BIN/docker" <<'DOCKERSHIM'
 #!/usr/bin/env bash
 case "$1" in
     ps)
-        printf 'daemon123|sandy-bar-def456|sandy-full|2026-07-14T10:00:00Z|true|bar-def456\n'
-        printf 'broken789|sandy-baz-fee789|sandy-full|2026-07-14T11:00:00Z|true|baz-fee789\n'
-        printf 'bare456|sandy-foo-abc123|sandy-claude-code|2026-07-14T09:00:00Z||\n'
+        # id|name|image|created|daemon|session|updated_at — the healthy daemon
+        # carries a sandy.updated_at label (update-restarted, #44); the broken
+        # and bare ones do not (→ updated_at null).
+        printf 'daemon123|sandy-bar-def456|sandy-full|2026-07-14T10:00:00Z|true|bar-def456|2026-07-14T12:00:00Z\n'
+        printf 'broken789|sandy-baz-fee789|sandy-full|2026-07-14T11:00:00Z|true|baz-fee789|\n'
+        printf 'bare456|sandy-foo-abc123|sandy-claude-code|2026-07-14T09:00:00Z|||\n'
         exit 0
         ;;
     exec)
@@ -4817,6 +4820,12 @@ assert isinstance(daemon['attached_clients'], int), daemon
 assert broken['daemon'] is True, broken
 assert broken['attached_clients'] is None, broken
 assert bare['attached_clients'] is None, bare
+# updated_at (#44): the label-bearing daemon carries the ISO timestamp; the
+# others are null (mutation: drop the sandy.updated_at label from the ps format
+# or the emit -> daemon['updated_at'] becomes null and this flips to FAIL).
+assert daemon['updated_at'] == '2026-07-14T12:00:00Z', daemon
+assert broken['updated_at'] is None, broken
+assert bare['updated_at'] is None, bare
 " "$_json"
 }
 check "full mode: daemon fields correct; a failing attach-probe yields null, not a dead emission" \


### PR DESCRIPTION
Cuts **1.2.0**: `sandy --update-sessions` (#41) + the `updated_at` print-state field (#44), on top of the already-merged fleet-update work. Closes #41, #44.

- `--update-sessions` — fleet image refresh + rolling restart of daemon sessions (`--dry-run`/`--yes`/`--idle-for`/`--rebuild`/`--workspace`).
- `image_stale` (full mode) + `updated_at` (both modes) in `--print-state`; `--update-sessions` in `cli_flags`. `schema_version` stays 1.
- Rolled-in fixes: project-image parent-ID staleness, failed-`--start` teardown, macOS portability, daemon + fleet acceptance harnesses as integration §19/§20.

Version bumped 1.1.1-dev → 1.2.0 in the release commit (bare version + `v1.2.0` tag land together — proxy image builds from the tag ref). Host-validated: full unit + integration suites green.

Fast-forward main after CI, then tag `v1.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)