### PR TITLE
chore: bump to 1.5.1-dev after cutting 1.5.0

### DIFF
--- a/sandy
+++ b/sandy
@@ -17,7 +17,7 @@ set -euo pipefail
 #   sandy --agent claude,gemini   Override agent selection for this run
 # =============================================================================
 
-SANDY_VERSION="1.5.0"
+SANDY_VERSION="1.5.1-dev"
 SANDY_COMMIT=""  # baked in by install.sh; empty = detect from git at runtime
 
 # Schema contract version for --print-schema / --print-state / --validate-config.


### PR DESCRIPTION
Post-release one-line version bump: `SANDY_VERSION` `1.5.0` → `1.5.1-dev`, per the CLAUDE.md versioning convention (so builds between 1.5.0 and the next release read as `1.5.1-dev`, not the released `1.5.0`). Mirrors `b87e52b` (1.4.1-dev after 1.4.0).

No behavior change. The update check strips `-dev`, so 1.5.1-dev users still compare as 1.5.1 and aren't nagged toward anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)