### PR TITLE
release: sandy 1.4.0 — HF-incident hardening + sandbox-escape follow-ups

### DIFF
--- a/sandy
+++ b/sandy
@@ -17,7 +17,7 @@ set -euo pipefail
 #   sandy --agent claude,gemini   Override agent selection for this run
 # =============================================================================
 
-SANDY_VERSION="1.3.1-dev"
+SANDY_VERSION="1.4.0"
 SANDY_COMMIT=""  # baked in by install.sh; empty = detect from git at runtime
 
 # Schema contract version for --print-schema / --print-state / --validate-config.


### PR DESCRIPTION
# sandy 1.4.0 — Hugging Face incident hardening + sandbox-escape follow-ups

This release works through the surviving findings from two security evaluations —
the "Week of Sandbox Escapes" review and the Hugging Face CISO incident
post-mortem — mapped onto sandy. Every item was implemented, reviewed, and
CI-gated as its own PR.

## Egress proxy — the incident's exact target, hardened

The HF incident broke containment via a zero-day *in the sandbox's egress proxy*.
Sandy's proxy is in the same structural position, so this release treats it as an
in-scope attack surface, not just a control:

- **Hardened sidecar** (#88): `no-new-privileges`, `--pids-limit`, `--memory`, and
  an in-proxy connection semaphore that bounds a connection storm with backpressure
  rather than the OOM-killer.
- **Auto-refresh** (#89): the proxy image rebuilds ~monthly (freshness epoch +
  `--pull`) so its golang base + Go stdlib get security fixes *between* sandy
  releases; `--print-state` full mode now reports `proxy_image_created`.
- **Adversarial testing** (#90): Go fuzz targets for the SNI / server-name / HTTP-Host
  wire parsers (invariant: never panic); THREAT_MODEL documents the proxy as a
  tier-3 target. *(CI wiring for the fuzz gate + `govulncheck` is a follow-up
  pending a workflow-scoped push.)*

## Observability — instrument what happens inside containment

The incident's central operational failure was three quiet days. Two new,
passive-safe, opt-in signals answer "what did this session actually do":

- **`SANDY_EGRESS_LOG`** (#91) — the proxy logs each distinct allowed `host:port`
  once (deduped); session end prints an egress summary (hosts reached, denials).
- **`SANDY_TOOL_AUDIT`** (#92) — seeds a Claude Code `PreToolUse` hook writing a
  `{ts,tool,args}` JSONL trail (only-if-absent; Claude-only; not tamper-proof
  against a determined agent — telemetry for the primary adversary).

## Recovery — rebuild from known-good, one command

- **`sandy --reset-sandbox`** (#93) — rebuild one project's sandbox from a
  known-good skeleton (destroy persistent package/agent state, preserve
  `WORKSPACE.json` lineage), refusing while a live session holds it.
- **`sandy --stop-all`** (#94) — fleet emergency stop: stop every daemon session
  via the hardened per-session teardown.

## Trust-handoff / workspace supply-chain follow-ups

- **`.sandy/Dockerfile` build approval gate** (1.3.x, #83) — the one live,
  exploitable finding; gated behind per-workspace approval, fail-closed non-interactive.
- Host-IDE-on-shared-workspace caveat (#84); host-reachable `.venv` warning (#85);
  session-end detection for a created-in-session `core.hooksPath` dir (#86);
  wrapped-agent CVE-watch posture (#87).

## Notes

- Additive release: new keys `SANDY_EGRESS_LOG`, `SANDY_TOOL_AUDIT` (passive-safe)
  and flags `--reset-sandbox`, `--stop-all`. Introspection `schema_version` stays 1.
- Sandbox forward-compat unchanged (`SANDY_SANDBOX_MIN_COMPAT` stays `0.7.10`).

---
Bumps `SANDY_VERSION` 1.3.1-dev → **1.4.0** (additive minor per the CLAUDE.md semver rule). `schema_version` stays 1; `SANDY_SANDBOX_MIN_COMPAT` unchanged. Tag + GitHub release follow once this merges.