### PR TITLE
fix(test): set @sandy_pane_agent from the launcher by pane-id, not a self-set race (#22)

### DIFF
--- a/sandy
+++ b/sandy
@@ -3783,27 +3783,48 @@ else
     _agent_names="$(IFS=' + '; echo "${_SANDY_AGENTS[*]}")"
     sandy_log "Launching $_agent_names (multi-pane)"
 
-    # First agent: create the tmux session
+    # First agent: create the tmux session.
+    #
+    # Test identity (#22, SANDY_TEST_PANE_TAGS): set each pane's @sandy_pane_agent
+    # option from the LAUNCHER, targeting the pane by its unique id captured via
+    # `-P -F '#{pane_id}'` at creation. An earlier approach had the pane's OWN
+    # command run `tmux set-option -p` — but that self-set (resolved via
+    # $TMUX_PANE / active pane) RACED the subsequent re-split of pane 0 and
+    # misfired on the left column (claude's tag lost, opencode's landed on the
+    # wrong pane). Setting by pane-id from the launcher is race-free: the id is
+    # stable and the option is written synchronously right after the pane exists.
+    # The printf marker is kept as a log line + a capture-pane fallback for the
+    # harness against an image predating this. Normal launches (var unset) take
+    # the else branch and are byte-identical to before.
     _cmd0="$(_sandy_build_agent_cmd "${_SANDY_AGENTS[0]}" "$@")"
     if [ "${SANDY_TEST_PANE_TAGS:-0}" = "1" ]; then
-        _cmd0="tmux set-option -p @sandy_pane_agent '${_SANDY_AGENTS[0]}' 2>/dev/null; printf '[sandy:pane-agent] %s\n' '${_SANDY_AGENTS[0]}'; $_cmd0"
+        _cmd0="printf '[sandy:pane-agent] %s\n' '${_SANDY_AGENTS[0]}'; $_cmd0"
+        _p_id="$(tmux new-session -d -P -F '#{pane_id}' -s sandy -n "sandy: ${SANDY_PROJECT_NAME:-$(basename "$WORKSPACE")}" -- bash -c "$_cmd0 2>&1")"
+        tmux set-option -p -t "$_p_id" @sandy_pane_agent "${_SANDY_AGENTS[0]}" 2>/dev/null
+    else
+        tmux new-session -d -s sandy -n "sandy: ${SANDY_PROJECT_NAME:-$(basename "$WORKSPACE")}" -- bash -c "$_cmd0 2>&1"
     fi
-    tmux new-session -d -s sandy -n "sandy: ${SANDY_PROJECT_NAME:-$(basename "$WORKSPACE")}" -- bash -c "$_cmd0 2>&1"
 
     # Second agent: split horizontally
     _cmd1="$(_sandy_build_agent_cmd "${_SANDY_AGENTS[1]}" "$@")"
     if [ "${SANDY_TEST_PANE_TAGS:-0}" = "1" ]; then
-        _cmd1="tmux set-option -p @sandy_pane_agent '${_SANDY_AGENTS[1]}' 2>/dev/null; printf '[sandy:pane-agent] %s\n' '${_SANDY_AGENTS[1]}'; $_cmd1"
+        _cmd1="printf '[sandy:pane-agent] %s\n' '${_SANDY_AGENTS[1]}'; $_cmd1"
+        _p_id="$(tmux split-window -h -P -F '#{pane_id}' -t sandy -- bash -c "$_cmd1 2>&1")"
+        tmux set-option -p -t "$_p_id" @sandy_pane_agent "${_SANDY_AGENTS[1]}" 2>/dev/null
+    else
+        tmux split-window -h -t sandy -- bash -c "$_cmd1 2>&1"
     fi
-    tmux split-window -h -t sandy -- bash -c "$_cmd1 2>&1"
 
     # Third agent (if present): split the right pane vertically
     if [ "$_SANDY_AGENT_COUNT" -ge 3 ]; then
         _cmd2="$(_sandy_build_agent_cmd "${_SANDY_AGENTS[2]}" "$@")"
         if [ "${SANDY_TEST_PANE_TAGS:-0}" = "1" ]; then
-            _cmd2="tmux set-option -p @sandy_pane_agent '${_SANDY_AGENTS[2]}' 2>/dev/null; printf '[sandy:pane-agent] %s\n' '${_SANDY_AGENTS[2]}'; $_cmd2"
+            _cmd2="printf '[sandy:pane-agent] %s\n' '${_SANDY_AGENTS[2]}'; $_cmd2"
+            _p_id="$(tmux split-window -v -P -F '#{pane_id}' -t sandy.1 -- bash -c "$_cmd2 2>&1")"
+            tmux set-option -p -t "$_p_id" @sandy_pane_agent "${_SANDY_AGENTS[2]}" 2>/dev/null
+        else
+            tmux split-window -v -t sandy.1 -- bash -c "$_cmd2 2>&1"
         fi
-        tmux split-window -v -t sandy.1 -- bash -c "$_cmd2 2>&1"
     fi
 
     # Fourth agent (if present): split the left pane vertically → 2x2 grid.
@@ -3811,9 +3832,12 @@ else
     if [ "$_SANDY_AGENT_COUNT" -ge 4 ]; then
         _cmd3="$(_sandy_build_agent_cmd "${_SANDY_AGENTS[3]}" "$@")"
         if [ "${SANDY_TEST_PANE_TAGS:-0}" = "1" ]; then
-            _cmd3="tmux set-option -p @sandy_pane_agent '${_SANDY_AGENTS[3]}' 2>/dev/null; printf '[sandy:pane-agent] %s\n' '${_SANDY_AGENTS[3]}'; $_cmd3"
+            _cmd3="printf '[sandy:pane-agent] %s\n' '${_SANDY_AGENTS[3]}'; $_cmd3"
+            _p_id="$(tmux split-window -v -P -F '#{pane_id}' -t sandy.0 -- bash -c "$_cmd3 2>&1")"
+            tmux set-option -p -t "$_p_id" @sandy_pane_agent "${_SANDY_AGENTS[3]}" 2>/dev/null
+        else
+            tmux split-window -v -t sandy.0 -- bash -c "$_cmd3 2>&1"
         fi
-        tmux split-window -v -t sandy.0 -- bash -c "$_cmd3 2>&1"
     fi
 
     tmux select-pane -t sandy.0

--- a/templates/user-setup.sh.tmpl
+++ b/templates/user-setup.sh.tmpl
@@ -915,27 +915,48 @@ else
     _agent_names="$(IFS=' + '; echo "${_SANDY_AGENTS[*]}")"
     sandy_log "Launching $_agent_names (multi-pane)"
 
-    # First agent: create the tmux session
+    # First agent: create the tmux session.
+    #
+    # Test identity (#22, SANDY_TEST_PANE_TAGS): set each pane's @sandy_pane_agent
+    # option from the LAUNCHER, targeting the pane by its unique id captured via
+    # `-P -F '#{pane_id}'` at creation. An earlier approach had the pane's OWN
+    # command run `tmux set-option -p` — but that self-set (resolved via
+    # $TMUX_PANE / active pane) RACED the subsequent re-split of pane 0 and
+    # misfired on the left column (claude's tag lost, opencode's landed on the
+    # wrong pane). Setting by pane-id from the launcher is race-free: the id is
+    # stable and the option is written synchronously right after the pane exists.
+    # The printf marker is kept as a log line + a capture-pane fallback for the
+    # harness against an image predating this. Normal launches (var unset) take
+    # the else branch and are byte-identical to before.
     _cmd0="$(_sandy_build_agent_cmd "${_SANDY_AGENTS[0]}" "$@")"
     if [ "${SANDY_TEST_PANE_TAGS:-0}" = "1" ]; then
-        _cmd0="tmux set-option -p @sandy_pane_agent '${_SANDY_AGENTS[0]}' 2>/dev/null; printf '[sandy:pane-agent] %s\n' '${_SANDY_AGENTS[0]}'; $_cmd0"
+        _cmd0="printf '[sandy:pane-agent] %s\n' '${_SANDY_AGENTS[0]}'; $_cmd0"
+        _p_id="$(tmux new-session -d -P -F '#{pane_id}' -s sandy -n "sandy: ${SANDY_PROJECT_NAME:-$(basename "$WORKSPACE")}" -- bash -c "$_cmd0 2>&1")"
+        tmux set-option -p -t "$_p_id" @sandy_pane_agent "${_SANDY_AGENTS[0]}" 2>/dev/null
+    else
+        tmux new-session -d -s sandy -n "sandy: ${SANDY_PROJECT_NAME:-$(basename "$WORKSPACE")}" -- bash -c "$_cmd0 2>&1"
     fi
-    tmux new-session -d -s sandy -n "sandy: ${SANDY_PROJECT_NAME:-$(basename "$WORKSPACE")}" -- bash -c "$_cmd0 2>&1"
 
     # Second agent: split horizontally
     _cmd1="$(_sandy_build_agent_cmd "${_SANDY_AGENTS[1]}" "$@")"
     if [ "${SANDY_TEST_PANE_TAGS:-0}" = "1" ]; then
-        _cmd1="tmux set-option -p @sandy_pane_agent '${_SANDY_AGENTS[1]}' 2>/dev/null; printf '[sandy:pane-agent] %s\n' '${_SANDY_AGENTS[1]}'; $_cmd1"
+        _cmd1="printf '[sandy:pane-agent] %s\n' '${_SANDY_AGENTS[1]}'; $_cmd1"
+        _p_id="$(tmux split-window -h -P -F '#{pane_id}' -t sandy -- bash -c "$_cmd1 2>&1")"
+        tmux set-option -p -t "$_p_id" @sandy_pane_agent "${_SANDY_AGENTS[1]}" 2>/dev/null
+    else
+        tmux split-window -h -t sandy -- bash -c "$_cmd1 2>&1"
     fi
-    tmux split-window -h -t sandy -- bash -c "$_cmd1 2>&1"
 
     # Third agent (if present): split the right pane vertically
     if [ "$_SANDY_AGENT_COUNT" -ge 3 ]; then
         _cmd2="$(_sandy_build_agent_cmd "${_SANDY_AGENTS[2]}" "$@")"
         if [ "${SANDY_TEST_PANE_TAGS:-0}" = "1" ]; then
-            _cmd2="tmux set-option -p @sandy_pane_agent '${_SANDY_AGENTS[2]}' 2>/dev/null; printf '[sandy:pane-agent] %s\n' '${_SANDY_AGENTS[2]}'; $_cmd2"
+            _cmd2="printf '[sandy:pane-agent] %s\n' '${_SANDY_AGENTS[2]}'; $_cmd2"
+            _p_id="$(tmux split-window -v -P -F '#{pane_id}' -t sandy.1 -- bash -c "$_cmd2 2>&1")"
+            tmux set-option -p -t "$_p_id" @sandy_pane_agent "${_SANDY_AGENTS[2]}" 2>/dev/null
+        else
+            tmux split-window -v -t sandy.1 -- bash -c "$_cmd2 2>&1"
         fi
-        tmux split-window -v -t sandy.1 -- bash -c "$_cmd2 2>&1"
     fi
 
     # Fourth agent (if present): split the left pane vertically → 2x2 grid.
@@ -943,9 +964,12 @@ else
     if [ "$_SANDY_AGENT_COUNT" -ge 4 ]; then
         _cmd3="$(_sandy_build_agent_cmd "${_SANDY_AGENTS[3]}" "$@")"
         if [ "${SANDY_TEST_PANE_TAGS:-0}" = "1" ]; then
-            _cmd3="tmux set-option -p @sandy_pane_agent '${_SANDY_AGENTS[3]}' 2>/dev/null; printf '[sandy:pane-agent] %s\n' '${_SANDY_AGENTS[3]}'; $_cmd3"
+            _cmd3="printf '[sandy:pane-agent] %s\n' '${_SANDY_AGENTS[3]}'; $_cmd3"
+            _p_id="$(tmux split-window -v -P -F '#{pane_id}' -t sandy.0 -- bash -c "$_cmd3 2>&1")"
+            tmux set-option -p -t "$_p_id" @sandy_pane_agent "${_SANDY_AGENTS[3]}" 2>/dev/null
+        else
+            tmux split-window -v -t sandy.0 -- bash -c "$_cmd3 2>&1"
         fi
-        tmux split-window -v -t sandy.0 -- bash -c "$_cmd3 2>&1"
     fi
 
     tmux select-pane -t sandy.0

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -6151,8 +6151,11 @@ check "the harness verifies pane identity via capture-pane" \
     grep -q 'capture-pane' "$_S80_TOPO"
 # Primary identity is now the @sandy_pane_agent tmux PANE OPTION (agent-proof;
 # a scrollback marker is wiped when a real credentialed agent redraws its pane).
-check "sandy sets the @sandy_pane_agent pane option (agent-proof identity)" \
-    bash -c '[ "$(grep -c "set-option -p @sandy_pane_agent" "$1")" -ge 4 ]' -- "$_S80"
+check "sandy sets the @sandy_pane_agent pane option by pane-id (agent-proof identity)" \
+    bash -c '[ "$(grep -cE "set-option -p .*@sandy_pane_agent" "$1")" -ge 4 ]' -- "$_S80"
+check "the @sandy_pane_agent option is set from the launcher by pane-id, not a \$TMUX_PANE self-set" \
+    bash -c 'grep -qE "tmux (new-session|split-window).* -P -F .#\{pane_id\}" "$1" \
+        && ! grep -qE "_cmd[0-9]=.tmux set-option" "$1"' -- "$_S80"
 check "the harness reads pane identity from the @sandy_pane_agent option" \
     grep -q '@sandy_pane_agent' "$_S80_TOPO"
 check "the harness tears down via --stop between combos" \


### PR DESCRIPTION
A maintainer diagnostic on a live 4-agent `all` combo finally localized the persistent identity failure. Dumping `@sandy_pane_agent` per pane by geometry:

| pane | position | `@sandy_pane_agent` | should be |
|---|---|---|---|
| idx=0 (L=0,T=1) | top-left | `opencode` | claude ❌ |
| idx=1 (L=0,T=13) | bottom-left | `` (empty) | opencode ❌ |
| idx=2 (L=41,T=1) | top-right | `gemini` | gemini ✅ |
| idx=3 (L=41,T=13) | bottom-right | `codex` | codex ✅ |

## Cause
The marker was set by each pane's **own command** (`tmux set-option -p`, resolved via `$TMUX_PANE` / the active pane). That self-set **raced the last split** (`split -v -t sandy.0` re-splits pane 0), so on the left column claude's tag was lost and opencode's landed on the wrong pane. The right column (first split + its sub-split) was never touched by a re-split, which is exactly why only the 4-agent combo's left-column identity checks flapped.

## Fix
Set `@sandy_pane_agent` from the **launcher**, targeting the pane by the unique id captured at creation (`-P -F '#{pane_id}'`), written synchronously right after the pane exists. Race-free — stable id, no `$TMUX_PANE`/active-pane/index dependency. Removed the pane-command self-set (kept the `printf` marker as a log line + capture-pane fallback).

**Only the `SANDY_TEST_PANE_TAGS` branch changes; normal launches take a byte-identical else branch.** Mirrored to `user-setup.sh.tmpl` (BUILD_HASH → one-time rebuild on next `--start`). `run-tests.sh §80` gets a guard that the option is set by pane-id (not a self-set); **19/19 standalone**. `bash -n` + regen clean.

Maintainer confirmation: a fresh `bash test/acceptance-pane-topology.sh` after this should be a steady 66/0, and the diagnostic dump should show all four panes correctly tagged.