### PR TITLE
feat(git): leave .git/HEAD writable so `git switch` works in-container (#80)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,19 +75,25 @@ Since Claude Code running inside sandy cannot access Docker, running tests requi
 
 See `TESTING_PLAN.md` for manual validation steps that require interactive TUI sessions.
 
-## Git branch work inside sandy (`.git/HEAD` is read-only)
+## Git branch work inside sandy (`.git/HEAD` is writable as of 1.5.0, #80)
 
-sandy bind-mounts `.git/HEAD`, `.git/config`, and `.git/packed-refs` **read-only** (the protected-git-files anti-ref-spoofing defense — see "Protected Files"). One consequence for an agent working *inside* a sandy container: **you cannot switch branches.** `git commit` and `git reset` work (they update `refs/heads/<branch>`, a writable loose ref), but `git checkout <branch>` / `git switch` / `git checkout -b` fail with `error: unable to write symref for HEAD: Device or resource busy` — they rewrite the `.git/HEAD` symref, and you can't rename over a read-only bind-mounted file. Ref ops that rewrite `.git/packed-refs` (some branch deletes, `git gc`) fail the same way. This is the protection working as intended, not a bug (tracked as a known limitation / enhancement in issue #80).
+As of 1.5.0 (#80) sandy leaves `.git/HEAD` **read-write**, so `git switch <branch>` / `git checkout <branch>` / `git checkout -b` **work inside the container** — HEAD is a symref (which branch is checked out), not a host-code-execution vector. What stays bind-mounted **read-only** (the anti-ref-spoofing / hook-injection defense — see "Protected Files"): `.git/config`, `.gitmodules`, `.git/packed-refs`, `.git/hooks`, `.git/info`, and submodule gitdirs. Consequences of *those* staying `:ro`:
 
-**The HEAD-preserving pattern** — how to do feature-branch / PR work from inside sandy without switching HEAD:
+- `git commit`, `git reset`, `git switch`, `git checkout -b` — **work** (HEAD + loose refs are writable).
+- Repo-local `git config` writes (`.git/config`) — **fail** (`:ro`).
+- Deleting a **packed** branch ref, `git pack-refs`, `git gc` (repacking refs) — **fail** with `error: ... .git/packed-refs: Device or resource busy` (`:ro`). Loose-ref deletes still work.
 
-1. Make edits and `git commit` on the current branch (usually `main`).
-2. `git branch <feature> HEAD` (or `git branch -f <feature> HEAD` to reuse an existing ref) — labels a loose ref at that commit, never touches HEAD.
+**Session-end notice.** Because HEAD is writable, sandy snapshots the launch branch and, at session end, prints a yellow notice if HEAD was left on a different (or detached) branch — a host `git`/IDE would otherwise silently see a checkout you didn't choose. It's informational (the RCE vectors above stay `:ro`), and names the `git switch <launch-branch>` to restore.
+
+**The HEAD-preserving pattern** is still the way to land a PR from inside sandy — `main` is protected by a required-status-checks ruleset, so every change goes via PR + CI, never a direct push, and this flow keeps HEAD on `main` (and works even where `git gc`/packed-ref ops don't):
+
+1. Make edits and `git commit` on the current branch.
+2. `git branch -f <feature> HEAD` — labels a loose ref at that commit.
 3. `git push origin <feature>`.
-4. `git reset --hard origin/main` to move the current branch back (preserve any uncommitted `.gitignore`/untracked working changes across the reset).
+4. `git reset --hard origin/main` to move the branch back (preserve any uncommitted `.gitignore`/untracked changes across the reset).
 5. `gh pr create --head <feature> --base main`.
 
-Note `main` is protected by a branch ruleset (required status checks), so every change lands via a PR + CI, never a direct push to `main`.
+You can now also `git switch -c <feature>` and work on it directly; just note the session-end notice if you leave HEAD off `main`.
 
 ## Introspection Surface
 
@@ -614,7 +620,7 @@ Certain sensitive files and directories in the workspace are mounted read-only i
 
 **Protected files**: `.bashrc`, `.bash_profile`, `.zshrc`, `.zprofile`, `.profile`, `.gitconfig`, `.ripgreprc`, `.mcp.json`, `.envrc`, `.tool-versions`, `.mise.toml`, `.nvmrc`, `.node-version`, `.python-version`, `.ruby-version`, `.npmrc`, `.yarnrc`, `.yarnrc.yml`, `.pypirc`, `.netrc`, `.pre-commit-config.yaml`, `.claude/settings.json`, `.claude/settings.local.json`
 
-**Protected git files** (only mounted when present on host): `.git/config`, `.gitmodules`, `.git/HEAD`, `.git/packed-refs`
+**Protected git files** (only mounted when present on host): `.git/config`, `.gitmodules`, `.git/packed-refs`. (`.git/HEAD` is deliberately **not** here as of 1.5.0 (#80) — it's left read-write so `git switch`/`checkout` work in-container; a symref is not an RCE vector, and a HEAD left on an unexpected branch is caught by the session-end notice.)
 
 If `core.hooksPath` redirects git hooks to a non-default directory *inside* the workspace (e.g. `.githooks/`), sandy resolves it (`_sandy_extra_hooks_dir`) and mounts the **configured** hooks path `:ro` — it canonicalizes (`pwd -P`) only to verify containment, but locks the path git actually consults (not the resolved target) so a *symlinked* hooksPath can't be swapped for a fresh writable dir. Closes the gap where `.git/hooks/` is protected but hooks run from elsewhere. A `core.hooksPath` pointing outside the workspace, at the workspace root, or at an already-protected dir is left alone.
 

--- a/README.md
+++ b/README.md
@@ -742,7 +742,7 @@ The workspace is bind-mounted read/write so Claude can modify your project files
 | `.tool-versions`, `.mise.toml`, `.nvmrc`, `.node-version`, `.python-version`, `.ruby-version` | Blocks asdf/mise/nvm/pyenv/rbenv toolchain hijacking |
 | `.npmrc`, `.yarnrc`, `.yarnrc.yml`, `.pypirc`, `.netrc` | Blocks registry hijacking and credential exfiltration |
 | `.pre-commit-config.yaml` | Blocks pre-commit hook injection |
-| `.git/config`, `.gitmodules`, `.git/HEAD`, `.git/packed-refs` | Blocks git remote/hook path manipulation and ref spoofing |
+| `.git/config`, `.gitmodules`, `.git/packed-refs` | Blocks git remote/hook path manipulation and ref spoofing (`.git/HEAD` is left writable so `git switch` works in-container — #80) |
 | `.git/hooks/` | Blocks git hook injection (pre-commit, post-checkout, etc.) |
 | `.git/info/` | Blocks `.git/info/attributes` filter-driver injection |
 | `.git/modules/<sub>/{config,hooks,info}` | Same, for every submodule gitdir (walked recursively) |

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -764,8 +764,9 @@ Certain files and directories in the workspace are overlaid at container launch 
 |---|---|
 | `.git/config` | Remote path manipulation, `core.fsmonitor` injection, `core.hooksPath` redirect |
 | `.gitmodules` | Submodule URL hijacking |
-| `.git/HEAD` | Ref spoofing |
-| `.git/packed-refs` | Ref spoofing |
+| `.git/packed-refs` | Bulk ref spoofing / `git gc` repack |
+
+`.git/HEAD` is intentionally left read-write as of 1.5.0 (#80) so `git switch`/`checkout`/`checkout -b` work inside the container — a symref is not a host-code-execution vector. A HEAD left on an unexpected branch at session end is surfaced by a yellow notice (detection-not-prevention, mirroring the protected-dirs hybrid).
 
 **Directories (existence-gated — mounted read-only when present on host):**
 

--- a/sandy
+++ b/sandy
@@ -491,12 +491,30 @@ EOF
 # Top-level .git files that can trigger host-side code execution if tampered.
 # Separate list because gated on -f instead of -e.
 _sandy_protected_git_files() {
+    # NOTE: .git/HEAD is DELIBERATELY absent (#80). It is a symref whose only
+    # power is "which branch is checked out" — not an RCE vector (the host-code
+    # paths are .git/config filter-drivers/hooks, .git/info attributes,
+    # .git/hooks, .git/modules/*, .github/workflows — all still :ro). Leaving
+    # HEAD rw restores in-container `git switch`/`checkout`/`checkout -b`; a
+    # switch left on an unexpected branch is caught by the session-end notice
+    # (detection-not-prevention, mirroring the protected-dirs hybrid model).
+    # packed-refs STAYS :ro (bulk ref-spoofing / gc), so branch deletes of a
+    # packed ref and `git gc` still fail — an accepted, narrow limitation.
     cat <<'EOF'
 .git/config
 .gitmodules
-.git/HEAD
 .git/packed-refs
 EOF
+}
+
+# #80: pretty-print a snapshotted HEAD value for the session-end notice.
+#   refs/heads/<b> -> <b>;  detached:<sha> -> "detached HEAD (<sha>)".
+_sandy_head_display() {
+    case "$1" in
+        refs/heads/*) printf '%s' "${1#refs/heads/}" ;;
+        detached:*)   printf 'detached HEAD (%s)' "${1#detached:}" ;;
+        *)            printf '%s' "$1" ;;
+    esac
 }
 # Protected directories. .github/workflows is included by default; opt out via
 # SANDY_ALLOW_WORKFLOW_EDIT=1 in .sandy/config (passive tier).
@@ -7620,6 +7638,25 @@ cleanup() {
         fi
         rm -f "$SANDBOX_DIR/.protected-existed-at-launch"
     fi
+    # #80: .git/HEAD is rw in-container, so `git switch` works — but a switch that
+    # left HEAD on a different (or detached) branch means a host git/IDE now sees a
+    # checkout the user didn't choose. Surface it. Informational, NOT a security
+    # alarm: the RCE vectors (.git/config, hooks, info, packed-refs, .github/
+    # workflows) all stay :ro, so this is a surprise to correct, not an escape.
+    if [ -n "${SANDBOX_DIR:-}" ] && [ -f "$SANDBOX_DIR/.head-at-launch" ] \
+            && [ -n "${WORK_DIR:-}" ] && git -C "$WORK_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+        _head_launch="$(cat "$SANDBOX_DIR/.head-at-launch" 2>/dev/null)"
+        if _head_now="$(git -C "$WORK_DIR" symbolic-ref -q HEAD 2>/dev/null)"; then :; else
+            _head_now="detached:$(git -C "$WORK_DIR" rev-parse --short HEAD 2>/dev/null)"
+        fi
+        if [ -n "$_head_launch" ] && [ -n "$_head_now" ] && [ "$_head_now" != "$_head_launch" ]; then
+            printf "\n${YELLOW}[sandy]${NC} git HEAD was left on %s (launched on %s).\n" \
+                "$(_sandy_head_display "$_head_now")" "$(_sandy_head_display "$_head_launch")" >&2
+            printf "${YELLOW}[sandy]${NC} A host git/IDE will see that checkout — run \`git switch %s\` on the host to restore.\n" \
+                "$(_sandy_head_display "$_head_launch")" >&2
+        fi
+        rm -f "$SANDBOX_DIR/.head-at-launch"
+    fi
     # HF-incident Issue 4: session-end egress summary. When allowed-egress logging
     # is on, roll up proxy.log into "what hosts did the agent actually reach" — the
     # first question after a suspected prompt injection or a leaked-token scare.
@@ -7747,7 +7784,7 @@ fi
 # we exit in the gap, cleanup's existence-guarded blocks skip (no false
 # "protected paths appeared" warnings). SANDBOX_DIR is set (line 3594); the agent
 # does not start until docker run (well after 5906), so nothing is missed.
-rm -f "$SANDBOX_DIR/.session-created-stubs" "$SANDBOX_DIR/.protected-existed-at-launch" 2>/dev/null || true
+rm -f "$SANDBOX_DIR/.session-created-stubs" "$SANDBOX_DIR/.protected-existed-at-launch" "$SANDBOX_DIR/.head-at-launch" 2>/dev/null || true
 
 # Create the per-instance network(s) now that the cleanup trap is armed — in
 # proxy mode this also starts the dual-homed proxy container. Doing it post-trap
@@ -8629,6 +8666,17 @@ while IFS= read -r _pf; do
     [ -z "$_pf" ] && continue
     [ -e "$WORK_DIR/$_pf" ] && echo "$_pf" >> "$SANDBOX_DIR/.protected-existed-at-launch"
 done < <(_sandy_protected_files)
+
+# #80: .git/HEAD is rw in-container (git switch/checkout work). Snapshot the
+# launch branch so the session-end sweep can flag if HEAD was left elsewhere —
+# a host git/IDE would otherwise silently see a different checkout. Records the
+# symref (refs/heads/<branch>) or a detached marker. Skipped for non-git dirs.
+if git -C "$WORK_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+    if _head_snap="$(git -C "$WORK_DIR" symbolic-ref -q HEAD 2>/dev/null)"; then :; else
+        _head_snap="detached:$(git -C "$WORK_DIR" rev-parse --short HEAD 2>/dev/null)"
+    fi
+    [ -n "$_head_snap" ] && printf '%s\n' "$_head_snap" > "$SANDBOX_DIR/.head-at-launch"
+fi
 
 # --- Submodule gitdir protection (S1.1) ---
 # git stores each submodule's real gitdir under .git/modules/<path>/ (or under

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -2741,14 +2741,20 @@ sandy_run "echo '*.txt filter=evil' >> /workspace/.git/info/attributes 2>/dev/nu
     >/dev/null 2>&1 && WR_GITINFO=yes || WR_GITINFO=no
 check "cannot modify .git/info/attributes" test "$WR_GITINFO" = "no"
 
-# .git/HEAD and .git/packed-refs too
+# .git/HEAD is now WRITABLE (#80 — enables `git switch`/`checkout` in-session);
+# .git/packed-refs STAYS :ro (bulk ref-spoofing / gc protection).
 echo "ref: refs/heads/main" > "$TEST_PROJECT/.git/HEAD"
 echo "# pack-refs" > "$TEST_PROJECT/.git/packed-refs"
-chmod 0444 "$TEST_PROJECT/.git/HEAD" "$TEST_PROJECT/.git/packed-refs"  # :ro-drop backstop
+chmod 0644 "$TEST_PROJECT/.git/HEAD"            # rw — the container uid owns it
+chmod 0444 "$TEST_PROJECT/.git/packed-refs"     # :ro-drop backstop
 
-sandy_run "echo 'ref: refs/heads/pwned' > /workspace/.git/HEAD 2>/dev/null" \
+sandy_run "echo 'ref: refs/heads/feature' > /workspace/.git/HEAD 2>/dev/null" \
     >/dev/null 2>&1 && WR_HEAD=yes || WR_HEAD=no
-check "cannot overwrite .git/HEAD" test "$WR_HEAD" = "no"
+check ".git/HEAD is writable in-session (git switch works, #80)" test "$WR_HEAD" = "yes"
+
+sandy_run "echo 'deadbeef refs/heads/x' >> /workspace/.git/packed-refs 2>/dev/null" \
+    >/dev/null 2>&1 && WR_PACKED=yes || WR_PACKED=no
+check "cannot overwrite .git/packed-refs (stays :ro)" test "$WR_PACKED" = "no"
 
 rm -rf "$TEST_PROJECT/.git"
 
@@ -6630,6 +6636,34 @@ check "session-end points at the tool-audit trail" \
     bash -c 'grep -q "Tool-use audit trail" "$1"' -- "$_S81"
 check "SANDY_TOOL_AUDIT IS a real config key (has a _sandy_key_metadata row)" \
     bash -c 'awk "/^_sandy_key_metadata\(\)/,/^EOF\$/" "$1" | grep -q "^SANDY_TOOL_AUDIT|"' -- "$_S81"
+
+# ============================================================
+echo ""
+echo "§83: git HEAD rw for in-session switch (#80) — HEAD not :ro, packed-refs stays"
+# ============================================================
+# .git/HEAD is deliberately NOT in the protected :ro git-file list (#80): a symref
+# isn't an RCE vector, so leaving it rw restores in-container `git switch`. The
+# real host-code vectors (config/packed-refs/hooks/info/modules/workflows) stay
+# :ro. A session-end notice flags a HEAD left on an unexpected branch. The actual
+# rw-mount behavior is proven by the "cannot overwrite" Docker block (test 35);
+# these are the static structural guards + a pure-fn unit test.
+_S83="$SANDY_SCRIPT"
+check ".git/HEAD is NOT in the protected git-file :ro list (#80)" \
+    bash -c '! awk "/^_sandy_protected_git_files\(\)/,/^}/" "$1" | grep -qx ".git/HEAD"' -- "$_S83"
+check ".git/packed-refs STAYS in the protected git-file list (ref-spoofing/gc)" \
+    bash -c 'awk "/^_sandy_protected_git_files\(\)/,/^}/" "$1" | grep -qx ".git/packed-refs"' -- "$_S83"
+check ".git/config STAYS in the protected git-file list (hooks/filter-drivers)" \
+    bash -c 'awk "/^_sandy_protected_git_files\(\)/,/^}/" "$1" | grep -qx ".git/config"' -- "$_S83"
+check "launch snapshots HEAD to .head-at-launch" \
+    grep -q '\.head-at-launch' "$_S83"
+check "session-end notice compares HEAD (symbolic-ref) + surfaces the change" \
+    bash -c 'grep -q "_sandy_head_display" "$1" && grep -q "git HEAD was left on" "$1"' -- "$_S83"
+check ".head-at-launch is cleaned up unconditionally at session end" \
+    bash -c 'grep -q "rm -f .*\.head-at-launch" "$1"' -- "$_S83"
+# _sandy_head_display behavioral unit test (pure fn, no docker)
+_hd_out="$(bash -c 'source <(sed -n "/^_sandy_head_display()/,/^}/p" "$1"); _sandy_head_display refs/heads/feature/x; printf "|"; _sandy_head_display detached:abc1234' -- "$_S83")"
+check "_sandy_head_display: refs/heads/<b>→<b>; detached:<sha>→detached HEAD (<sha>)" \
+    test "$_hd_out" = "feature/x|detached HEAD (abc1234)"
 
 # ============================================================
 # Summary


### PR DESCRIPTION
Closes #80.

Working inside sandy, `git switch` / `checkout` / `checkout -b` failed with `unable to write symref for HEAD: Device or resource busy` — `.git/HEAD` was bind-mounted `:ro` as part of the protected-git-files defense. This restores in-session branch switching.

## Why it's safe to relax HEAD specifically
`.git/HEAD` is a **symref** — it records *which branch is checked out*, nothing more. It is **not** a host-code-execution vector. Every real RCE path from the red-team (ISOLATION_STRESS Finding 1) stays `:ro`:

| Vector | Status |
|---|---|
| `.git/config` (filter-drivers, `core.hooksPath`, remote manipulation) | **:ro** |
| `.git/hooks/`, submodule `.git/modules/*/hooks` | **:ro** |
| `.git/info/` (`attributes` filter-driver injection) | **:ro** |
| `.github/workflows/` | **:ro** |
| `.git/packed-refs` (bulk ref-spoofing / `git gc` repack) | **:ro** |
| `.git/HEAD` (symref) | **rw** ← this PR |

And `.git/index` + loose refs were **already** writable (`git commit`/`reset` always worked). A checkout only executes code via post-checkout **hooks**, which stay `:ro` — so an agent can't plant one. The residual is purely: an agent could leave HEAD on an unexpected branch → a host `git`/IDE sees a different checkout. That's a surprise, not an escape — and it's surfaced (below).

## Change (detection-not-prevention, mirroring the protected-*dirs* hybrid)
- Drop `.git/HEAD` from `_sandy_protected_git_files` → rw via the workspace mount.
- **Launch** snapshots the branch to `$SANDBOX_DIR/.head-at-launch`.
- **Session end** (`cleanup()`) prints a yellow notice if HEAD was left on a different/detached branch, naming `git switch <launch-branch>` to restore.
- `.git/packed-refs` stays `:ro` → packed-ref deletes and `git gc` still fail (accepted, narrow).

## What now works / still doesn't (in-container)
- ✅ `git switch`, `git checkout <branch>`, `git checkout -b`, `git commit`, `git reset`
- ❌ repo-local `git config` writes (`.git/config` `:ro`), packed-ref deletes / `git gc` (`.git/packed-refs` `:ro`)

## Tests
- Docker test 35 flips from *"cannot overwrite .git/HEAD"* → *".git/HEAD is writable (#80)"*, plus a new *"cannot overwrite .git/packed-refs"* assertion (proves packed-refs stays locked).
- New **§83** static block: HEAD absent from the `:ro` list; packed-refs/config stay; snapshot + notice wiring present; `_sandy_head_display` pure-fn unit test.
- `--print-schema` `protected_paths.git_files` drops `.git/HEAD` (`schema_version` stays 1).

Docs: CLAUDE.md git-branch section + protected-files list, README table, SPEC table.

## Verification note
The session-end notice *firing on a real switch* needs a live Docker session to observe; CI covers the rw-mount assertion (test 35) + all static guards. Quick manual check: `SANDY_AGENT=claude sandy` → `git switch -c tmp` inside → exit → expect the yellow "HEAD was left on tmp (launched on main)" notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)