### PR TITLE
fix(print-state): don't double-strip the sandbox name for a `sandy`-named workspace

### DIFF
--- a/sandy
+++ b/sandy
@@ -992,8 +992,19 @@ _sandy_emit_container_daemon_fields() {
     if [ -n "$_csession" ]; then
         _sandbox="$_csession"
     else
-        _sandbox="${_cname#sandy-proxy-}"
-        _sandbox="${_sandbox#sandy-}"
+        # `sandy-proxy-<sandbox>` and `sandy-<sandbox>` are MUTUALLY EXCLUSIVE
+        # forms — strip exactly ONE, not both in sequence. Stripping both let a
+        # proxy whose sandbox name itself begins with `sandy-` double-strip to the
+        # bare hash: a workspace literally named `sandy` → sandbox `sandy-<hash>`
+        # → proxy container `sandy-proxy-sandy-<hash>`, which the old
+        # `#sandy-proxy-` then `#sandy-` sequence collapsed to `<hash>` (dropping
+        # the sandbox's own `sandy-`). Test the proxy form FIRST — a proxy name
+        # also matches `sandy-*`. Mirrors the --gc lister's single-strip (#36).
+        case "$_cname" in
+            sandy-proxy-*) _sandbox="${_cname#sandy-proxy-}" ;;
+            sandy-*)       _sandbox="${_cname#sandy-}" ;;
+            *)             _sandbox="$_cname" ;;
+        esac
     fi
 
     if [ "$_cdaemon" = "true" ]; then

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -5076,6 +5076,11 @@ case "$1" in
         printf 'daemon123|sandy-bar-def456|sandy-full|2026-07-14T10:00:00Z|true|bar-def456|2026-07-14T12:00:00Z\n'
         printf 'broken789|sandy-baz-fee789|sandy-full|2026-07-14T11:00:00Z|true|baz-fee789|\n'
         printf 'bare456|sandy-foo-abc123|sandy-claude-code|2026-07-14T09:00:00Z|||\n'
+        # Regression: a proxy sidecar for a workspace literally named `sandy`
+        # (sandbox sandy-<hash> → container sandy-proxy-sandy-<hash>). No labels,
+        # so it takes the name-strip path; the fix must strip ONLY `sandy-proxy-`,
+        # never also the sandbox's own `sandy-` (which used to yield the bare hash).
+        printf 'proxy999|sandy-proxy-sandy-92aa9f98|sandy-proxy|2026-07-14T13:00:00Z|||\n'
         exit 0
         ;;
     exec)
@@ -5101,10 +5106,11 @@ import json, sys
 d = json.loads(sys.argv[1])
 rc = d['running_containers']
 assert rc is not None, 'running_containers is null'
-assert len(rc) == 3, rc
+assert len(rc) == 4, rc
 daemon = next(c for c in rc if c.get('sandbox') == 'bar-def456')
 broken = next(c for c in rc if c.get('sandbox') == 'baz-fee789')
 bare = next(c for c in rc if c.get('sandbox') == 'foo-abc123')
+proxy = next(c for c in rc if c.get('name') == 'sandy-proxy-sandy-92aa9f98')
 for c in rc:
     for f in ('id', 'name', 'image', 'started_at'):
         assert f in c, f + ' missing: ' + repr(c)
@@ -5114,6 +5120,11 @@ assert isinstance(daemon['attached_clients'], int), daemon
 assert broken['daemon'] is True, broken
 assert broken['attached_clients'] is None, broken
 assert bare['attached_clients'] is None, bare
+# Regression: the proxy of a `sandy`-named workspace must join to sandy-92aa9f98,
+# NOT the double-stripped bare hash '92aa9f98'. A proxy is not a daemon session.
+assert proxy['sandbox'] == 'sandy-92aa9f98', proxy
+assert proxy['daemon'] is False, proxy
+assert proxy['attached_clients'] is None, proxy
 # updated_at (#44): the label-bearing daemon carries the ISO timestamp; the
 # others are null (mutation: drop the sandy.updated_at label from the ps format
 # or the emit -> daemon['updated_at'] becomes null and this flips to FAIL).


### PR DESCRIPTION
## Symptom
`sandy --print-state` reported a wrong `sandbox` name for the proxy sidecar of a workspace **literally named `sandy`**:
```
{ "sandbox": "sandy-92aa9f98", "daemon": true,  ... }   # agent  — correct
{ "sandbox": "92aa9f98",       "daemon": false, ... }   # proxy  — WRONG (should be sandy-92aa9f98)
```
A `pka`-named workspace parsed fine, which masked the bug.

## Cause
For non-daemon-labeled rows (proxy sidecars, bare agents), the `sandbox` field was derived by stripping `sandy-proxy-` **then** `sandy-` in sequence (`sandy:995-996`). The two forms are mutually exclusive, so the second strip over-stripped when the sandbox name itself began with `sandy-`:
```
sandy-proxy-sandy-92aa9f98  →#sandy-proxy-→  sandy-92aa9f98  →#sandy-→  92aa9f98  ✗
```

## Fix
Strip exactly one prefix via a `case` (proxy form first — a proxy name also matches `sandy-*`), mirroring the `--gc` lister's existing single-strip (#36):
```sh
case "$_cname" in
    sandy-proxy-*) _sandbox="${_cname#sandy-proxy-}" ;;
    sandy-*)       _sandbox="${_cname#sandy-}" ;;
    *)             _sandbox="$_cname" ;;
esac
```
Proxies are **still listed** and still join to `sandboxes[]` (intended — the emit fn explicitly handles them); only the name derivation is corrected. Unit-verified across proxy/agent × sandy-named/pka-named, plus the daemon-session-label path.

## Not changed (by design)
Proxy sidecars still appear as their own `running_containers[]` entries — that's intended, and they're distinguishable via `image == "sandy-proxy"` (already emitted) or `daemon == false`. Only the name was wrong.

## Test
§68 gains a `sandy-proxy-sandy-92aa9f98` fixture row asserting `sandbox == "sandy-92aa9f98"` (not the bare hash) in both `--print-state` modes. No schema change (`schema_version` stays 1) — same fields, correct values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)