### PR TITLE
release: bump to 1.2.2-dev post-v1.2.1

### DIFF
--- a/sandy
+++ b/sandy
@@ -17,7 +17,7 @@ set -euo pipefail
 #   sandy --agent claude,gemini   Override agent selection for this run
 # =============================================================================
 
-SANDY_VERSION="1.2.1"
+SANDY_VERSION="1.2.2-dev"
 SANDY_COMMIT=""  # baked in by install.sh; empty = detect from git at runtime
 
 # Schema contract version for --print-schema / --print-state / --validate-config.


### PR DESCRIPTION
Post-release version bump after tagging v1.2.1 (GitHub release published, Latest). Keeps `SANDY_VERSION` at a `-dev` value so the proxy build resolves `_sandy_proxy_ref` from the branch/main, not a future tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)