### PR TITLE
release: 1.2.1 — daemon-mode robustness, git-auth hardening, cleanup fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -566,6 +566,8 @@ On subsequent launches:
 - **Identical or reduced set** → proceed silently (symlink deletions update the list).
 - **New escape present** → **hard error at launch**, naming the offending link(s), with remediation (`rm` the link, relaunch, re-approve). Sandy refuses to re-prompt — a y/N that fires every session can be trained past, whereas a hard error forces a deliberate action.
 
+**Non-interactive fail-close (daemon `--start`).** The first-encounter y/N is a `read` deep in the launch flow — but under `sandy --start` that flow runs in the non-TTY supervisor (stdin `/dev/null`), where a bare read consumes EOF, aborts with misleading "remove the symlinks" guidance, and leaves the `--start` client burning its full readiness timeout (a reported hang). So the prompt is gated on an interactive stdin (`[ -t 0 ]`): non-interactive → **fail closed** with the correct guidance ("launch `sandy` interactively once in this workspace to approve, then retry"), and the supervisor drops a `"$SANDY_DAEMON_LOG.fatal"` marker so the `--start` client fast-fails in ~1s instead of waiting out the timeout (its EXIT trap has already torn down the proxy/networks/lock). Same class as the passive-privileged approval's non-TTY fail-close. Guarded by `run-tests.sh §75`.
+
 ## Terminal Notifications
 
 Sandy's inner tmux is configured with `allow-passthrough on`, which forwards OSC escape sequences (9/99/777) from Claude Code through to the outer terminal. This enables notification features in terminals like cmux and iTerm2.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,37 @@
+## sandy v1.2.1
+
+A **bug-fix and hardening** patch — no new features, no config-key or introspection changes (`schema_version` stays `1`), and the sandbox forward-compat promise holds. Most of these surfaced running 1.2.0 in real daemon-mode / `sandy-ui` use.
+
+### Daemon-mode robustness
+
+- **A session that ends no longer leaves a zombie.** When the agent exits, the supervisor watches the inner session and tears the container down — no more `sandy-<name>` / `sandy-proxy-<name>` left holding networks, the workspace lock, and a stale forwarded token. (#47)
+- **Restart recovers from a leftover container.** If a daemon container is still up but its agent session has exited (e.g. you `Ctrl-D`'d out and relaunched inside the ~60s teardown window), `sandy --start` and bare `sandy` now probe the inner session and reap the dead-session container instead of reporting "already running" and wedging you out.
+- **`sandy --attach` exit codes are honest at session-end.** A container-up-but-session-gone state exits `0` (session ended), not `5` (attach failed) — so a UI stops sticky-reconnecting a session on its way down. Exit `5` is reserved for a genuine failure to *establish* the attach.
+- **`sandy --start` grants passive-privileged approval on the client TTY** before forking the non-TTY supervisor, so workspace `.sandy/.secrets` keys aren't silently dropped from an interactive `--start`.
+- **A first-encounter dangerous-symlink prompt no longer hangs `--start`.** That approval is a `read` the non-TTY daemon supervisor can't answer; it now fails closed with the correct "approve interactively once, then retry" guidance and a marker so the `--start` client gives up in ~1s instead of burning the readiness timeout (workaround unchanged: run `sandy` once interactively to approve the set, then `--start` proceeds silently).
+- **Cleaner daemon log.** The `--start` supervisor log renders in color and no longer dumps the verbose base-image build (both gated on supervisor mode; the interactive experience is byte-unchanged). (#51)
+
+### Git / credentials
+
+- **Guaranteed git credential helper, independent of `gh`.** Container git auth no longer depends on `gh auth setup-git` succeeding — a direct helper supplies the forwarded token for `github.com` with no network round-trip, so a transient `api.github.com` failure at startup can't leave you with no working helper.
+- **Secret values are redacted** in the passive-privileged approval prompt and the persisted approval file (names only) — they were previously printed, which could leak into the daemon supervisor log.
+
+### Other fixes
+
+- **`/ss` screenshot command** no longer breaks on quotes in its arguments — the shell line runs a fixed `sandy-ss-paths` and the count is handled in prose (which also removes a shell-injection vector). (#43)
+- **Host-side channel relay** (Telegram/Discord for gemini/codex/opencode) execs tmux as the container's user (`-u`), so message injection actually reaches the session. (#48)
+- **`--print-state` full mode is cheaper on busy hosts** — the per-container `image_stale` inspect and the per-candidate `orphan_networks` inspect are each batched into a single `docker` call (46 spawns on a 7-session host → a handful). (#52)
+- **Rebuilds no longer leak dangling images** — after a successful base/proxy/agent rebuild the now-untagged predecessor is reclaimed (the Claude auto-update rebuild was the main continuous leak). (#36)
+- **`sandy --update-sessions` no longer hangs on a session whose config needs approval, and shows a progress heartbeat.** Two fixes to the per-session image refresh: (1) the child build now runs with `stdin` from `/dev/null`, so a workspace whose `.sandy` config sets privileged keys (or has un-approved dangerous symlinks) fails the approval *closed* instead of blocking forever on a `[y/N]` prompt written into the captured (invisible) build log — that was the real "hangs on one session" bug; (2) since each session's build output is captured and image builds run `-q`, a long `--no-cache` rebuild used to print nothing for minutes and look hung, so it now emits an elapsed-time line with the current phase every ~20s.
+
+### Portability / tests
+
+- **macOS bash 3.2** empty-array-under-`set -u` fix that had regressed `--build-only`.
+- **`sandy --update-sessions` no longer aborts a refresh on a benign build-file race.** The generated `Dockerfile.base`/`entrypoint.sh`/etc. staging files live in the shared `$SANDY_HOME`, so a concurrent sandy (a sibling session's launch build) could consume one before `--build-only`'s `rm`/`mv`, aborting under `set -e`. The staging is now idempotent (deterministic content, tolerant `rm -f`/`mv -f`).
+- The daemon and fleet-update **acceptance harnesses now actually run** in a full `run-integration-tests.sh` — they were silently skipping when invoked from the workspace root (a `$(dirname "$0")` that resolved after a `cd`).
+
+---
+
 ## sandy v1.2.0
 
 **Fleet updates for daemon sessions.** Daemon sessions can stay up for days, running an ever-staler image — nothing at launch refreshes them once launches become rare. `sandy --update-sessions` closes that: one command refreshes every daemon session's images and rolling-restarts the ones that came out stale, conversations resuming automatically. Additive and backward-compatible: bare `sandy` and the `--start`/`--attach`/`--stop` lifecycle are unchanged, and the introspection `schema_version` stays `1`.

--- a/sandy
+++ b/sandy
@@ -17,7 +17,7 @@ set -euo pipefail
 #   sandy --agent claude,gemini   Override agent selection for this run
 # =============================================================================
 
-SANDY_VERSION="1.2.0"
+SANDY_VERSION="1.2.1"
 SANDY_COMMIT=""  # baked in by install.sh; empty = detect from git at runtime
 
 # Schema contract version for --print-schema / --print-state / --validate-config.
@@ -3469,14 +3469,22 @@ ensure_build_files() {
     generate_tmux_conf
     generate_channel_relay
 
-    # Only update on-disk files if content has changed
+    # Only update on-disk files if content has changed. The .new files live in
+    # the SHARED $SANDY_HOME, so a concurrent sandy (a daemon supervisor's own
+    # launch build, or `--update-sessions` refreshing a sibling session) may have
+    # already consumed this .new. The generated content is deterministic, so
+    # whichever process won left identical files — a missing .new here is benign
+    # and must NOT abort the build under `set -e` (bare `rm`/`mv` on a
+    # race-consumed .new was the fleet-update failure caught by
+    # run-integration-tests §20). Guard existence, and use -f + tolerate a lost
+    # race on the mv.
     local changed=false
     for f in Dockerfile.base entrypoint.sh user-setup.sh tmux.conf channel-relay.sh; do
+        [ -e "$SANDY_HOME/$f.new" ] || continue
         if [ ! -f "$SANDY_HOME/$f" ] || ! diff -q "$SANDY_HOME/$f.new" "$SANDY_HOME/$f" &>/dev/null; then
-            mv "$SANDY_HOME/$f.new" "$SANDY_HOME/$f"
-            changed=true
+            mv -f "$SANDY_HOME/$f.new" "$SANDY_HOME/$f" 2>/dev/null && changed=true || true
         else
-            rm "$SANDY_HOME/$f.new"
+            rm -f "$SANDY_HOME/$f.new"
         fi
     done
 
@@ -3655,6 +3663,14 @@ if [ "$SANDY_START" = "true" ] && [ "${SANDY_DAEMON_SUPERVISOR:-0}" != "1" ]; th
         "$0" "${_sandy_reexec_args[@]}" </dev/null >>"$_sandy_daemon_log" 2>&1 &
     disown 2>/dev/null || true
 
+    # Fast-fail signal: the supervisor writes "$_sandy_daemon_log.fatal" if it
+    # hits an unanswerable approval (e.g. a first-encounter dangerous-symlink
+    # prompt it can't answer under /dev/null) so the readiness loop below stops
+    # immediately instead of burning the full timeout. It has already torn its
+    # own wreckage down via its EXIT trap by the time it writes this.
+    _sandy_fatal_marker="${_sandy_daemon_log}.fatal"
+    rm -f "$_sandy_fatal_marker" 2>/dev/null || true
+
     info "Starting daemon session for $WORK_DIR..."
 
     # D8 — startup contract: stream the supervisor's log to stdout/stderr
@@ -3670,7 +3686,14 @@ if [ "$SANDY_START" = "true" ] && [ "${SANDY_DAEMON_SUPERVISOR:-0}" != "1" ]; th
     _sandy_waited=0
     _sandy_restarts=0
     _sandy_daemon_container=""
+    _sandy_sup_fatal=false
     while [ "$_sandy_waited" -lt "$_sandy_timeout_s" ]; do
+        # Supervisor reported an unrecoverable startup refusal (it already cleaned
+        # up) — give up now instead of waiting out the timeout.
+        if [ -f "$_sandy_fatal_marker" ]; then
+            _sandy_sup_fatal=true
+            break
+        fi
         _sandy_daemon_container="$(docker ps -q "${_sandy_daemon_filter[@]}" 2>/dev/null | head -1)" || true
         # -u: docker exec defaults to the image's user (root — no USER
         # directive), but the tmux server runs as the host uid the entrypoint
@@ -3701,13 +3724,16 @@ if [ "$SANDY_START" = "true" ] && [ "${SANDY_DAEMON_SUPERVISOR:-0}" != "1" ]; th
         wait "$_sandy_tail_pid" 2>/dev/null || true
     fi
 
+    rm -f "$_sandy_fatal_marker" 2>/dev/null || true
     if [ "$_sandy_ready" = "true" ]; then
         _sandy_daemon_name="$(docker inspect -f '{{ index .Config.Labels "sandy.session" }}' "$_sandy_daemon_container" 2>/dev/null || true)"
         info "Daemon session ready: ${_sandy_daemon_name:-$_sandy_daemon_container} (container ${_sandy_daemon_container:0:12})"
         rm -f "$_sandy_daemon_log" 2>/dev/null || true
         exit 0
     else
-        if [ "${_sandy_restarts:-0}" -ge 3 ] 2>/dev/null; then
+        if [ "$_sandy_sup_fatal" = "true" ]; then
+            error "Daemon startup was refused before it could launch (see the guidance above)."
+        elif [ "${_sandy_restarts:-0}" -ge 3 ] 2>/dev/null; then
             error "Daemon container is crash-looping (RestartCount=$_sandy_restarts) — giving up."
         else
             error "Daemon session failed to become attachable within ${_sandy_timeout_s}s."
@@ -4017,12 +4043,42 @@ if [ "$SANDY_UPDATE_SESSIONS" = "true" ]; then
         _upd_build_args=(--build-only)
         [ "$SANDY_REBUILD" = "true" ] && _upd_build_args+=(--rebuild)
         _upd_build_log="$(mktemp)"
-        if ! (cd "$_upd_ws" && "$_sandy_self" "${_upd_build_args[@]}") >"$_upd_build_log" 2>&1; then
+        _upd_done="$_upd_build_log.done"   # unique, absent until the child finishes
+        # Run the child build in the background and emit a progress heartbeat. The
+        # child's output is captured to the log (surfaced only on failure) and its
+        # agent/project image builds run -q, so a long --no-cache rebuild would
+        # otherwise print nothing for minutes and look hung. We poll a done-marker
+        # (never `kill -0`, which reads a reaped/zombie child as alive) and every
+        # ~20s echo elapsed time + the child's current phase (its last log line).
+        #
+        # `</dev/null` is REQUIRED, not cosmetic: a workspace whose .sandy config
+        # sets privileged keys (or has un-approved dangerous symlinks) triggers an
+        # interactive approval `read` in the child. Without redirecting stdin the
+        # child inherits our terminal (a TTY), so it prints the [y/N] prompt into
+        # the CAPTURED log (invisible) and blocks forever on the read — the real
+        # "--update-sessions hangs on one session" bug. With /dev/null the child's
+        # stdin is non-interactive, so the approval fails closed (drops the keys,
+        # which the build doesn't need) and the refresh proceeds.
+        { ( cd "$_upd_ws" && "$_sandy_self" "${_upd_build_args[@]}" ) </dev/null >"$_upd_build_log" 2>&1
+          echo "$?" > "$_upd_done"; } &
+        _upd_build_pid=$!
+        _upd_hb=0
+        while [ ! -f "$_upd_done" ]; do
+            sleep 1
+            [ -f "$_upd_done" ] && break
+            _upd_hb=$((_upd_hb + 1))
+            if [ $((_upd_hb % 20)) -eq 0 ]; then
+                _upd_phase="$(tail -n 1 "$_upd_build_log" 2>/dev/null | sed -E 's/^\[sandy\] +//; s/\.\.\.[[:space:]]*$//')"
+                info "  ...still refreshing $_upd_sess (${_upd_hb}s${_upd_phase:+: $_upd_phase})"
+            fi
+        done
+        wait "$_upd_build_pid" 2>/dev/null || true
+        if [ "$(cat "$_upd_done" 2>/dev/null || echo 1)" != "0" ]; then
             error "  Build failed for $_upd_sess — tail of output:"
             tail -n 20 "$_upd_build_log" | sed 's/^/[sandy]   /' >&2
             _upd_build_failed[$_upd_i]=1
         fi
-        rm -f "$_upd_build_log" 2>/dev/null || true
+        rm -f "$_upd_build_log" "$_upd_done" 2>/dev/null || true
     done
 
     # Steps 3+4 — staleness check, then (only when --idle-for was given) the
@@ -7100,6 +7156,23 @@ if [ ${#DANGEROUS_SYMLINKS[@]} -gt 0 ]; then
             warn "  $s"
         done
         printf "\033[0;33m[sandy] These could allow Claude to access files outside the sandbox.\033[0m\n"
+        # No interactive stdin to answer y/N — the `sandy --start` supervisor runs
+        # the launch under /dev/null (a headless/piped run has no terminal either).
+        # A bare `read` here consumes EOF and "aborts" with misleading "remove the
+        # symlinks" guidance, and under --start leaves the client polling out the
+        # full readiness timeout (the reported hang). Fail CLOSED with the correct
+        # fix, and drop a marker beside the streamed daemon log so the --start
+        # client stops waiting immediately rather than burning the timeout. The
+        # EXIT trap installed above already tears down the proxy/networks/lock.
+        if [ ! -t 0 ]; then
+            error "Dangerous symlinks need interactive approval, but stdin is not a terminal."
+            error "Approve them once by launching sandy interactively in this workspace:"
+            error "  cd '$WORK_DIR' && sandy      # answer y at the prompt, then exit"
+            error "then retry (e.g. 'sandy --start'). Or clear the list: rm '$_approved_list'"
+            [ -n "${SANDY_DAEMON_LOG:-}" ] && : > "${SANDY_DAEMON_LOG}.fatal"
+            rm -f "$_current_tmp"
+            exit 1
+        fi
         printf "\033[0;33m[sandy] Proceed anyway? [y/N] \033[0m"
         read -r REPLY
         if [[ ! "$REPLY" =~ ^[Yy]$ ]]; then

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -5457,6 +5457,70 @@ check "a dead-session daemon zombie is reaped via \$0 --stop (both --start + bar
     bash -c '[ "$(grep -c "\"\$0\" --stop --workspace \"\$WORK_DIR\" >/dev/null 2>&1 || true" "$1")" -ge 2 ]' -- "$_S73"
 
 # ============================================================
+echo ""
+echo "§74: ensure_build_files tolerates a race-consumed .new (fleet-update, §20)"
+# ============================================================
+# The *.new build files live in the SHARED $SANDY_HOME, so a concurrent sandy
+# (a daemon supervisor's launch build, or --update-sessions refreshing a sibling
+# session) can consume one before this process's mv/rm. Generated content is
+# deterministic, so the race is benign — but a BARE `rm "$SANDY_HOME/$f.new"`
+# aborts the build under set -e (the fleet-update §20 failure). The loop must
+# guard existence and use tolerant rm -f / mv -f.
+_S74="$(cd "$(dirname "$0")/.." && pwd)/sandy"
+check "ensure_build_files guards .new existence before mv/rm (no set -e abort)" \
+    bash -c 'sed -n "/^ensure_build_files()/,/^}\$/p" "$1" | grep -qF "[ -e \"\$SANDY_HOME/\$f.new\" ] || continue"' -- "$_S74"
+check "ensure_build_files uses tolerant rm -f / mv -f for the shared .new files" \
+    bash -c '_f="$(sed -n "/^ensure_build_files()/,/^}\$/p" "$1")"
+        printf "%s" "$_f" | grep -qF "rm -f \"\$SANDY_HOME/\$f.new\"" \
+            && printf "%s" "$_f" | grep -qF "mv -f \"\$SANDY_HOME/\$f.new\""' -- "$_S74"
+check "no bare (abort-prone) rm of a shared build .new remains" \
+    bash -c '! sed -n "/^ensure_build_files()/,/^}\$/p" "$1" | grep -qF "rm \"\$SANDY_HOME/\$f.new\""' -- "$_S74"
+
+# ============================================================
+echo ""
+echo "§75: dangerous-symlink approval fails closed under a non-interactive --start"
+# ============================================================
+# The symlink first-encounter prompt is a `read` deep in the launch flow, which
+# under `sandy --start` runs in the non-TTY daemon supervisor (stdin /dev/null).
+# A bare read there consumes EOF and aborts with misleading guidance, and the
+# --start client burns the full readiness timeout (the reported hang). The prompt
+# must gate on an interactive stdin, fail closed with the correct "approve
+# interactively" guidance, drop a fatal marker, and the --start client must
+# fast-fail on that marker instead of waiting out the timeout.
+_S75="$(cd "$(dirname "$0")/.." && pwd)/sandy"
+check "symlink read is gated behind a non-tty check (no bare daemon prompt)" \
+    bash -c 'sed -n "/First encounter for this sandbox/,/read -r REPLY/p" "$1" | grep -qF "if [ ! -t 0 ]; then"' -- "$_S75"
+check "symlink approval fails closed with interactive-approval guidance" \
+    grep -qF 'Dangerous symlinks need interactive approval' "$_S75"
+check "symlink fail-close drops a fatal marker for the --start client" \
+    grep -qF ': > "${SANDY_DAEMON_LOG}.fatal"' "$_S75"
+check "--start readiness loop fast-fails on the supervisor fatal marker" \
+    bash -c 'grep -qF "if [ -f \"\$_sandy_fatal_marker\" ]; then" "$1"' -- "$_S75"
+
+# ============================================================
+echo ""
+echo "§76: --update-sessions refresh emits a progress heartbeat (no silent multi-minute build)"
+# ============================================================
+# Each session's --build-only output is captured (surfaced only on failure) and
+# image builds run -q, so a long --no-cache rebuild would print nothing and look
+# hung. The refresh must background the child, poll a done-marker (not kill -0,
+# which reads a reaped child as alive), and emit an elapsed heartbeat.
+_S76="$(cd "$(dirname "$0")/.." && pwd)/sandy"
+check "refresh runs the child build in the background with a done-marker" \
+    bash -c 'grep -qF "echo \"\$?\" > \"\$_upd_done\"" "$1"' -- "$_S76"
+check "refresh polls the done-marker (not kill -0 on a reap-prone child)" \
+    bash -c 'grep -qF "while [ ! -f \"\$_upd_done\" ]; do" "$1"' -- "$_S76"
+check "refresh emits an elapsed-time progress heartbeat" \
+    grep -qF 'still refreshing $_upd_sess' "$_S76"
+# The child MUST read /dev/null: a workspace whose config sets privileged keys
+# (or has un-approved dangerous symlinks) triggers an interactive approval read
+# in the child. With an inherited-TTY stdin it prints the [y/N] into the captured
+# log and blocks forever (the "--update-sessions hangs on one session" bug). With
+# /dev/null the approval fails closed and the refresh proceeds.
+check "refresh child runs non-interactively (</dev/null) so an approval fails closed, not hangs" \
+    grep -qF ') </dev/null >"$_upd_build_log"' "$_S76"
+
+# ============================================================
 # Summary
 # ============================================================
 COMPLETED=true   # suppress the early-abort message in the EXIT trap


### PR DESCRIPTION
Cuts **v1.2.1** — a bug-fix/hardening patch (no features, `schema_version` stays `1`, sandbox forward-compat holds). Bumps `SANDY_VERSION` 1.2.0 → 1.2.1 (also correcting the accidental revert to `1.2.0` in `2c49fb4`) + the RELEASE_NOTES entry.

All fixes already merged to `main` since v1.2.0 across PRs #53/#54/#55/#56 and the #49 batch:
- **Daemon robustness:** zombie teardown + restart recovery + attach exit-5 (#47), client-TTY approval, log polish (#51)
- **Git/creds:** gh-independent credential helper, secret redaction
- **Fixes:** `/ss` quoting (#43), channel-relay uid (#48), print-state batching (#52 pt1), predecessor-image GC (#36 slice)
- **Portability/tests:** bash-3.2 `--build-only` fix, §19/§20 acceptance-harness skip fix

After merge: tag `v1.2.1` at the merge commit → GitHub release (stable, not pre-release) → bump `main` to `1.2.2-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)