### PR TITLE
test: print a run-provenance footer (timestamp · commit · clean/dirty)

### DIFF
--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -126,6 +126,20 @@ pass()  { PASS=$((PASS + 1)); printf "  \033[0;32m✓ %s\033[0m\n" "$*"; }
 fail()  { FAIL=$((FAIL + 1)); ERRORS+=("$*"); printf "  \033[0;31m✗ %s\033[0m\n" "$*"; }
 skip()  { SKIP=$((SKIP + 1)); printf "  \033[0;33m⊘ %s (skipped)\033[0m\n" "$*"; }
 
+# Print a one-line run-provenance footer: UTC timestamp, short commit + describe,
+# and clean/dirty (tracked changes vs HEAD — untracked scratch files don't count).
+# This suite is long-running; the footer says which build a scrolled-back result
+# came from. macOS/BSD-portable: `date -u` fmt, `git describe`, `git diff --quiet`.
+_run_provenance() {
+    local repo ts sha desc tree
+    repo="$(cd "$(dirname "$0")/.." 2>/dev/null && pwd)"
+    ts="$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo '?')"
+    sha="$(git -C "$repo" rev-parse --short HEAD 2>/dev/null || echo '?')"
+    desc="$(git -C "$repo" describe --tags --always 2>/dev/null || echo '?')"
+    if git -C "$repo" diff --quiet HEAD 2>/dev/null; then tree="clean"; else tree="dirty"; fi
+    printf "\033[0;36m── run finished %s · commit %s (%s) · tree: %s\033[0m\n" "$ts" "$sha" "$desc" "$tree"
+}
+
 _emit_summary() {
     local code=$?
     printf '\033>' 2>/dev/null || true
@@ -1654,5 +1668,6 @@ else
     if [ "$SKIP" -gt 0 ]; then
         printf "\033[0;33m(%d tests skipped — missing credentials)\033[0m\n" "$SKIP"
     fi
-    exit 1
 fi
+_run_provenance
+[ "$FAIL" -eq 0 ] || exit 1

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -81,6 +81,19 @@ check() {
     if "$@" >/dev/null 2>&1; then pass "$desc"; else fail "$desc"; fi
 }
 
+# Print a one-line run-provenance footer: UTC timestamp, short commit + describe,
+# and clean/dirty (tracked changes vs HEAD — untracked scratch files don't count).
+# macOS/BSD-portable: `date -u` fmt, `git describe`, `git diff --quiet HEAD`.
+_run_provenance() {
+    local repo ts sha desc tree
+    repo="$(cd "$(dirname "$0")/.." 2>/dev/null && pwd)"
+    ts="$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo '?')"
+    sha="$(git -C "$repo" rev-parse --short HEAD 2>/dev/null || echo '?')"
+    desc="$(git -C "$repo" describe --tags --always 2>/dev/null || echo '?')"
+    if git -C "$repo" diff --quiet HEAD 2>/dev/null; then tree="clean"; else tree="dirty"; fi
+    printf "\033[0;36m── run finished %s · commit %s (%s) · tree: %s\033[0m\n" "$ts" "$sha" "$desc" "$tree"
+}
+
 # Create a temp sandbox with persistent mount dirs
 setup_sandbox() {
     SANDBOX_DIR="$(mktemp -d)"
@@ -6276,5 +6289,7 @@ else
     for e in "${ERRORS[@]}"; do
         printf "  \033[0;31m- %s\033[0m\n" "$e"
     done
-    exit 1
 fi
+_run_provenance   # timestamp + commit + tree state, so a result you scroll back
+                  # to after a context switch says which build produced it.
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Both `run-tests.sh` and `run-integration-tests.sh` now print a one-line footer at the end of the run:

```
── run finished 2026-07-23T20:58:21Z · commit e3c0d02 (v1.2.1-12-ge3c0d02) · tree: clean
```

## Why
The integration suite is long-running; a result you scroll back to after a context switch otherwise gives no hint *which* build produced it (easy to mistake a stale run for a current one — which just happened chasing the pane-topology flake).

## Details
- Prints on **both** pass and fail (the `exit 1` moved after the footer; exit-code semantics unchanged).
- `tree: clean|dirty` keys off **tracked** changes vs HEAD (`git diff --quiet HEAD`), so the repo's persistent untracked scratch files (`docs/social/`, `.claude/`, …) don't false-flag "dirty."
- macOS/BSD-portable: `date -u '+%Y-%m-%dT%H:%M:%SZ'`, `git describe --tags --always`, `git diff --quiet HEAD` — all work on the maintainer's Mac.

Test-infra only; `bash -n` clean on both.