### PR TITLE
release: 1.3.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,14 @@
-## sandy v1.3.0 (unreleased)
+## sandy v1.3.0
 
-Additive feature work. `schema_version` stays `1`; the sandbox forward-compat promise holds.
+Six additive features — **observability, reclaim, and readiness**. `schema_version` stays `1` and the 1.x sandbox forward-compat promise holds, so any 1.x sandbox keeps working.
+
+- **Two status lines** — the outer tmux bar now shows color-coded egress posture, agent(s), workspace, client count, and daemon/session state; the Claude pane gets a native status line with live model · effort · context. (#42, #67)
+- **`sandy --gc`** — one-pass reclaim of leaked Docker resources (dead-owner containers, orphan networks, orphaned per-project/skill images, dangling images), reboot-safe by design. (#36)
+- **Egress-proxy readiness** — the launch gate waits for the proxy's listeners to actually bind via a Docker `HEALTHCHECK`, closing a first-request "connection refused" race. (#37)
+- **`SANDY_AGENT_ARGS`** — persistent extra agent flags from `.sandy/config`, applied on every launch including sandy-ui. (#59)
+- **Automated multi-agent pane-topology verification** — a Docker-runtime harness proves the documented split-pane layouts. (#22)
+
+Per-feature detail below. (#52 and #23 moved to 1.3.1.)
 
 ### `SANDY_AGENT_ARGS` — persistent extra agent args from config (#59)
 

--- a/sandy
+++ b/sandy
@@ -17,7 +17,7 @@ set -euo pipefail
 #   sandy --agent claude,gemini   Override agent selection for this run
 # =============================================================================
 
-SANDY_VERSION="1.2.2-dev"
+SANDY_VERSION="1.3.0"
 SANDY_COMMIT=""  # baked in by install.sh; empty = detect from git at runtime
 
 # Schema contract version for --print-schema / --print-state / --validate-config.


### PR DESCRIPTION
Cuts **sandy 1.3.0** — six additive features (observability, reclaim, readiness):

- **#42 / #67** — two status lines: the outer tmux bar (color-coded egress posture, agent, workspace, clients, daemon/session) and the Claude pane's native statusLine (live model · effort · context).
- **#36** — `sandy --gc` unified Docker-resource reclaim (reboot-safe).
- **#37** — egress-proxy readiness via Docker `HEALTHCHECK`.
- **#59** — `SANDY_AGENT_ARGS` persistent agent flags from config.
- **#22** — automated multi-agent pane-topology verification.

`SANDY_VERSION` → `1.3.0`; `schema_version` stays `1`; sandbox forward-compat floor unchanged (`0.7.10`). #52 and #23 moved to milestone 1.3.1. RELEASE_NOTES finalized (overview + per-feature detail).

Post-merge: tag `v1.3.0`, publish the GitHub release, then bump to `1.3.1-dev`.