### PR TITLE
fix(proxy): stop `healthy: command not found` spam on every launch

### DIFF
--- a/sandy
+++ b/sandy
@@ -2734,7 +2734,7 @@ COPY --from=build /sandy-proxy /usr/local/bin/sandy-proxy
 # Config is bind-mounted at /etc/sandy-proxy.json by the launcher (PR 2.7.3).
 # Readiness (#37): scratch has no shell, so the healthcheck IS the binary
 # re-invoked with -healthcheck, probing its own listeners. The container reports
-# `healthy` only once the listeners actually bind, not merely when the process
+# healthy only once the listeners actually bind, not merely when the process
 # starts — closing the transient "connection refused" window on the first
 # request. Exec form (no shell); the launcher's gate polls .State.Health.Status.
 HEALTHCHECK --interval=1s --start-period=0s --timeout=2s --retries=3 CMD ["/usr/local/bin/sandy-proxy", "-healthcheck"]

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -4016,6 +4016,15 @@ check "proxy Dockerfile: builds proxy/ statically (CGO_ENABLED=0)" \
     bash -c 'grep -q "cd /src/proxy" "$1" && grep -q "CGO_ENABLED=0 go build" "$1"' -- "$_PX_DF"
 check "proxy Dockerfile: entrypoint is the proxy binary" \
     grep -qF 'ENTRYPOINT ["/usr/local/bin/sandy-proxy"]' "$_PX_DF"
+# Regression (real launch bug, 2026-07-23): the Dockerfile.proxy heredoc is
+# UNQUOTED (it needs ${ref} expanded), so any backtick / $( ) / unescaped ${ }
+# in its body is executed by the SHELL at generation time — a stray `word` in a
+# comment ran `word` and printed "word: command not found" on every launch (the
+# generation call above swallows stderr with 2>/dev/null, which is why CI never
+# caught it). Assert the generator emits NOTHING on stderr.
+check "proxy Dockerfile generation emits no stderr (no unescaped shell-specials in the heredoc)" \
+    bash -c '_h="$(mktemp -d)"; _e="$(SANDY_HOME="$_h" SANDY_VERSION=0.13.1 SANDY_PROXY_REF="" GITHUB_HEAD_REF= bash -c "$1
+generate_dockerfile_proxy" 2>&1 >/dev/null)"; rm -rf "$_h"; [ -z "$_e" ]' -- "$_PX_FNS"
 rm -rf "$_PX_TMP"
 
 # Build phase: gated on the normalized proxy predicate, uses .build_hash_proxy,


### PR DESCRIPTION
## Symptom
Every `sandy` launch printed:
```
/Users/…/.local/bin/sandy: line NNNN: healthy: command not found
```

## Cause
`generate_dockerfile_proxy()` writes the proxy Dockerfile via an **unquoted** heredoc (`<<DOCKERFILE`) — it has to, to expand `${ref}` into the pinned `ARG SANDY_PROXY_REF`. An unquoted heredoc means the **shell** expands backticks / `$( )` / `${ }` in the body at generation time. The #37 readiness comment wrote `` `healthy` `` in backticks, so the shell ran `healthy` as a command → `command not found` on stderr, every launch.

Non-fatal (launch continued; the backticks were merely stripped from the generated comment), but alarming. Removed the backticks.

## Why CI missed it
§49's generation call swallows stderr with `2>/dev/null`. Added a regression guard that asserts `generate_dockerfile_proxy` emits **nothing** on stderr — catching any unescaped shell-special that slips into that unquoted heredoc in the future.

Verified in-sandbox: generation is now stderr-clean and the guard passes. Two-line product fix + one test.