### PR TITLE
chore: bump to 1.4.1-dev after cutting 1.4.0

### DIFF
--- a/sandy
+++ b/sandy
@@ -17,7 +17,7 @@ set -euo pipefail
 #   sandy --agent claude,gemini   Override agent selection for this run
 # =============================================================================
 
-SANDY_VERSION="1.4.0"
+SANDY_VERSION="1.4.1-dev"
 SANDY_COMMIT=""  # baked in by install.sh; empty = detect from git at runtime
 
 # Schema contract version for --print-schema / --print-state / --validate-config.


### PR DESCRIPTION
Post-release `-dev` bump per the CLAUDE.md versioning convention. The update check strips everything after the first `-`, so this compares as `1.4.0` and never nags stable users toward a dev build.