### PR TITLE
fix(build): bash 3.2-safe empty-array expansion for _BASE_BUILD_Q (#51 regression)

### DIFF
--- a/sandy
+++ b/sandy
@@ -4846,7 +4846,7 @@ BASE_REBUILT=false
 if [ ! -f "$BASE_HASH_FILE" ] || [ "$(cat "$BASE_HASH_FILE")" != "$BASE_HASH" ] || ! docker image inspect "$BASE_IMAGE_NAME" &>/dev/null; then
     info "Building base image (language runtimes) — this may take several minutes on first run..."
     _old_base_id="$(docker image inspect -f '{{.Id}}' "$BASE_IMAGE_NAME" 2>/dev/null || true)"
-    docker build "${_BASE_BUILD_Q[@]}" --no-cache -t "$BASE_IMAGE_NAME" -f "$SANDY_HOME/Dockerfile.base" "$SANDY_HOME"
+    docker build ${_BASE_BUILD_Q[@]+"${_BASE_BUILD_Q[@]}"} --no-cache -t "$BASE_IMAGE_NAME" -f "$SANDY_HOME/Dockerfile.base" "$SANDY_HOME"
     echo "$BASE_HASH" > "$BASE_HASH_FILE"
     BASE_REBUILT=true
     _sandy_prune_old_image "$_old_base_id" "$BASE_IMAGE_NAME"

--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -87,6 +87,11 @@ export SANDY_AUTO_APPROVE_PRIVILEGED=1
 export SANDY_EGRESS_PROXY="${SANDY_EGRESS_PROXY:-0}"
 
 SANDY_SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/sandy"
+# Absolute path to THIS suite's own directory, resolved ONCE before any `cd`.
+# The §19/§20 acceptance harnesses live beside this script; resolving them via a
+# bare `$(dirname "$0")` at use-site broke because the suite `cd`s into scratch
+# workspaces first (relative $0 → wrong dir → silently skipped).
+_INT_SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
 SANDY_HOME="${SANDY_HOME:-$HOME/.sandy}"
 PASS=0
 FAIL=0
@@ -1552,7 +1557,7 @@ info "19. Daemon-mode lifecycle acceptance (#17) — test/acceptance-daemon.sh"
 # self-cleans (its own EXIT trap + scratch workspaces), so it needs nothing
 # from this suite's cleanup. SANDY is pinned to this suite's sandy; the harness
 # inherits this suite's credential/auto-approve env for its --start.
-_acc_daemon="$(dirname "$0")/acceptance-daemon.sh"
+_acc_daemon="$_INT_SELF_DIR/acceptance-daemon.sh"
 if [ -f "$_acc_daemon" ]; then
     _acc_out="$(mktemp)"
     set +e   # a failing harness exits non-zero; don't let set -e abort the suite
@@ -1581,7 +1586,7 @@ info "20. Fleet-update acceptance (#41) — test/acceptance-update-sessions.sh"
 # rebuilds the SHARED agent image, which will (correctly) mark any OTHER daemon
 # sessions on this host as stale afterward; that is inherent to what it tests,
 # not a side effect of running it here. Same invocation contract as §19.
-_acc_upd="$(dirname "$0")/acceptance-update-sessions.sh"
+_acc_upd="$_INT_SELF_DIR/acceptance-update-sessions.sh"
 if [ -f "$_acc_upd" ]; then
     _acc_out="$(mktemp)"
     set +e

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -5428,8 +5428,12 @@ check "base/proxy/agent rebuilds capture + prune the predecessor image (#36)" \
 # --- #51: daemon-log polish (color forced + base build quieted under supervisor) ---
 check "colors are forced under the daemon supervisor (#51)" \
     grep -qF '[ -t 1 ] || [ "${SANDY_DAEMON_SUPERVISOR:-0}" = "1" ]' "$_S72"
-check "base build is quieted under the daemon supervisor (#51)" \
-    bash -c 'grep -qF "_BASE_BUILD_Q=(-q)" "$1" && grep -qF "docker build \"\${_BASE_BUILD_Q[@]}\"" "$1"' -- "$_S72"
+# The build must use the array via the bash-3.2-safe `${arr[@]+"${arr[@]}"}`
+# idiom — a bare "${arr[@]}" is an unbound-variable error for an EMPTY array
+# under `set -u` on macOS bash 3.2 (regressed --build-only; see sandy:1780).
+check "base build is quieted under the daemon supervisor, bash-3.2-safe (#51)" \
+    bash -c 'grep -qF "_BASE_BUILD_Q=(-q)" "$1" \
+        && grep -qF "docker build \${_BASE_BUILD_Q[@]+" "$1"' -- "$_S72"
 
 # ============================================================
 # Summary


### PR DESCRIPTION
Fixes the 4 host-side §71 test failures reported after PR #54.

**Root cause:** the #51 daemon-log fix added `docker build "${_BASE_BUILD_Q[@]}" …`, with `_BASE_BUILD_Q` an **empty** array in the non-supervisor case. On **bash 3.2** (macOS) under `set -u`, expanding `"${arr[@]}"` for an empty array is an unbound-variable error → the base build line fails → `--build-only` fails → the §71 `--update-sessions` fixture (which primes a `--build-only`) cascades all 4 failures. CI (Linux, bash 5.x) doesn't reproduce it, which is why PR #54 went green.

**Fix:** use the codebase's own bash-3.2 idiom (`${arr[@]+"${arr[@]}"}`, already at `sandy:1780`) so an empty array expands to nothing. Verified the idiom yields `` (empty) and `-q` (supervisor) correctly.

The two other new arrays from #52 (`_pf_cids`, `_candidates`) were already guarded by `${#…[@]}` count checks before any `"${…[@]}"` expansion, so only this line was affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)