### PR TITLE
ci(proxy): wire the fuzz gate + advisory govulncheck (HF Issue 1 follow-up)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,29 @@ jobs:
         working-directory: proxy
         run: go test -race ./...
 
+      # HF-incident Issue 1: the proxy parses attacker-influenced wire bytes, so
+      # prove the parsers never panic under adversarial input — a short fuzz pass
+      # per target (seed corpus + fuzzing). Any crasher fails the build.
+      - name: go fuzz (short)
+        working-directory: proxy
+        run: |
+          for t in FuzzExtractSNI FuzzParseServerName FuzzExtractHTTPHost; do
+            echo "== fuzz $t =="
+            go test -run='^$' -fuzz="^${t}$" -fuzztime=30s .
+          done
+
+      # HF-incident Issue 1: surface known vulnerabilities in the proxy's own
+      # dependency + stdlib call paths. Advisory (continue-on-error): stdlib patch
+      # latency is remediated by the proxy image's monthly golang-base refresh
+      # (Issue 3) and miekg/dns bumps by Dependabot, so a new stdlib CVE surfaces
+      # here without hard-breaking every unrelated proxy PR.
+      - name: govulncheck (advisory)
+        continue-on-error: true
+        working-directory: proxy
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          "$(go env GOPATH)/bin/govulncheck" ./...
+
       - name: static build
         working-directory: proxy
         run: CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /tmp/sandy-proxy .


### PR DESCRIPTION
Completes **HF-incident Issue 1** (#90 shipped the fuzz targets + threat-model note; this adds the CI wiring that was blocked by the `workflow` token scope).

The proxy CI job now runs:
- **`go fuzz (short)`** — a 30s `-fuzztime` pass per wire-parser target (`FuzzExtractSNI` / `FuzzParseServerName` / `FuzzExtractHTTPHost`). **Hard gate** — any crasher fails the build.
- **`govulncheck (advisory)`** — `continue-on-error: true`. Stdlib patch latency is remediated by the proxy image's monthly golang-base refresh (Issue 3, #89) + Dependabot on `proxy/go.mod`, so a new CVE **surfaces** here without hard-breaking every unrelated proxy PR. *(It currently reports 21 stdlib vulns — CI toolchain `go1.24.1`, fixed in ≥1.24.4 — exactly the staleness the monthly refresh targets.)*

Workflows-only change; split from #90 because pushing `.github/workflows/` needs a `workflow`-scoped token.