### PR TITLE
feat(agent): add Grok Build as a selectable agent (#99)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ Sandy loads configuration from four sources in order: `$HOME/.sandy/config`, `$H
 
 - **Privileged-only keys** (require per-workspace approval when set from a passive source):
   <!-- BEGIN AUTOGEN:privileged-key-list Run `test/regen-config-docs.sh` to update. -->
-  `SANDY_SSH`, `SANDY_SKIP_PERMISSIONS`, `SANDY_ALLOW_NO_ISOLATION`, `SANDY_ALLOW_LAN_HOSTS`, `SANDY_LOCAL_LLM_HOST`, `SANDY_ALLOW_HOSTS`, `SANDY_EXTRA_ENV`, `SANDY_AGENT_ARGS`, `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `GEMINI_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, `SANDY_SCREENSHOT_DIR`, `SANDY_GEMINI_EXTENSIONS`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_ALLOWED_SENDERS`, `DISCORD_BOT_TOKEN`, `DISCORD_ALLOWED_SENDERS`
+  `SANDY_SSH`, `SANDY_SKIP_PERMISSIONS`, `SANDY_ALLOW_NO_ISOLATION`, `SANDY_ALLOW_LAN_HOSTS`, `SANDY_LOCAL_LLM_HOST`, `SANDY_ALLOW_HOSTS`, `SANDY_EXTRA_ENV`, `SANDY_AGENT_ARGS`, `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `GEMINI_API_KEY`, `OPENAI_API_KEY`, `XAI_API_KEY`, `GOOGLE_API_KEY`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, `SANDY_SCREENSHOT_DIR`, `SANDY_GEMINI_EXTENSIONS`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_ALLOWED_SENDERS`, `DISCORD_BOT_TOKEN`, `DISCORD_ALLOWED_SENDERS`
   <!-- END AUTOGEN:privileged-key-list -->
 
   These would let a malicious `.sandy/config` committed to a repo disable isolation or exfiltrate credentials, so sandy collects them, prints the exact `KEY=VALUE` set, and asks for explicit approval before honoring them. Approvals are persisted to `$SANDY_HOME/approvals/passive-<workspace-hash>.list` (first line is a sha256 of the sorted `KEY=VALUE` set). Subsequent launches with the same set are silent; any edit to `.sandy/config` that changes a privileged key re-prompts. Revoke with `rm $SANDY_HOME/approvals/passive-<hash>.list`. Headless mode (`-p`/`--print`/`--prompt`) and non-TTY stdin fail closed — the keys are dropped with a pointer to "launch sandy interactively once from this directory to approve."
@@ -141,7 +141,7 @@ Sandy loads configuration from four sources in order: `$HOME/.sandy/config`, `$H
 
 - **Passive-safe keys** (allowed from any source):
   <!-- BEGIN AUTOGEN:passive-key-list Run `test/regen-config-docs.sh` to update. -->
-  `SANDY_AGENT`, `SANDY_MODEL`, `SANDY_CPUS`, `SANDY_MEM`, `SANDY_GPU`, `SANDY_SKILL_PACKS`, `SANDY_CHANNELS`, `SANDY_CHANNEL_TARGET_PANE`, `SANDY_VERBOSE`, `SANDY_VENV_OVERLAY`, `SANDY_EGRESS_PROXY`, `SANDY_EGRESS_NO_ISOLATION`, `SANDY_EGRESS_STRICT`, `SANDY_EGRESS_LOG`, `SANDY_ALLOW_WORKFLOW_EDIT`, `CLAUDE_CODE_MAX_OUTPUT_TOKENS`, `GEMINI_MODEL`, `SANDY_GEMINI_AUTH`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, `GOOGLE_GENAI_USE_VERTEXAI`, `CODEX_MODEL`, `SANDY_CODEX_AUTH`, `OPENCODE_MODEL`, `SANDY_OPENCODE_AUTH`, `SANDY_TOOL_AUDIT`
+  `SANDY_AGENT`, `SANDY_MODEL`, `SANDY_CPUS`, `SANDY_MEM`, `SANDY_GPU`, `SANDY_SKILL_PACKS`, `SANDY_CHANNELS`, `SANDY_CHANNEL_TARGET_PANE`, `SANDY_VERBOSE`, `SANDY_VENV_OVERLAY`, `SANDY_EGRESS_PROXY`, `SANDY_EGRESS_NO_ISOLATION`, `SANDY_EGRESS_STRICT`, `SANDY_EGRESS_LOG`, `SANDY_ALLOW_WORKFLOW_EDIT`, `CLAUDE_CODE_MAX_OUTPUT_TOKENS`, `GEMINI_MODEL`, `SANDY_GEMINI_AUTH`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, `GOOGLE_GENAI_USE_VERTEXAI`, `CODEX_MODEL`, `SANDY_CODEX_AUTH`, `OPENCODE_MODEL`, `SANDY_OPENCODE_AUTH`, `GROK_MODEL`, `SANDY_GROK_AUTH`, `SANDY_TOOL_AUDIT`
   <!-- END AUTOGEN:passive-key-list -->
 
 - **Value-aware exceptions** (passive for values that *strengthen* isolation, approval-gated for values that *weaken* it): a few passive keys are not uniformly safe from a committed `.sandy/config` because one of their values lowers the sandbox's protection. `_sandy_passive_value_privileged()` routes those weakening values through the same per-workspace approval prompt as a privileged key, while leaving the strengthening/neutral values frictionless — *"a repo may make the sandbox tighter, never looser."* The gated values are: `SANDY_EGRESS_NO_ISOLATION=1` (proxy off), `SANDY_EGRESS_STRICT=0` (downgrade a host-set strict), `SANDY_EGRESS_PROXY=0` (deprecated alias for proxy-off), and `SANDY_ALLOW_WORKFLOW_EDIT=1` (drops `.github/workflows/` protection). This closes the hole where a committed workspace config could silently disable network isolation (threat-model adversary #2) — on macOS with the proxy off that is *total* loss of network isolation. Guarded by `run-tests.sh §65`.
@@ -150,20 +150,22 @@ Additionally, `SANDY_ALLOW_LAN_HOSTS` is validated at use-site to reject world-o
 
 ## Agent Selection
 
-Sandy supports Claude Code (default), Gemini CLI, OpenAI Codex CLI, OpenCode (sst/opencode), or **any combination side-by-side in multi-pane tmux**, selectable per-project via `SANDY_AGENT` in `.sandy/config`:
+Sandy supports Claude Code (default), Gemini CLI, OpenAI Codex CLI, OpenCode (sst/opencode), Grok Build (xAI), or **any combination side-by-side in multi-pane tmux**, selectable per-project via `SANDY_AGENT` in `.sandy/config`:
 
 ```sh
-SANDY_AGENT=gemini                      # single agent: claude (default), gemini, codex, opencode
-SANDY_AGENT=claude,codex                # any comma-separated combo (2–4 agents)
-SANDY_AGENT=claude,gemini,codex,opencode # all four in a 4-pane layout
-SANDY_AGENT=all                         # alias for claude,gemini,codex,opencode
+SANDY_AGENT=grok                        # single agent: claude (default), gemini, codex, opencode, grok
+SANDY_AGENT=claude,codex                # any comma-separated combo (2–4 agents; hard cap of 4 — the layout is a 2x2 grid)
+SANDY_AGENT=claude,gemini,codex,opencode # four in a 2x2 layout
+SANDY_AGENT=all                         # alias for claude,gemini,codex,opencode (unchanged; grok is opt-in, not in `all`, so the default stays a 4-pane grid)
 ```
 
-Single-agent modes use their own Docker images (`sandy-claude-code`, `sandy-gemini-cli`, `sandy-codex`, `sandy-opencode`); multi-agent combos use `sandy-full` (which includes all four agents). All share the common `sandy-base`. Gemini CLI, Codex CLI, and OpenCode are installed via `npm install -g @google/gemini-cli`, `npm install -g @openai/codex`, and `npm install -g opencode-ai` respectively. Gemini launches with `GEMINI_SANDBOX=false`; Codex launches with `--sandbox danger-full-access` plus `sandbox_mode = "danger-full-access"` in its `config.toml` (belt-and-suspenders — codex's Landlock sandbox does not nest cleanly in Docker, and sandy already provides whole-session isolation). The sandbox directory has sibling `claude/`, `gemini/`, `codex/`, and `opencode/` subdirs. The first three mount at `~/.claude`, `~/.gemini`, and `~/.codex`; OpenCode straddles two XDG paths and uses `opencode/{config,share}` mounting at `~/.config/opencode` and `~/.local/share/opencode` respectively. v1 layouts with `settings.json` at the sandbox top level are auto-migrated on launch.
+Single-agent modes use their own Docker images (`sandy-claude-code`, `sandy-gemini-cli`, `sandy-codex`, `sandy-opencode`, `sandy-grok`); multi-agent combos use `sandy-full` (which includes all five agents). With five selectable agents but a 2x2-grid layout, sandy hard-errors on a 5+ combo. Grok Build is installed via `curl -fsSL https://x.ai/cli/install.sh | bash` (a prebuilt binary, not npm — sandy relocates it to `/usr/local/bin/grok` since `/home/claude` is a tmpfs); its config/session lives in the `grok/` sandbox subdir mounted at `~/.grok`. All share the common `sandy-base`. Gemini CLI, Codex CLI, and OpenCode are installed via `npm install -g @google/gemini-cli`, `npm install -g @openai/codex`, and `npm install -g opencode-ai` respectively. Gemini launches with `GEMINI_SANDBOX=false`; Codex launches with `--sandbox danger-full-access` plus `sandbox_mode = "danger-full-access"` in its `config.toml` (belt-and-suspenders — codex's Landlock sandbox does not nest cleanly in Docker, and sandy already provides whole-session isolation). The sandbox directory has sibling `claude/`, `gemini/`, `codex/`, and `opencode/` subdirs. The first three mount at `~/.claude`, `~/.gemini`, and `~/.codex`; OpenCode straddles two XDG paths and uses `opencode/{config,share}` mounting at `~/.config/opencode` and `~/.local/share/opencode` respectively. v1 layouts with `settings.json` at the sandbox top level are auto-migrated on launch.
 
 **Gemini credentials** are probed in this order (override via `SANDY_GEMINI_AUTH=auto|api_key|oauth|adc`): `GEMINI_API_KEY` env var, host `~/.gemini/tokens.json` (copied ephemerally), host `~/.config/gcloud/application_default_credentials.json` (Google ADC / Vertex AI).
 
 **Codex credentials** are probed in this order (override via `SANDY_CODEX_AUTH=auto|api_key|oauth`): `OPENAI_API_KEY` env var (materialized as an ephemeral `auth.json` mounted **read-only** — codex 0.139+ no longer reads the env var for first-party auth, so sandy writes what `codex login --with-api-key` would write), host `~/.codex/auth.json` (copied ephemerally and mounted **read-only** — prevents token leakage back to host and prevents stale-token races). Because `auth.json` is mounted read-only, in-session OAuth refresh will fail — users must re-login inside the container if the token expires. On first launch, sandy seeds `~/.codex/config.toml` with `model = "gpt-5.5"`, `sandbox_mode = "danger-full-access"`, and a full `[notice]` block to suppress all first-run prompts; a `[projects."$SANDY_WORKSPACE"] trust_level = "trusted"` entry is appended at session start by `user-setup.sh` (it needs the container-side workspace path).
+
+**Grok credentials** — Grok Build authenticates fully headless from **`XAI_API_KEY`** (docs.x.ai; resolution order `model.api_key > env_key > active session token > XAI_API_KEY`), so — unlike codex — sandy has **no auth file to materialize**: it just forwards the env var (privileged tier, like the other agent keys). The alternative is an interactive `grok login` OAuth session, which persists in the rw `~/.grok` mount across launches (host `~/.grok` OAuth-session seeding is a possible follow-up, deliberately kept out of the persisted mount for now). Model via `GROK_MODEL` (passed as `-m`; default `grok-4.5`); probe override via `SANDY_GROK_AUTH=auto|api_key|oauth`. Headless (`-p`) adds `--no-auto-update` (grok can't self-update against the read-only rootfs anyway; docs.x.ai headless-scripting). Auto-update *detection* isn't wired (grok installs via `install.sh` with no version API) — `sandy --rebuild` re-fetches latest; a monthly-freshness rebuild trigger (like the proxy image) is a candidate follow-up.
 
 **OpenCode credentials** are provider-agnostic — opencode reads `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `GROQ_API_KEY`, etc. natively from the env, and sandy forwards whichever the user has set. The OAuth path mounts host `~/.local/share/opencode/auth.json` read-only when present (override the probe with `SANDY_OPENCODE_AUTH=auto|api_key|oauth`). OpenCode's flexibility is what makes the **local-LLM passthrough** below useful — point the config at a local Ollama/vLLM endpoint and pair with `SANDY_LOCAL_LLM_HOST`.
 
@@ -177,18 +179,18 @@ Single-agent modes use their own Docker images (`sandy-claude-code`, `sandy-gemi
 
 **Feature support by agent**:
 
-| Feature | `claude` | `gemini` | `codex` | `opencode` | multi-agent |
-|---|---|---|---|---|---|
-| Skill packs | yes | — | — | — | yes (claude pane only) |
-| Synthkit commands | yes (slash commands, Markdown) | yes (slash commands, TOML in `~/.gemini/commands/`) | yes (skills context, SKILL.md in `~/.codex/skills/`) | — (v0) | per agent |
-| Channels (Telegram) | in-container plugin | host-side tmux relay | host-side tmux relay | host-side tmux relay (untested in v0) | host-side tmux relay |
-| Channels (Discord) | yes | — | — | — | — |
-| `--remote` | yes | — | — | — | — |
-| Gemini extensions (`SANDY_GEMINI_EXTENSIONS`) | — | yes | — | — | yes (when gemini is in the combo) |
-| Local-LLM passthrough (`SANDY_LOCAL_LLM_HOST`) | — | — | — | yes | yes (when opencode is in the combo) |
-| Provider choice via own config | — | — | — | yes | — |
+| Feature | `claude` | `gemini` | `codex` | `opencode` | `grok` | multi-agent |
+|---|---|---|---|---|---|---|
+| Skill packs | yes | — | — | — | — | yes (claude pane only) |
+| Synthkit commands | yes (slash commands, Markdown) | yes (slash commands, TOML in `~/.gemini/commands/`) | yes (skills context, SKILL.md in `~/.codex/skills/`) | — (v0) | — (v0; tool binaries on PATH) | per agent |
+| Channels (Telegram) | in-container plugin | host-side tmux relay | host-side tmux relay | host-side tmux relay (untested in v0) | host-side tmux relay (untested in v0) | host-side tmux relay |
+| Channels (Discord) | yes | — | — | — | — | — |
+| `--remote` | yes | — | — | — | — | — |
+| Gemini extensions (`SANDY_GEMINI_EXTENSIONS`) | — | yes | — | — | — | yes (when gemini is in the combo) |
+| Local-LLM passthrough (`SANDY_LOCAL_LLM_HOST`) | — | — | — | yes | — | yes (when opencode is in the combo) |
+| Provider choice via own config | — | — | — | yes | — | — |
 
-Codex headless mode (`-p` / `--print` / `--prompt`) translates to `codex exec --skip-git-repo-check` — the prompt is passed as a positional arg, not a flag, and the trust/git-repo gate is skipped (codex 0.139+ refuses `exec` outside a trusted dir or git repo; sandy provides the outer isolation). OpenCode headless mirrors that pattern: `opencode run <prompt>`. Both `exec` and `run` only support `0`/`1` exit codes (no nuanced codes like Claude's `--print`). `--continue` / `-c` is silently dropped for both (neither has a headless continuation flag). Multi-agent combos use comma-separated syntax (e.g., `claude,codex`); `all` is an alias for `claude,gemini,codex,opencode`. The old `both` alias was removed in `v0.12` — sandy now errors out with a pointer to the comma-separated syntax.
+Codex headless mode (`-p` / `--print` / `--prompt`) translates to `codex exec --skip-git-repo-check` — the prompt is passed as a positional arg, not a flag, and the trust/git-repo gate is skipped (codex 0.139+ refuses `exec` outside a trusted dir or git repo; sandy provides the outer isolation). OpenCode headless mirrors that pattern: `opencode run <prompt>`. Both `exec` and `run` only support `0`/`1` exit codes (no nuanced codes like Claude's `--print`). `--continue` / `-c` is silently dropped for both (neither has a headless continuation flag). **Grok** headless is Claude-shaped instead: `-p`/`--print`/`--prompt` map to grok's `-p` print flag (the prompt stays a positional arg, not a subcommand like `exec`/`run`), plus `--no-auto-update`; `--continue`/`-c` dropped. Multi-agent combos use comma-separated syntax (e.g., `claude,codex`); `all` is an alias for `claude,gemini,codex,opencode`. With grok there are now **five** selectable agents but the layout is a 2x2 grid, so sandy hard-errors on a 5+ combo (`all` deliberately stays 4). The old `both` alias was removed in `v0.12` — sandy now errors out with a pointer to the comma-separated syntax.
 
 The Telegram host-side relay (`$SANDY_HOME/channel-relay.sh`) is an agent-agnostic long-polling bridge that injects messages into the container's tmux session via `docker exec ... tmux send-keys`. In multi-agent mode, `SANDY_CHANNEL_TARGET_PANE=0|1|2` selects which pane receives messages (default `0` = first pane in `SANDY_AGENT`).
 

--- a/README.md
+++ b/README.md
@@ -327,9 +327,22 @@ Headless mode (`-p` / `--print` / `--prompt "..."`) translates to `opencode run`
 
 Not supported with `opencode` in v0: `--remote`, `SANDY_SKILL_PACKS`, `SANDY_CHANNELS=discord`. Synthkit is installed in the image but skill auto-discovery for opencode is deferred until upstream support stabilizes.
 
+### Running Grok Build (`SANDY_AGENT=grok`)
+
+Grok Build is xAI's coding agent. Sandy installs it in the image from `https://x.ai/cli/install.sh` (a prebuilt binary, relocated onto `PATH` since the home dir is a tmpfs) and authenticates it **fully headless from an `XAI_API_KEY`** — no auth file to manage:
+
+| Auth | How | Notes |
+|---|---|---|
+| API key | `XAI_API_KEY=xai-...` in `.sandy/.secrets` or env | Forwarded into the container; the primary path |
+| OAuth | `grok login` inside the container | Session persists in the `~/.grok` sandbox mount across launches |
+
+- Model: `GROK_MODEL=grok-4.5` (default; passed as `-m`). Probe override: `SANDY_GROK_AUTH=auto|api_key|oauth`.
+- Headless mode (`-p` / `--print` / `--prompt "..."`) runs `grok --no-auto-update -p "<prompt>"` (grok can't self-update against the read-only rootfs). `--continue` / `-c` is dropped.
+- Not supported with `grok` in v0: `--remote`, `SANDY_SKILL_PACKS`, synthkit slash-commands, channels beyond the host-side Telegram relay. Auto-update detection isn't wired (no version API) — `sandy --rebuild` re-fetches the latest grok.
+
 ### Multi-agent mode
 
-Sandy runs any combination of Claude, Gemini, Codex, and OpenCode side-by-side in a single tmux session, selected via comma-separated values in `SANDY_AGENT`:
+Sandy runs any combination of Claude, Gemini, Codex, OpenCode, and Grok side-by-side in a single tmux session — **up to 4 at once** (the layout is a 2×2 grid) — selected via comma-separated values in `SANDY_AGENT`:
 
 ```bash
 SANDY_AGENT=claude,gemini              # two panes

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -14,6 +14,7 @@ Sandy is a self-contained command that runs an AI coding agent (Claude Code, Gem
 | `gemini` | `sandy-gemini-cli` | Gemini CLI — Google OAuth / ADC / Vertex AI / API key auth |
 | `codex` | `sandy-codex` | OpenAI Codex CLI — `OPENAI_API_KEY` (materialized as ephemeral `auth.json`) or ChatGPT OAuth; both as read-only mounts |
 | `opencode` | `sandy-opencode` | OpenCode (sst/opencode) — provider-agnostic; reads `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` natively, plus optional OAuth from `~/.local/share/opencode/auth.json`. Local-LLM passthrough via `SANDY_LOCAL_LLM_HOST`. |
+| `grok` | `sandy-grok` | Grok Build (xAI) — installed from `x.ai/cli/install.sh` (prebuilt binary, relocated to `/usr/local/bin`); authenticates headless from `XAI_API_KEY` (or an in-container `grok login` OAuth session in `~/.grok`). Model via `GROK_MODEL` (`-m`, default `grok-4.5`). Not in the `all` alias. |
 | `<a>,<b>[,<c>[,<d>]]` (e.g. `claude,gemini`, `claude,codex`, `claude,gemini,codex,opencode`) | `sandy-full` | Multi-agent combo — one tmux pane per agent, in the order listed |
 | `all` | `sandy-full` | Alias for `claude,gemini,codex,opencode` — all four agents in a 4-pane tmux session |
 
@@ -143,12 +144,12 @@ Each call to `_load_sandy_config` takes a `tier` argument (`privileged` or `pass
 
 **Privileged-only keys** (allowed only from `$SANDY_HOME/config` and `$SANDY_HOME/.secrets`):
 <!-- BEGIN AUTOGEN:privileged-key-list Run `test/regen-config-docs.sh` to update. -->
-`SANDY_SSH`, `SANDY_SKIP_PERMISSIONS`, `SANDY_ALLOW_NO_ISOLATION`, `SANDY_ALLOW_LAN_HOSTS`, `SANDY_LOCAL_LLM_HOST`, `SANDY_ALLOW_HOSTS`, `SANDY_EXTRA_ENV`, `SANDY_AGENT_ARGS`, `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `GEMINI_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, `SANDY_SCREENSHOT_DIR`, `SANDY_GEMINI_EXTENSIONS`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_ALLOWED_SENDERS`, `DISCORD_BOT_TOKEN`, `DISCORD_ALLOWED_SENDERS`
+`SANDY_SSH`, `SANDY_SKIP_PERMISSIONS`, `SANDY_ALLOW_NO_ISOLATION`, `SANDY_ALLOW_LAN_HOSTS`, `SANDY_LOCAL_LLM_HOST`, `SANDY_ALLOW_HOSTS`, `SANDY_EXTRA_ENV`, `SANDY_AGENT_ARGS`, `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `GEMINI_API_KEY`, `OPENAI_API_KEY`, `XAI_API_KEY`, `GOOGLE_API_KEY`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, `SANDY_SCREENSHOT_DIR`, `SANDY_GEMINI_EXTENSIONS`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_ALLOWED_SENDERS`, `DISCORD_BOT_TOKEN`, `DISCORD_ALLOWED_SENDERS`
 <!-- END AUTOGEN:privileged-key-list -->
 
 **Passive-safe keys** (allowed from any source):
 <!-- BEGIN AUTOGEN:passive-key-list Run `test/regen-config-docs.sh` to update. -->
-`SANDY_AGENT`, `SANDY_MODEL`, `SANDY_CPUS`, `SANDY_MEM`, `SANDY_GPU`, `SANDY_SKILL_PACKS`, `SANDY_CHANNELS`, `SANDY_CHANNEL_TARGET_PANE`, `SANDY_VERBOSE`, `SANDY_VENV_OVERLAY`, `SANDY_EGRESS_PROXY`, `SANDY_EGRESS_NO_ISOLATION`, `SANDY_EGRESS_STRICT`, `SANDY_EGRESS_LOG`, `SANDY_ALLOW_WORKFLOW_EDIT`, `CLAUDE_CODE_MAX_OUTPUT_TOKENS`, `GEMINI_MODEL`, `SANDY_GEMINI_AUTH`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, `GOOGLE_GENAI_USE_VERTEXAI`, `CODEX_MODEL`, `SANDY_CODEX_AUTH`, `OPENCODE_MODEL`, `SANDY_OPENCODE_AUTH`, `SANDY_TOOL_AUDIT`
+`SANDY_AGENT`, `SANDY_MODEL`, `SANDY_CPUS`, `SANDY_MEM`, `SANDY_GPU`, `SANDY_SKILL_PACKS`, `SANDY_CHANNELS`, `SANDY_CHANNEL_TARGET_PANE`, `SANDY_VERBOSE`, `SANDY_VENV_OVERLAY`, `SANDY_EGRESS_PROXY`, `SANDY_EGRESS_NO_ISOLATION`, `SANDY_EGRESS_STRICT`, `SANDY_EGRESS_LOG`, `SANDY_ALLOW_WORKFLOW_EDIT`, `CLAUDE_CODE_MAX_OUTPUT_TOKENS`, `GEMINI_MODEL`, `SANDY_GEMINI_AUTH`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, `GOOGLE_GENAI_USE_VERTEXAI`, `CODEX_MODEL`, `SANDY_CODEX_AUTH`, `OPENCODE_MODEL`, `SANDY_OPENCODE_AUTH`, `GROK_MODEL`, `SANDY_GROK_AUTH`, `SANDY_TOOL_AUDIT`
 <!-- END AUTOGEN:passive-key-list -->
 
 ### `SANDY_ALLOW_LAN_HOSTS` Sanity Check
@@ -174,6 +175,7 @@ The table below is generated from `sandy --print-schema` (the `_sandy_key_metada
 | `CLAUDE_CODE_OAUTH_TOKEN` | privileged | unset | 0.7.0 | stable | Claude Code OAuth token (alternative to ANTHROPIC_API_KEY). |
 | `GEMINI_API_KEY` | privileged | unset | 0.9.0 | stable | Google API key for Gemini CLI. |
 | `OPENAI_API_KEY` | privileged | unset | 0.10.0 | stable | OpenAI API key for Codex CLI. |
+| `XAI_API_KEY` | privileged | unset | 1.5.0 | stable | xAI API key for Grok Build (docs.x.ai). Enables fully-headless auth (resolution: model.api_key > env_key > session token > XAI_API_KEY); alternative is an interactive 'grok login' OAuth session inside the container. |
 | `GOOGLE_API_KEY` | privileged | unset | 0.9.0 | stable | Google API key for Vertex AI / ADC. |
 | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | privileged | unset | 0.1.0 | experimental | Enable Claude Code experimental agent-teams feature. |
 | `SANDY_SCREENSHOT_DIR` | privileged | unset | 0.12.0 | stable | Host directory containing screenshots; mounted read-only at /home/claude/screenshots and exposed as $SANDY_SCREENSHOTS_PATH inside the container. Enables /ss skill across agents. |
@@ -207,6 +209,8 @@ The table below is generated from `sandy --print-schema` (the `_sandy_key_metada
 | `SANDY_CODEX_AUTH` | passive | `auto` | 0.10.0 | stable | Codex credential probe strategy. |
 | `OPENCODE_MODEL` | passive | unset | 0.12.0 | stable | OpenCode model override (provider/model format, e.g. 'anthropic/claude-sonnet-4'). |
 | `SANDY_OPENCODE_AUTH` | passive | `auto` | 0.12.0 | stable | OpenCode credential probe strategy. |
+| `GROK_MODEL` | passive | unset | 1.5.0 | stable | Grok Build model override (passed as -m; default grok-4.5). |
+| `SANDY_GROK_AUTH` | passive | `auto` | 1.5.0 | stable | Grok Build credential probe strategy. |
 | `SANDY_TOOL_AUDIT` | passive | `0` | 1.4.0 | stable | Seed a Claude Code PreToolUse audit hook (HF-incident Issue 6) that appends {ts,tool,args} JSONL to ~/.claude/tool-audit.jsonl for per-session tool-use telemetry — instrumenting the agent harness itself, not just the box. Only-if-absent: a user's own PreToolUse hook is never clobbered. Passive-safe (only ADDS visibility). Claude-only (no equivalent seam for codex/gemini/opencode). Not tamper-proof against a determined agent (runs in-box) — telemetry for the primary wrong-but-not-evil adversary. Default 0 (off). |
 | `SANDY_AUTO_APPROVE_PRIVILEGED` | env-only | unset | 0.11.2 | internal | Bypass the passive-privileged approval prompt. Intended for CI / test harnesses only. |
 | `SANDY_DEBUG_CLEANUP` | env-only | unset | 0.11.4 | internal | Print session-stub cleanup diagnostics on exit. |
@@ -485,7 +489,7 @@ A phase rebuilds if: hash differs from stored, upstream phase was rebuilt, Docke
 
 **Container-liveness predicate.** `--gc`'s dead-owner-container lister (`_sandy_dead_owner_containers_list`) reuses the daemon-mode D6/D9 rule verbatim: *the container is truth only with a LIVE inner tmux session.* One `docker ps -a --filter 'name=^/sandy-'` enumerates every candidate; classification is a **two-pass** walk over the captured output, because a proxy sidecar's liveness is a function of its *paired agent's* liveness, which is only known once every agent has been classified. Agent-vs-proxy is decided by **image**, never by name prefix — a workspace whose sanitized basename happens to be `proxy` produces a container literally named `sandy-proxy-<hash>` running a real agent image, and a name-prefix test would misclassify it as a proxy sidecar (a real pre-release regression, fixed before 1.3.0 shipped).
 
-**Pass 1 — every AGENT container** (any recognized sandy image other than `sandy-proxy`: `sandy-base`, `sandy-claude-code`, `sandy-gemini-cli`, `sandy-codex`, `sandy-opencode`, `sandy-full`, `sandy-project-*`, `sandy-skills*`; the image-name gate is best-effort and deliberately name-based rather than label-based so it works retroactively against containers a pre-1.3.0 sandy started):
+**Pass 1 — every AGENT container** (any recognized sandy image other than `sandy-proxy`: `sandy-base`, `sandy-claude-code`, `sandy-gemini-cli`, `sandy-codex`, `sandy-opencode`, `sandy-grok`, `sandy-full`, `sandy-project-*`, `sandy-skills*`; the image-name gate is best-effort and deliberately name-based rather than label-based so it works retroactively against containers a pre-1.3.0 sandy started):
 
 1. **`sandy.daemon=true` labeled**: not running → dead, reap. Running → probe `docker exec -u "$(id -u)" <cid> tmux has-session -t sandy`, retried **5x with a 1s sleep** between attempts (mirroring `--start`'s own D6 idempotency retry) so a container whose supervisor hasn't created the tmux session yet isn't misread as a zombie mid-startup: success → **ALIVE, KEPT — never touch, regardless of `sandy.daemon_pid` liveness** (the D9 defense: a rebooted host can resurrect a `--restart unless-stopped` container on a dead supervisor pid while the session itself is healthy); failure (all 5 attempts) → zombie, reap. The retry is gated to the destructive reap path only (`_sandy_dead_owner_containers_list reap`) — `--print-state`'s `orphaned_containers` COUNT uses a single probe, since a momentarily-stale count is informational and a 5s stall per mid-startup container would defeat its cheap-poll budget.
 2. **Not daemon-labeled** (a foreground/interactive agent container): SANDBOX_NAME is derived by stripping *only* the `sandy-` prefix (never `sandy-proxy-` — this branch only ever sees a real agent image). Not running → dead, reap. Running → check `$SANDY_HOME/sandboxes/.<name>.lock/pid`: missing/non-numeric/dead → dead-owner, reap; live pid → KEPT, skip. (Reuses the same `lock_holder_alive` liveness test `--print-state`/the #14 workspace mutex use.)
@@ -943,7 +947,7 @@ Sandy wraps Claude Code in a tmux session:
 
 ### Multi-Agent Mode (comma-separated `SANDY_AGENT`)
 
-When `SANDY_AGENT` contains more than one agent (e.g. `claude,gemini`, `claude,codex`, `claude,gemini,codex,opencode`, or the alias `all`), the user-setup script creates a tmux session with one pane per agent, in the order listed. Layouts: 2 agents → side-by-side; 3 agents → left half + top-right + bottom-right; 4 agents → 2×2 grid (top-left, top-right, bottom-right, bottom-left in pane-index order). The launch logic is factored into per-agent helpers (`build_claude_cmd()`, `build_gemini_cmd()`, `build_codex_cmd()`, `build_opencode_cmd()`) so single-agent and multi-agent paths share the same command construction. Each pane is an independent process; exiting one leaves the others running.
+When `SANDY_AGENT` contains more than one agent (e.g. `claude,gemini`, `claude,codex`, `claude,gemini,codex,opencode`, or the alias `all`), the user-setup script creates a tmux session with one pane per agent, in the order listed. Layouts: 2 agents → side-by-side; 3 agents → left half + top-right + bottom-right; 4 agents → 2×2 grid (top-left, top-right, bottom-right, bottom-left in pane-index order). The launch logic is factored into per-agent helpers (`build_claude_cmd()`, `build_gemini_cmd()`, `build_codex_cmd()`, `build_opencode_cmd()`, `build_grok_cmd()`) so single-agent and multi-agent paths share the same command construction. Each pane is an independent process; exiting one leaves the others running.
 
 The previous `both` alias (= `claude,gemini`) was removed in `v0.12` once the comma-separated syntax supported every combination. Using it now exits early with an error message pointing at the new syntax.
 

--- a/sandy
+++ b/sandy
@@ -44,6 +44,7 @@ SANDY_PRIVILEGED_KEYS=(
     CLAUDE_CODE_OAUTH_TOKEN
     GEMINI_API_KEY
     OPENAI_API_KEY
+    XAI_API_KEY
     GOOGLE_API_KEY
     CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS
     SANDY_SCREENSHOT_DIR
@@ -90,6 +91,8 @@ SANDY_PASSIVE_KEYS=(
     SANDY_CODEX_AUTH
     OPENCODE_MODEL
     SANDY_OPENCODE_AUTH
+    GROK_MODEL
+    SANDY_GROK_AUTH
     SANDY_TOOL_AUDIT
 )
 
@@ -637,6 +640,7 @@ ANTHROPIC_API_KEY|secret|||0.1.0|stable|Anthropic API key for Claude Code. Not r
 CLAUDE_CODE_OAUTH_TOKEN|secret|||0.7.0|stable|Claude Code OAuth token (alternative to ANTHROPIC_API_KEY).
 GEMINI_API_KEY|secret|||0.9.0|stable|Google API key for Gemini CLI.
 OPENAI_API_KEY|secret|||0.10.0|stable|OpenAI API key for Codex CLI.
+XAI_API_KEY|secret|||1.5.0|stable|xAI API key for Grok Build (docs.x.ai). Enables fully-headless auth (resolution: model.api_key > env_key > session token > XAI_API_KEY); alternative is an interactive 'grok login' OAuth session inside the container.
 GOOGLE_API_KEY|secret|||0.9.0|stable|Google API key for Vertex AI / ADC.
 CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS|bool|||0.1.0|experimental|Enable Claude Code experimental agent-teams feature.
 SANDY_AGENT|agent_combo|claude||0.9.0|stable|Agent(s) to launch. Comma-separated (e.g. 'claude,codex'). 'all' = 'claude,gemini,codex,opencode'.
@@ -666,6 +670,8 @@ CODEX_MODEL|string|||0.10.0|stable|Codex model override.
 SANDY_CODEX_AUTH|enum:auto,api_key,oauth|auto||0.10.0|stable|Codex credential probe strategy.
 OPENCODE_MODEL|string|||0.12.0|stable|OpenCode model override (provider/model format, e.g. 'anthropic/claude-sonnet-4').
 SANDY_OPENCODE_AUTH|enum:auto,api_key,oauth|auto||0.12.0|stable|OpenCode credential probe strategy.
+GROK_MODEL|string|||1.5.0|stable|Grok Build model override (passed as -m; default grok-4.5).
+SANDY_GROK_AUTH|enum:auto,api_key,oauth|auto||1.5.0|stable|Grok Build credential probe strategy.
 TELEGRAM_BOT_TOKEN|secret|||0.7.6|stable|Telegram bot token for the channel relay.
 TELEGRAM_ALLOWED_SENDERS|string|||0.7.6|stable|Comma-separated Telegram user IDs allowed to send messages.
 DISCORD_BOT_TOKEN|secret|||0.7.6|stable|Discord bot token for the channel relay.
@@ -929,6 +935,12 @@ _sandy_emit_schema() {
     _json_kv name '"opencode"'; printf ','; _json_kv image '"sandy-opencode"'
     printf ','; _json_kv features '["local_llm_passthrough","provider_choice"]'
     printf ','; _json_kv credentials '{"probe_order":["provider_env_keys","host_auth_json"]}'
+    printf '}'
+    printf ','
+    printf '{'
+    _json_kv name '"grok"'; printf ','; _json_kv image '"sandy-grok"'
+    printf ','; _json_kv features '[]'
+    printf ','; _json_kv credentials '{"probe_order":["XAI_API_KEY","host_grok_session"]}'
     printf '}'
     printf ']'
 
@@ -1468,7 +1480,7 @@ ${_cname}"
             continue
         fi
         case "$_img_base" in
-            sandy-base|sandy-claude-code|sandy-gemini-cli|sandy-codex|sandy-opencode|sandy-full|sandy-project-*|sandy-skills*) : ;;
+            sandy-base|sandy-claude-code|sandy-gemini-cli|sandy-codex|sandy-opencode|sandy-grok|sandy-full|sandy-project-*|sandy-skills*) : ;;
             *) continue ;;
         esac
         _sbname="${_cname#sandy-}"
@@ -1601,9 +1613,9 @@ _sandy_emit_state() {
         # names below in original order keeps output byte-identical.
         local _ii_map=""   # newline-joined "name|id|created"
         _ii_map="$(docker image inspect \
-            sandy-base sandy-claude-code sandy-gemini-cli sandy-codex sandy-opencode sandy-full \
+            sandy-base sandy-claude-code sandy-gemini-cli sandy-codex sandy-opencode sandy-grok sandy-full \
             --format '{{index .RepoTags 0}}|{{.Id}}|{{.Created}}' 2>/dev/null || true)"
-        for img in sandy-base sandy-claude-code sandy-gemini-cli sandy-codex sandy-opencode sandy-full; do
+        for img in sandy-base sandy-claude-code sandy-gemini-cli sandy-codex sandy-opencode sandy-grok sandy-full; do
             # find the map line whose tag is "<img>:..." (strip the :tag)
             _ii_line="$(printf '%s\n' "$_ii_map" | awk -F'|' -v n="$img" \
                 '{t=$1; sub(/:[^:]*$/,"",t)} t==n {print $2"|"$3; exit}')"
@@ -2428,7 +2440,7 @@ Environment variables:
                      like "0" or "0,1" (requires NVIDIA Container Toolkit)
   SANDY_SKILL_PACKS  Comma-separated skill packs to install (e.g. "gstack")
   SANDY_AGENT        AI agent(s): "claude" (default), "gemini", "codex",
-                     "opencode", or comma-separated combo
+                     "opencode", "grok", or comma-separated combo (max 4)
                      (e.g. "claude,gemini,codex"). Alias: "all" = all four.
   GEMINI_API_KEY     Google API key for Gemini CLI (SANDY_AGENT=gemini only)
   GEMINI_MODEL       Gemini model override (SANDY_AGENT=gemini only)
@@ -2866,6 +2878,34 @@ ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 DOCKERFILE
 }
 
+generate_dockerfile_grok() {
+    cat > "$SANDY_HOME/Dockerfile.grok.new" <<DOCKERFILE
+FROM ${BASE_IMAGE_NAME}
+# Install the Grok Build CLI (xAI). The installer drops a prebuilt grok binary
+# somewhere on PATH; relocate it to /usr/local/bin because /home/claude is a
+# tmpfs at runtime, so a home-dir install would vanish. The build has network.
+RUN set -eu; \\
+    curl -fsSL https://x.ai/cli/install.sh | bash; \\
+    _gb="\$(command -v grok || true)"; \\
+    [ -n "\$_gb" ] || _gb="\$(find /root /usr/local /opt /home -maxdepth 5 -type f -name grok 2>/dev/null | head -1)"; \\
+    [ -n "\$_gb" ] || { echo 'sandy: grok binary not found after install' >&2; exit 1; }; \\
+    [ "\$_gb" = /usr/local/bin/grok ] || install -m 0755 "\$_gb" /usr/local/bin/grok; \\
+    mkdir -p /opt/grok; \\
+    grok --version 2>/dev/null | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+' > /opt/grok/.version || true
+# synthkit dependencies (WeasyPrint needs pango/cairo/gdk-pixbuf)
+RUN apt-get update && apt-get install -y --no-install-recommends \\
+    libpango1.0-dev libcairo2-dev libgdk-pixbuf2.0-dev \\
+ && rm -rf /var/lib/apt/lists/*
+RUN UV_TOOL_DIR=/opt/uv-tools UV_TOOL_BIN_DIR=/usr/local/bin uv tool install --python-preference system synthkit
+COPY tmux.conf /etc/tmux.conf
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY user-setup.sh /usr/local/bin/user-setup.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/user-setup.sh
+WORKDIR /workspace
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+DOCKERFILE
+}
+
 generate_dockerfile_opencode() {
     cat > "$SANDY_HOME/Dockerfile.opencode.new" <<DOCKERFILE
 FROM ${BASE_IMAGE_NAME}
@@ -2891,7 +2931,7 @@ DOCKERFILE
 generate_dockerfile_full() {
     cat > "$SANDY_HOME/Dockerfile.full.new" <<DOCKERFILE
 FROM ${BASE_IMAGE_NAME}
-# Install all four agents. Used for any multi-agent combo.
+# Install all five agents. Used for any multi-agent combo.
 # Claude Code
 RUN HOME=/home/claude su -s /bin/bash claude -c "curl -fsSL https://claude.ai/install.sh | bash" \\
  && cp -L /home/claude/.local/bin/claude /usr/local/bin/claude \\
@@ -2910,6 +2950,15 @@ RUN npm install -g @openai/codex \\
 RUN npm install -g opencode-ai \\
  && mkdir -p /opt/opencode \\
  && { opencode --version 2>/dev/null | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+' > /opt/opencode/.version || true; }
+# Grok Build (xAI) — installer drops a binary on PATH; relocate off the tmpfs home.
+RUN set -eu; \\
+    curl -fsSL https://x.ai/cli/install.sh | bash; \\
+    _gb="\$(command -v grok || true)"; \\
+    [ -n "\$_gb" ] || _gb="\$(find /root /usr/local /opt /home -maxdepth 5 -type f -name grok 2>/dev/null | head -1)"; \\
+    [ -n "\$_gb" ] || { echo 'sandy: grok binary not found after install' >&2; exit 1; }; \\
+    [ "\$_gb" = /usr/local/bin/grok ] || install -m 0755 "\$_gb" /usr/local/bin/grok; \\
+    mkdir -p /opt/grok; \\
+    grok --version 2>/dev/null | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+' > /opt/grok/.version || true
 # synthkit dependencies (WeasyPrint needs pango/cairo/gdk-pixbuf)
 RUN apt-get update && apt-get install -y --no-install-recommends \\
     libpango1.0-dev libcairo2-dev libgdk-pixbuf2.0-dev \\
@@ -3835,6 +3884,16 @@ _sandy_translate_args() {
                     *)                   out+=" $(printf '%q' "$arg")" ;;
                 esac
                 ;;
+            grok)
+                # grok's headless is a print flag + positional prompt (like
+                # Claude, not a subcommand): -p / --print / --prompt → grok's -p.
+                # --continue / -c dropped (headless-resume support unknown).
+                case "$arg" in
+                    -p|--print|--prompt) out+=" -p" ;;
+                    --continue|-c)       : ;;
+                    *)                   out+=" $(printf '%q' "$arg")" ;;
+                esac
+                ;;
         esac
     done
     printf '%s' "$out"
@@ -3985,6 +4044,20 @@ build_opencode_cmd() {
     _sandy_wrap_cmd_exit_pause "OpenCode" "$cmd"
 }
 
+build_grok_cmd() {
+    # Headless: `grok -p "PROMPT"` (a print flag + positional prompt, like Claude —
+    # not a subcommand like codex/opencode). Interactive: `grok` (TUI).
+    # --no-auto-update: the rootfs is read-only so grok can't self-update anyway;
+    # this skips its background update check (docs.x.ai headless-scripting). Model
+    # via -m (default grok-4.5); auth from XAI_API_KEY (forwarded by the launcher).
+    local cmd="grok --no-auto-update"
+    if [ -n "${GROK_MODEL:-}" ]; then
+        cmd+=" -m $(printf "%q" "$GROK_MODEL")"
+    fi
+    cmd+="$(_sandy_translate_args grok "$@")"
+    _sandy_wrap_cmd_exit_pause "Grok" "$cmd"
+}
+
 build_gemini_cmd() {
     # Gemini CLI has its own per-tool sandbox; disable it since sandy provides
     # whole-session isolation via Docker. GEMINI_SANDBOX=false is the documented
@@ -4017,6 +4090,7 @@ _sandy_build_agent_cmd() {
         gemini)   build_gemini_cmd   "${@:2}" ;;
         codex)    build_codex_cmd    "${@:2}" ;;
         opencode) build_opencode_cmd "${@:2}" ;;
+        grok)     build_grok_cmd     "${@:2}" ;;
     esac
 }
 
@@ -4424,6 +4498,7 @@ ensure_agent_dockerfile() {
             gemini)   generate_dockerfile_gemini;   f="Dockerfile.gemini"   ;;
             codex)    generate_dockerfile_codex;    f="Dockerfile.codex"    ;;
             opencode) generate_dockerfile_opencode; f="Dockerfile.opencode" ;;
+            grok)     generate_dockerfile_grok;     f="Dockerfile.grok"     ;;
             *)        generate_dockerfile;          f="Dockerfile"          ;;
         esac
     fi
@@ -5690,8 +5765,8 @@ IFS=',' read -ra _SANDY_AGENTS <<< "$SANDY_AGENT"
 _SANDY_AGENT_COUNT="${#_SANDY_AGENTS[@]}"
 for _a in "${_SANDY_AGENTS[@]}"; do
     case "$_a" in
-        claude|gemini|codex|opencode) ;;
-        *) echo "[sandy] ERROR: Invalid agent '$_a' in SANDY_AGENT='$SANDY_AGENT' (valid: claude, gemini, codex, opencode, or comma-separated combo)" >&2; exit 1 ;;
+        claude|gemini|codex|opencode|grok) ;;
+        *) echo "[sandy] ERROR: Invalid agent '$_a' in SANDY_AGENT='$SANDY_AGENT' (valid: claude, gemini, codex, opencode, grok, or comma-separated combo)" >&2; exit 1 ;;
     esac
 done
 # Detect duplicates
@@ -5701,6 +5776,13 @@ if [ "$_SANDY_AGENT_COUNT" -ge 2 ]; then
         case ",$_seen," in *,"$_a",*) echo "[sandy] ERROR: Duplicate agent '$_a' in SANDY_AGENT='$SANDY_AGENT'" >&2; exit 1 ;; esac
         _seen="$_seen,$_a"
     done
+fi
+# Cap at 4: the multi-agent tmux layout tops out at a 2x2 grid (agents 2/3/4 are
+# splits of the first pane). With five selectable agents now (grok added), reject
+# a 5+ combo up front rather than silently dropping the extra agents' panes.
+if [ "$_SANDY_AGENT_COUNT" -gt 4 ]; then
+    echo "[sandy] ERROR: at most 4 agents per session (the multi-agent layout is a 2x2 grid); got $_SANDY_AGENT_COUNT in SANDY_AGENT='$SANDY_AGENT'" >&2
+    exit 1
 fi
 _SANDY_IS_MULTI=false
 [ "$_SANDY_AGENT_COUNT" -gt 1 ] && _SANDY_IS_MULTI=true
@@ -5713,6 +5795,7 @@ else
         gemini)   IMAGE_NAME="sandy-gemini-cli" ;;
         codex)    IMAGE_NAME="sandy-codex" ;;
         opencode) IMAGE_NAME="sandy-opencode" ;;
+        grok)     IMAGE_NAME="sandy-grok" ;;
     esac
 fi
 # Helper: check if a specific agent is in the resolved agent list
@@ -5755,6 +5838,9 @@ else
         opencode)
             DOCKERFILE_PATH="$SANDY_HOME/Dockerfile.opencode"
             BUILD_HASH_FILE_NAME=".build_hash_opencode" ;;
+        grok)
+            DOCKERFILE_PATH="$SANDY_HOME/Dockerfile.grok"
+            BUILD_HASH_FILE_NAME=".build_hash_grok" ;;
         *)
             DOCKERFILE_PATH="$SANDY_HOME/Dockerfile"
             BUILD_HASH_FILE_NAME=".build_hash" ;;
@@ -5832,7 +5918,7 @@ fi
 
 # Apply --rebuild flag (must come after ensure_build_files creates SANDY_HOME)
 if [ "$SANDY_REBUILD" = true ]; then
-    rm -f "$SANDY_HOME/.base_build_hash" "$SANDY_HOME/.build_hash" "$SANDY_HOME/.build_hash_gemini" "$SANDY_HOME/.build_hash_codex" "$SANDY_HOME/.build_hash_opencode" "$SANDY_HOME/.build_hash_full" "$SANDY_HOME/.build_hash_proxy" "$SANDY_HOME/.skills_build_hash"
+    rm -f "$SANDY_HOME/.base_build_hash" "$SANDY_HOME/.build_hash" "$SANDY_HOME/.build_hash_gemini" "$SANDY_HOME/.build_hash_codex" "$SANDY_HOME/.build_hash_opencode" "$SANDY_HOME/.build_hash_grok" "$SANDY_HOME/.build_hash_full" "$SANDY_HOME/.build_hash_proxy" "$SANDY_HOME/.skills_build_hash"
     info "Build cache cleared. Images will be rebuilt."
 fi
 
@@ -6632,6 +6718,12 @@ fi
 # Ensure per-agent config dirs exist so bind mounts always land on real dirs.
 if _sandy_agent_has claude; then
     mkdir -p "$SANDBOX_DIR/claude"
+fi
+if _sandy_agent_has grok; then
+    # Sandbox dir for grok's ~/.grok (config.toml + any `grok login` session).
+    # Auth normally rides XAI_API_KEY (env); host ~/.grok OAuth-session seeding is
+    # a possible follow-up (kept out of the persisted mount for now).
+    mkdir -p "$SANDBOX_DIR/grok"
 fi
 if _sandy_agent_has codex; then
     mkdir -p "$SANDBOX_DIR/codex"
@@ -8194,6 +8286,12 @@ if _sandy_agent_has codex; then
         RUN_FLAGS+=(-v "$CODEX_CRED_TMPDIR/auth.json:/home/claude/.codex/auth.json:ro")
     fi
 fi
+if _sandy_agent_has grok; then
+    # grok stores config.toml (+ any `grok login` session) under ~/.grok; the
+    # sandbox mount persists it rw across launches. Auth itself rides XAI_API_KEY
+    # (env, forwarded above) so — unlike codex — no ephemeral :ro auth mount.
+    RUN_FLAGS+=(-v "$SANDBOX_DIR/grok:/home/claude/.grok")
+fi
 if _sandy_agent_has opencode; then
     RUN_FLAGS+=(-v "$SANDBOX_DIR/opencode/config:/home/claude/.config/opencode")
     RUN_FLAGS+=(-v "$SANDBOX_DIR/opencode/share:/home/claude/.local/share/opencode")
@@ -8834,6 +8932,22 @@ if _sandy_agent_has opencode; then
     fi
     if [ -n "${SANDY_LOCAL_LLM_HOST:-}" ]; then
         RUN_FLAGS+=(-e "SANDY_LOCAL_LLM_HOST=$SANDY_LOCAL_LLM_HOST")
+    fi
+fi
+if _sandy_agent_has grok; then
+    # Grok Build authenticates fully headless from XAI_API_KEY (docs.x.ai:
+    # resolution is model.api_key > model.env_key > session token > XAI_API_KEY),
+    # so — unlike codex — there's no auth.json to materialize; just forward the
+    # env var. An interactive `grok login` OAuth session persists in the ~/.grok
+    # sandbox mount (below). GROK_MODEL feeds the `-m` flag; default is grok-4.5.
+    if [ -n "${XAI_API_KEY:-}" ]; then
+        _sandy_add_secret_env XAI_API_KEY "$XAI_API_KEY"
+    fi
+    if [ -n "${GROK_MODEL:-}" ]; then
+        RUN_FLAGS+=(-e "GROK_MODEL=$GROK_MODEL")
+    fi
+    if [ -n "${SANDY_GROK_AUTH:-}" ]; then
+        RUN_FLAGS+=(-e "SANDY_GROK_AUTH=$SANDY_GROK_AUTH")
     fi
 fi
 

--- a/templates/user-setup.sh.tmpl
+++ b/templates/user-setup.sh.tmpl
@@ -678,6 +678,16 @@ _sandy_translate_args() {
                     *)                   out+=" $(printf '%q' "$arg")" ;;
                 esac
                 ;;
+            grok)
+                # grok's headless is a print flag + positional prompt (like
+                # Claude, not a subcommand): -p / --print / --prompt → grok's -p.
+                # --continue / -c dropped (headless-resume support unknown).
+                case "$arg" in
+                    -p|--print|--prompt) out+=" -p" ;;
+                    --continue|-c)       : ;;
+                    *)                   out+=" $(printf '%q' "$arg")" ;;
+                esac
+                ;;
         esac
     done
     printf '%s' "$out"
@@ -828,6 +838,20 @@ build_opencode_cmd() {
     _sandy_wrap_cmd_exit_pause "OpenCode" "$cmd"
 }
 
+build_grok_cmd() {
+    # Headless: `grok -p "PROMPT"` (a print flag + positional prompt, like Claude —
+    # not a subcommand like codex/opencode). Interactive: `grok` (TUI).
+    # --no-auto-update: the rootfs is read-only so grok can't self-update anyway;
+    # this skips its background update check (docs.x.ai headless-scripting). Model
+    # via -m (default grok-4.5); auth from XAI_API_KEY (forwarded by the launcher).
+    local cmd="grok --no-auto-update"
+    if [ -n "${GROK_MODEL:-}" ]; then
+        cmd+=" -m $(printf "%q" "$GROK_MODEL")"
+    fi
+    cmd+="$(_sandy_translate_args grok "$@")"
+    _sandy_wrap_cmd_exit_pause "Grok" "$cmd"
+}
+
 build_gemini_cmd() {
     # Gemini CLI has its own per-tool sandbox; disable it since sandy provides
     # whole-session isolation via Docker. GEMINI_SANDBOX=false is the documented
@@ -860,6 +884,7 @@ _sandy_build_agent_cmd() {
         gemini)   build_gemini_cmd   "${@:2}" ;;
         codex)    build_codex_cmd    "${@:2}" ;;
         opencode) build_opencode_cmd "${@:2}" ;;
+        grok)     build_grok_cmd     "${@:2}" ;;
     esac
 }
 

--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -49,6 +49,7 @@
 #   GEMINI_API_KEY          │ §5-6: gemini build/headless/container
 #   + ~/.gemini/tokens.json │ + §10: OAuth detection
 #   ANTHROPIC_API_KEY       │ §7: claude headless regression
+#   XAI_API_KEY             │ §12b: grok build/headless (§12c builds w/o creds)
 #   Any two of the above    │ + §8: cross-agent switching regression
 #
 # ── Notes ──────────────────────────────────────────────────────────────
@@ -404,6 +405,7 @@ HAS_GEMINI_API_KEY=false
 HAS_GEMINI_OAUTH=false
 HAS_CLAUDE=false
 HAS_OPENCODE_OAUTH=false
+HAS_XAI_API_KEY=false
 
 # Source credentials from ~/.sandy/.secrets if it exists (same file sandy reads).
 # This is a safe KEY=VALUE file (no shell code) — sandy validates it against an
@@ -419,11 +421,13 @@ if [ -f "$HOME/.sandy/.secrets" ]; then
             GEMINI_API_KEY)            [ -z "${GEMINI_API_KEY:-}" ]            && export GEMINI_API_KEY="$_val" ;;
             ANTHROPIC_API_KEY)         [ -z "${ANTHROPIC_API_KEY:-}" ]         && export ANTHROPIC_API_KEY="$_val" ;;
             CLAUDE_CODE_OAUTH_TOKEN)   [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]   && export CLAUDE_CODE_OAUTH_TOKEN="$_val" ;;
+            XAI_API_KEY)               [ -z "${XAI_API_KEY:-}" ]               && export XAI_API_KEY="$_val" ;;
         esac
     done < "$HOME/.sandy/.secrets"
 fi
 
 [ -n "${OPENAI_API_KEY:-}" ] && HAS_OPENAI_API_KEY=true
+[ -n "${XAI_API_KEY:-}" ] && HAS_XAI_API_KEY=true
 [ -f "$HOME/.codex/auth.json" ] && HAS_CODEX_OAUTH=true
 [ -f "$HOME/.local/share/opencode/auth.json" ] && HAS_OPENCODE_OAUTH=true
 [ -n "${GEMINI_API_KEY:-}" ] && HAS_GEMINI_API_KEY=true
@@ -447,11 +451,15 @@ info "Sandy Integration Tests"
 HAS_CODEX=false
 HAS_GEMINI=false
 HAS_OPENCODE=false
+HAS_GROK=false
 [ "$HAS_OPENAI_API_KEY" = true ] || [ "$HAS_CODEX_OAUTH" = true ] && HAS_CODEX=true
 [ "$HAS_GEMINI_API_KEY" = true ] || [ "$HAS_GEMINI_OAUTH" = true ] || [ "$HAS_GEMINI_ADC" = true ] && HAS_GEMINI=true
 # OpenCode auth: either the OAuth file, or any provider API key the user has set
 # (opencode reads ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY natively).
 [ "$HAS_OPENCODE_OAUTH" = true ] || [ -n "${ANTHROPIC_API_KEY:-}" ] || [ -n "${OPENAI_API_KEY:-}" ] || [ -n "${GEMINI_API_KEY:-}" ] && HAS_OPENCODE=true
+# Grok auth: XAI_API_KEY (grok's headless-native path; host ~/.grok OAuth seeding
+# is deferred, so the env/secrets key is the only gated auth for these tests).
+[ "$HAS_XAI_API_KEY" = true ] && HAS_GROK=true
 
 _label() { if [ "$1" = true ]; then printf "\033[0;32m✓\033[0m"; else printf "\033[0;31m✗\033[0m"; fi; }
 _auth_detail() {
@@ -471,10 +479,11 @@ echo "  Codex:    $(_label $HAS_CODEX)  $(_auth_detail "api-key=$HAS_OPENAI_API_
 echo "  Gemini:   $(_label $HAS_GEMINI)  $(_auth_detail "api-key=$HAS_GEMINI_API_KEY" "oauth=$HAS_GEMINI_OAUTH" "adc=$HAS_GEMINI_ADC")"
 echo "  Claude:   $(_label $HAS_CLAUDE)  $(_auth_detail "api-key=$([ -n "${ANTHROPIC_API_KEY:-}" ] && echo true || echo false)" "oauth-token=$([ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && echo true || echo false)" "credentials-file=$([ -f "$HOME/.claude/.credentials.json" ] && echo true || echo false)")"
 echo "  OpenCode: $(_label $HAS_OPENCODE)  $(_auth_detail "anthropic-key=$([ -n "${ANTHROPIC_API_KEY:-}" ] && echo true || echo false)" "openai-key=$HAS_OPENAI_API_KEY" "gemini-key=$HAS_GEMINI_API_KEY" "oauth=$HAS_OPENCODE_OAUTH")"
+echo "  Grok:     $(_label $HAS_GROK)  $(_auth_detail "api-key=$HAS_XAI_API_KEY")"
 echo ""
 
 _all_true=true
-for _v in $HAS_CODEX $HAS_GEMINI $HAS_CLAUDE $HAS_OPENCODE; do
+for _v in $HAS_CODEX $HAS_GEMINI $HAS_CLAUDE $HAS_OPENCODE $HAS_GROK; do
     [ "$_v" = true ] || _all_true=false
 done
 
@@ -513,6 +522,11 @@ if [ "$_all_true" = false ]; then
             echo "    export OPENAI_API_KEY=\"sk-...\""
             echo "    export GEMINI_API_KEY=\"AI...\""
             echo "    opencode auth login                     # OAuth → ~/.local/share/opencode/auth.json"
+            echo ""
+        fi
+        if [ "$HAS_GROK" = false ]; then
+            echo "  GROK (xAI Grok Build):"
+            echo "    export XAI_API_KEY=\"xai-...\"           # https://console.x.ai"
             echo ""
         fi
         echo "  To persist credentials, add them to ~/.sandy/.secrets (one per line):"
@@ -1192,6 +1206,90 @@ if ensure_image_built opencode sandy-opencode; then
     fi
 else
     fail "opencode in-container checks (failed to build sandy-opencode image)"
+fi
+
+# ============================================================
+info "12b. Grok — image build and headless response"
+# ============================================================
+
+if [ "$HAS_GROK" = true ]; then
+    setup_project grok "integ-grok"
+
+    # grok's headless-native auth is XAI_API_KEY, forwarded by the launcher.
+    _out="$(run_sandy_headless "XAI_API_KEY=$XAI_API_KEY" -- -p "reply with exactly one word: pineapple")"
+
+    if docker image inspect sandy-grok &>/dev/null; then
+        pass "sandy-grok image exists after build"
+    else
+        fail "sandy-grok image exists after build"
+    fi
+
+    if [ -n "$_out" ] && ! echo "$_out" | grep -qi "error.*api.key\|unauthorized\|no.*credential\|XAI_API_KEY.*not"; then
+        pass "grok headless responds without auth errors"
+    else
+        fail "grok headless responds without auth errors"
+        echo "    (output: $(echo "$_out" | head -6 | tr '\n' ' '))" >&2
+    fi
+
+    resolve_sandbox
+
+    if [ -n "$SANDBOX_DIR" ] && [ -d "$SANDBOX_DIR" ]; then
+        # Sandbox layout: a grok/ subdir mounting at ~/.grok
+        if [ -d "$SANDBOX_DIR/grok" ]; then
+            pass "grok/ dir exists in sandbox"
+        else
+            fail "grok/ dir exists in sandbox"
+        fi
+        # No cross-agent contamination
+        if [ ! -d "$SANDBOX_DIR/claude" ] && [ ! -d "$SANDBOX_DIR/codex" ] && [ ! -d "$SANDBOX_DIR/gemini" ] && [ ! -d "$SANDBOX_DIR/opencode" ]; then
+            pass "grok sandbox has no claude/, codex/, gemini/, or opencode/ subdirs"
+        else
+            fail "grok sandbox has no claude/, codex/, gemini/, or opencode/ subdirs"
+        fi
+    else
+        fail "sandbox directory exists for grok project"
+    fi
+else
+    skip "grok image build and headless (no XAI_API_KEY)"
+fi
+
+# ============================================================
+info "12c. Grok — in-container checks (sandy-grok image)"
+# ============================================================
+# Credentials-free: this is the authoritative check that grok's prebuilt-binary
+# install path (curl https://x.ai/cli/install.sh | bash, NOT npm) actually
+# resolves and lands a grok binary — the one link the static suite can't verify.
+
+if ensure_image_built grok sandy-grok; then
+    _ver="$(docker run --rm --entrypoint bash sandy-grok -c 'grok --version 2>/dev/null || echo MISSING')"
+    if [ "$_ver" != "MISSING" ] && [ -n "$_ver" ]; then
+        pass "grok binary on PATH in sandy-grok image (v$_ver)"
+    else
+        fail "grok binary on PATH in sandy-grok image"
+    fi
+
+    _vfile="$(docker run --rm --entrypoint cat sandy-grok /opt/grok/.version 2>/dev/null || true)"
+    if [ -n "$_vfile" ]; then
+        pass "/opt/grok/.version populated ($_vfile)"
+    else
+        fail "/opt/grok/.version populated"
+    fi
+
+    _node="$(docker run --rm --entrypoint bash sandy-grok -c 'node --version 2>/dev/null || echo MISSING')"
+    if [ "$_node" != "MISSING" ]; then
+        pass "node available in sandy-grok image ($_node)"
+    else
+        fail "node available in sandy-grok image"
+    fi
+
+    _sk="$(docker run --rm --entrypoint bash sandy-grok -c 'command -v md2pdf && echo OK || echo MISSING')"
+    if echo "$_sk" | grep -q OK; then
+        pass "synthkit (md2pdf) available in sandy-grok image"
+    else
+        fail "synthkit (md2pdf) available in sandy-grok image"
+    fi
+else
+    fail "grok in-container checks (failed to build sandy-grok image)"
 fi
 
 # ============================================================

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -3522,12 +3522,12 @@ d=json.load(open(sys.argv[1]))
 for k in d[\"config\"][\"privileged_keys\"]:
     assert k.get(\"passive_approval_required\") is True, k[\"name\"]
 " "$1"' -- "$_SCHEMA_JSON"
-check "schema lists all four agents (claude,gemini,codex,opencode)" \
+check "schema lists all five agents (claude,gemini,codex,opencode,grok)" \
     bash -c 'python3 -c "
 import json,sys
 d=json.load(open(sys.argv[1]))
 names=[a[\"name\"] for a in d[\"agents\"]]
-assert set(names)=={\"claude\",\"gemini\",\"codex\",\"opencode\"}
+assert set(names)=={\"claude\",\"gemini\",\"codex\",\"opencode\",\"grok\"}
 " "$1"' -- "$_SCHEMA_JSON"
 check "schema cli_flags includes --print-schema" \
     bash -c 'python3 -c "

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1657,6 +1657,12 @@ _helper_script_test "_sandy_translate_args opencode drops -p (positional-prompt 
     'out=$(_sandy_translate_args opencode -p hello); ! echo "$out" | grep -qE "(^| )-p( |$)"'
 _helper_script_test "_sandy_translate_args opencode drops --continue" \
     'out=$(_sandy_translate_args opencode --continue); ! echo "$out" | grep -q -- "--continue"'
+_helper_script_test "_sandy_translate_args grok maps -p to grok's -p print flag (Claude-shaped, not dropped)" \
+    'out=$(_sandy_translate_args grok -p hello); echo "$out" | grep -qE "(^| )-p( |\$)"'
+_helper_script_test "_sandy_translate_args grok maps --print/--prompt to -p" \
+    'out=$(_sandy_translate_args grok --print hello); echo "$out" | grep -qE "(^| )-p( |\$)"'
+_helper_script_test "_sandy_translate_args grok drops --continue" \
+    'out=$(_sandy_translate_args grok --continue); ! echo "$out" | grep -q -- "--continue"'
 _helper_script_test "_sandy_translate_args printf-quotes positional args with spaces" \
     'out=$(_sandy_translate_args claude "hello world"); echo "$out" | grep -qE "hello.+world"'
 
@@ -1669,6 +1675,43 @@ _helper_script_test "_sandy_wrap_cmd_exit_pause interactive verbose includes age
     '_sandy_is_headless=false SANDY_VERBOSE=1 out=$(_sandy_wrap_cmd_exit_pause "OpenCode" "opencode"); echo "$out" | grep -q "OpenCode exited"'
 _helper_script_test "_sandy_wrap_cmd_exit_pause interactive verbose escapes \$_exit for later eval" \
     '_sandy_is_headless=false SANDY_VERBOSE=1 out=$(_sandy_wrap_cmd_exit_pause Foo "claude"); echo "$out" | grep -qF "\$_exit"'
+
+# ============================================================
+info "28a2. Grok Build support — selection, image, credentials, headless (#99)"
+# ============================================================
+_GROK_S="$SANDY_SCRIPT"
+check "grok is a valid agent (validation case)" \
+    grep -q 'claude|gemini|codex|opencode|grok)' "$_GROK_S"
+check "invalid-agent error lists grok" \
+    grep -q "valid: claude, gemini, codex, opencode, grok" "$_GROK_S"
+check "grok maps to the sandy-grok image" \
+    grep -q 'grok)     IMAGE_NAME="sandy-grok"' "$_GROK_S"
+check "DOCKERFILE_PATH case has grok" \
+    grep -qF 'DOCKERFILE_PATH="$SANDY_HOME/Dockerfile.grok"' "$_GROK_S"
+check "generate_dockerfile_grok exists + installs via x.ai install.sh + relocates the binary" \
+    bash -c 'grep -q "^generate_dockerfile_grok()" "$1" && grep -q "x.ai/cli/install.sh" "$1" && grep -q "install -m 0755" "$1"' -- "$_GROK_S"
+check "sandy-full installs grok too" \
+    bash -c 'awk "/^generate_dockerfile_full\(\)/,/^}\$/" "$1" | grep -q "x.ai/cli/install.sh"' -- "$_GROK_S"
+check "build_grok_cmd exists + uses --no-auto-update" \
+    bash -c 'grep -q "^build_grok_cmd()" "$1" && grep -q "grok --no-auto-update" "$1"' -- "$_GROK_S"
+check "dispatch calls build_grok_cmd for grok" \
+    grep -q 'grok)     build_grok_cmd' "$_GROK_S"
+check "XAI_API_KEY forwarded for grok" \
+    grep -q '_sandy_add_secret_env XAI_API_KEY' "$_GROK_S"
+check "grok config dir mounts at ~/.grok" \
+    grep -qF 'SANDBOX_DIR/grok:/home/claude/.grok' "$_GROK_S"
+check "sandy-grok in the image-name lists (GC + rebuild loop)" \
+    bash -c 'grep -q "sandy-opencode|sandy-grok|sandy-full" "$1" && grep -q "sandy-opencode sandy-grok sandy-full" "$1"' -- "$_GROK_S"
+check ".build_hash_grok cleared on --rebuild" \
+    grep -q '.build_hash_grok' "$_GROK_S"
+check "max-4 agent guard present" \
+    grep -q 'at most 4 agents per session' "$_GROK_S"
+check "XAI_API_KEY is a privileged key" \
+    bash -c 'sed -n "/^SANDY_PRIVILEGED_KEYS=(/,/^)/p" "$1" | grep -qx "    XAI_API_KEY"' -- "$_GROK_S"
+check "GROK_MODEL + SANDY_GROK_AUTH are passive keys" \
+    bash -c 'b="$(sed -n "/^SANDY_PASSIVE_KEYS=(/,/^)/p" "$1")"; echo "$b" | grep -qx "    GROK_MODEL" && echo "$b" | grep -qx "    SANDY_GROK_AUTH"' -- "$_GROK_S"
+check "--print-schema agents[] includes grok (sandy-grok)" \
+    bash -c 'bash "$1" --print-schema 2>/dev/null | grep -q "\"sandy-grok\""' -- "$_GROK_S"
 
 # ============================================================
 info "28b. Codex CLI support — agent helpers and flag translation"


### PR DESCRIPTION
Closes #99.

Adds **Grok Build** (xai-org's `grok` CLI) as a fifth first-class agent, selectable via `SANDY_AGENT=grok` and usable in any comma-separated multi-agent combo.

## What changed

- **Selection** — `grok` accepted by validation and the invalid-agent error list; maps to the `sandy-grok` image.
- **Image build** — `generate_dockerfile_grok()` installs the **prebuilt** CLI via `curl -fsSL https://x.ai/cli/install.sh | bash` (grok ships a binary, *not* an npm package) and relocates it to `/usr/local/bin/grok`. The same install block is folded into `generate_dockerfile_full()` (the multi-agent image). `DOCKERFILE_PATH`, `ensure_agent_dockerfile`, the GC/reclaim image-name lists, and the `--rebuild` `.build_hash_grok` cleanup all learn `grok`.
- **Credentials** — `XAI_API_KEY` env-forward (privileged tier); `GROK_MODEL` and `SANDY_GROK_AUTH` passive. A `grok/` sandbox subdir mounts at `~/.grok`.
- **Headless** — `_sandy_translate_args` maps `-p`/`--print`/`--prompt` → grok's `-p`, drops `--continue`/`-c` (no known headless-resume flag). `build_grok_cmd` launches `grok --no-auto-update` (read-only-rootfs analog), adding `-m $GROK_MODEL` when set.
- **Multi-agent cap** — a hard **max-4 guard** rejects a 5th agent, since the tmux layout tops out at a 2x2 grid. `all` remains the 4-agent alias (grok is opt-in).
- **Introspection / docs** — `--print-schema` `agents[]` gains a `grok` entry; `--help` lists it and notes the cap. CLAUDE.md / README / SPECIFICATION updated; the mirrored `templates/user-setup.sh.tmpl` and the autogen config-key tables regenerated.

## Tests

`test/run-tests.sh` §28a2 adds 16 static checks (selection, image map, Dockerfile generator + install.sh + relocate, sandy-full fold-in, `build_grok_cmd` + `--no-auto-update`, dispatch, XAI forward, mount, image lists, `.build_hash_grok`, max-4 guard, XAI privileged tier, GROK passive tiers, schema entry) plus 3 translator cases. All pass; `--print-schema` stays valid JSON with `schema_version: 1` (additive).

## Deliberate scope decisions

- No `_check_grok_update` — grok exposes no version API the way Claude Code does. Image refresh is `sandy --rebuild`; a monthly-freshness nudge is a possible follow-up.
- Host `~/.grok` OAuth seeding (the `grok login` browser flow) is deferred — v1 is `XAI_API_KEY`-driven, which is grok's headless-native path.

## Runtime verification the maintainer must run (needs Docker + an xAI subscription/`XAI_API_KEY` — I can't build images or run grok from inside sandy)

- [ ] `SANDY_AGENT=grok sandy --rebuild` builds `sandy-base` → `sandy-grok` cleanly; `docker run --rm sandy-grok grok --version` prints a version.
- [ ] `XAI_API_KEY=... SANDY_AGENT=grok sandy -p "say hi"` returns a completion (headless auth via forwarded env).
- [ ] `SANDY_AGENT=grok sandy` — interactive TUI comes up clean, no first-run update/login prompt blocking.
- [ ] `SANDY_AGENT=claude,grok sandy --start` — both panes render their agent (pane-topology harness / `@sandy_pane_agent`).
- [ ] `SANDY_AGENT=claude,gemini,codex,opencode,grok sandy` errors with the max-4 guard message.
- [ ] Full `bash test/run-tests.sh` on a Docker host (§28a2 + the rest) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)