### PR TITLE
fix(test): §79 macOS/BSD portability — awk $-anchor + wc leading whitespace

### DIFF
--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -5672,7 +5672,7 @@ check "the container-liveness gate never reads/queries the sandy.daemon_pid labe
         ! printf "%s" "$_f" | grep -q "sandy\.daemon_pid"' -- "$_S79"
 
 check "--gc parses its OWN --dry-run/--yes into distinct locals, not SANDY_UPDATE_*" \
-    bash -c '_f="$(awk "/^if \[\[ \"\\\${1:-}\" == \"--gc\" \]\]; then/,/^fi\$/" "$1")"
+    bash -c '_f="$(awk "/^if .*--gc/,/^fi\$/" "$1")"
         printf "%s" "$_f" | grep -qF "_sandy_gc_dry_run" \
             && printf "%s" "$_f" | grep -qF "_sandy_gc_yes" \
             && ! printf "%s" "$_f" | grep -qE "SANDY_UPDATE_(DRY_RUN|YES)="' -- "$_S79"
@@ -5698,7 +5698,7 @@ check "the container reaper invokes the lister with the retrying 'reap' mode" \
         printf "%s" "$_f" | grep -qF "_sandy_dead_owner_containers_list reap"' -- "$_S79"
 
 check "the --gc dispatcher's plan step also uses 'reap' mode (plan matches what actually happens)" \
-    bash -c '_f="$(awk "/^if \[\[ \"\\\${1:-}\" == \"--gc\" \]\]; then/,/^fi\$/" "$1")"
+    bash -c '_f="$(awk "/^if .*--gc/,/^fi\$/" "$1")"
         printf "%s" "$_f" | grep -qF "_sandy_dead_owner_containers_list reap"' -- "$_S79"
 
 check "the container-liveness gate discriminates agent-vs-proxy by IMAGE, not name prefix (B1/B2 fix)" \
@@ -5906,7 +5906,7 @@ _S79_YES_RC=0
 PATH="$_S79_BIN:$PATH" SANDY_HOME="$_S79_HOME" bash "$_S79" --gc --yes </dev/null >/dev/null 2>&1 || _S79_YES_RC=$?
 check "--gc --yes (non-TTY) exits 0" test "$_S79_YES_RC" -eq 0
 check "--gc --yes reaped exactly the 5 expected dead-owner containers (4 base + 1 orphaned proxy)" \
-    bash -c 'sort -u "$1" | wc -l | grep -qx 5' -- "$_S79_RM_CONTAINERS"
+    bash -c '[ "$(sort -u "$1" | wc -l | tr -d " ")" = 5 ]' -- "$_S79_RM_CONTAINERS"
 check "--gc --yes never touched the D9-alive daemon container" \
     bash -c '! grep -qx "sandy-daemon-alive" "$1"' -- "$_S79_RM_CONTAINERS"
 check "--gc --yes never touched the live-lock foreground container" \


### PR DESCRIPTION
Three §79 (`sandy --gc`) checks pass in CI (Ubuntu/GNU) but fail on a macOS host. Both root causes are **BSD-vs-GNU userland differences in the test harness only** — the `sandy --gc` product code is unaffected (every per-container identity assertion passed on macOS; only these three broke):

| Failing check | Cause | Fix |
|---|---|---|
| "parses its OWN --dry-run/--yes into distinct locals" | macOS **BWK awk** treats `\$` as the `$` anchor (drops the backslash) → the region-start regex has an anchor mid-pattern → never matches → empty region → grep fails | rewrite start pattern to `/^if .*--gc/` (no literal `$`) |
| "plan step also uses 'reap' mode" | same (shares the extraction) | same |
| "reaped exactly the 5 expected dead-owner containers" | BSD `wc -l` emits leading whitespace (`&nbsp;&nbsp;&nbsp;5`) even when piped → `grep -qx 5` whole-line match fails | `[ "$(… \| wc -l \| tr -d ' ')" = 5 ]` |

## Verification
- Both structural checks pass under **mawk** (BSD-regex proxy) and default awk, extracting the identical 143-line region; `/^if .*--gc/` matches exactly the one dispatcher line.
- The count fix handles leading-whitespace `wc`.
- Swept the suite: no other `\${1:-}`-in-awk or `wc -l \| grep -qx` traps remain.
- `bash -n` clean.

Test-only; no product-code change. This is the same class as the earlier `_BASE_BUILD_Q` / `sleep infinity` macOS breaks — CI (GNU) can't catch them; surfaced by a maintainer host run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)