### PR TITLE
fix(grok): relocate the real binary, not the installer's symlink (#99)

### DIFF
--- a/sandy
+++ b/sandy
@@ -2881,15 +2881,19 @@ DOCKERFILE
 generate_dockerfile_grok() {
     cat > "$SANDY_HOME/Dockerfile.grok.new" <<DOCKERFILE
 FROM ${BASE_IMAGE_NAME}
-# Install the Grok Build CLI (xAI). The installer drops a prebuilt grok binary
-# somewhere on PATH; relocate it to /usr/local/bin because /home/claude is a
-# tmpfs at runtime, so a home-dir install would vanish. The build has network.
+# Install the Grok Build CLI (xAI). The installer downloads the real binary to
+# ~/.grok/downloads/grok-<platform> and leaves only SYMLINKS (grok, agent) in
+# ~/.grok/bin — all under the home dir, which is a tmpfs at runtime, so nothing
+# there survives. Resolve the symlink to the real binary and relocate THAT to
+# /usr/local/bin (a plain find -type f -name grok misses it: the symlink isn't
+# -type f and the real file is named grok-<platform>). The build has network.
 RUN set -eu; \\
+    export HOME=/root; \\
     curl -fsSL https://x.ai/cli/install.sh | bash; \\
-    _gb="\$(command -v grok || true)"; \\
-    [ -n "\$_gb" ] || _gb="\$(find /root /usr/local /opt /home -maxdepth 5 -type f -name grok 2>/dev/null | head -1)"; \\
-    [ -n "\$_gb" ] || { echo 'sandy: grok binary not found after install' >&2; exit 1; }; \\
-    [ "\$_gb" = /usr/local/bin/grok ] || install -m 0755 "\$_gb" /usr/local/bin/grok; \\
+    _real="\$(readlink -f "\$HOME/.grok/bin/grok" 2>/dev/null || true)"; \\
+    { [ -n "\$_real" ] && [ -f "\$_real" ]; } || _real="\$(find "\$HOME/.grok/downloads" -maxdepth 1 -type f -name 'grok-*' 2>/dev/null | head -1)"; \\
+    { [ -n "\$_real" ] && [ -f "\$_real" ]; } || { echo 'sandy: grok binary not found after install' >&2; exit 1; }; \\
+    install -m 0755 "\$_real" /usr/local/bin/grok; \\
     mkdir -p /opt/grok; \\
     grok --version 2>/dev/null | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+' > /opt/grok/.version || true
 # synthkit dependencies (WeasyPrint needs pango/cairo/gdk-pixbuf)
@@ -2950,13 +2954,15 @@ RUN npm install -g @openai/codex \\
 RUN npm install -g opencode-ai \\
  && mkdir -p /opt/opencode \\
  && { opencode --version 2>/dev/null | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+' > /opt/opencode/.version || true; }
-# Grok Build (xAI) — installer drops a binary on PATH; relocate off the tmpfs home.
+# Grok Build (xAI) — installer downloads the real binary to ~/.grok/downloads and
+# leaves only symlinks in ~/.grok/bin (tmpfs home at runtime); resolve + relocate.
 RUN set -eu; \\
+    export HOME=/root; \\
     curl -fsSL https://x.ai/cli/install.sh | bash; \\
-    _gb="\$(command -v grok || true)"; \\
-    [ -n "\$_gb" ] || _gb="\$(find /root /usr/local /opt /home -maxdepth 5 -type f -name grok 2>/dev/null | head -1)"; \\
-    [ -n "\$_gb" ] || { echo 'sandy: grok binary not found after install' >&2; exit 1; }; \\
-    [ "\$_gb" = /usr/local/bin/grok ] || install -m 0755 "\$_gb" /usr/local/bin/grok; \\
+    _real="\$(readlink -f "\$HOME/.grok/bin/grok" 2>/dev/null || true)"; \\
+    { [ -n "\$_real" ] && [ -f "\$_real" ]; } || _real="\$(find "\$HOME/.grok/downloads" -maxdepth 1 -type f -name 'grok-*' 2>/dev/null | head -1)"; \\
+    { [ -n "\$_real" ] && [ -f "\$_real" ]; } || { echo 'sandy: grok binary not found after install' >&2; exit 1; }; \\
+    install -m 0755 "\$_real" /usr/local/bin/grok; \\
     mkdir -p /opt/grok; \\
     grok --version 2>/dev/null | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+' > /opt/grok/.version || true
 # synthkit dependencies (WeasyPrint needs pango/cairo/gdk-pixbuf)


### PR DESCRIPTION
`sandy --agent grok` drops straight into `bash: grok: command not found` — the grok binary never lands on PATH in the image.

## Root cause
`x.ai/cli/install.sh` (source-verified) downloads the **real** binary to `~/.grok/downloads/grok-<platform>` and leaves only **symlinks** (`grok`, `agent`) in `~/.grok/bin`. The install `RUN` searched with `find … -type f -name grok`, which matches **neither** the symlink (not `-type f`) **nor** the real file (named `grok-<platform>`, not `grok`). And both dirs are under the home dir — a **tmpfs at runtime** — so even the symlink wouldn't survive to the running container.

## Fix
Both install sites (`generate_dockerfile_grok` → `sandy-grok`, and the grok block in `generate_dockerfile_full` → `sandy-full`):
- `readlink -f ~/.grok/bin/grok` resolves the symlink to the real binary;
- fall back to `find ~/.grok/downloads -maxdepth 1 -type f -name 'grok-*'`;
- `install -m 0755` **that** into `/usr/local/bin/grok`;
- `export HOME=/root` so the installer's paths are deterministic during build.
Also removes a backtick from a comment that was executing at heredoc-generation time (the §49 trap).

## ⚠️ Verification needed (I can't build images from inside sandy)
Please validate the resolve-and-relocate logic against `sandy-base` **before merge** — this runs the installer and exercises the exact fix, proving the relocated binary actually runs:

```sh
docker run --rm --entrypoint bash sandy-base -c '
  export HOME=/root
  curl -fsSL https://x.ai/cli/install.sh | bash >/dev/null 2>&1
  echo "--- bin (symlinks) ---";     ls -la ~/.grok/bin 2>&1
  echo "--- downloads (real) ---";   ls -la ~/.grok/downloads 2>&1
  real="$(readlink -f ~/.grok/bin/grok)"; echo "resolved: $real"
  install -m0755 "$real" /usr/local/bin/grok
  echo "--- does it run relocated? ---"; grok --version 2>&1 | head -3
'
```

If `grok --version` prints a version at the end, the fix is correct → then:
```sh
sandy --agent grok --rebuild        # rebuild sandy-grok with the fix
```

Two residual unknowns the above confirms: (1) the exact symlink path (`~/.grok/bin/grok`), and (2) that the relocated binary is self-contained (no dependency on `~/.grok` siblings). If (2) fails, the fix needs to copy more than just the binary — the diagnostic output will show it.

Once the integration suite runs in CI (#106), `§12c` would catch this class automatically — it builds `sandy-grok` and asserts `grok --version` in the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)