### PR TITLE
release: bump to 1.3.1-dev post-v1.3.0

### DIFF
--- a/sandy
+++ b/sandy
@@ -17,7 +17,7 @@ set -euo pipefail
 #   sandy --agent claude,gemini   Override agent selection for this run
 # =============================================================================
 
-SANDY_VERSION="1.3.0"
+SANDY_VERSION="1.3.1-dev"
 SANDY_COMMIT=""  # baked in by install.sh; empty = detect from git at runtime
 
 # Schema contract version for --print-schema / --print-state / --validate-config.


### PR DESCRIPTION
Post-release version bump after v1.3.0. `SANDY_VERSION` 1.3.0 → 1.3.1-dev (stays -dev until the next tag, per the proxy-ref convention). Milestone 1.3.1 holds #52 and #23.