### PR TITLE
feat(claude): SANDY_EFFORT — pin Claude Code reasoning effort + record it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,8 +112,11 @@ On every launch (all egress modes), sandy writes `$SANDBOX_DIR/sandy-session.jso
 ```json
 { "schema": 1, "sandy_version": "...", "egress_mode": "off|permissive|strict",
   "workspace": "...", "host_uid": 501, "host_gid": 20,
-  "launched_at": "2026-06-11T12:00:00Z", "session_nonce": "<hex>" }
+  "launched_at": "2026-06-11T12:00:00Z", "session_nonce": "<hex>",
+  "effort": "high" }
 ```
+
+The `effort` field records the reasoning effort sandy **pinned** for the claude agent via `SANDY_EFFORT` (a JSON string like `"high"`), or `null` when sandy did not pin it (the agent ran at Claude Code's own default — currently `high`). This makes a run's effort provable after the fact rather than inferred from the ephemeral live statusline — the gap that let a red-team run silently at default effort. `schema` stays `1` (additive field).
 
 **Why it exists.** Env vars (`SANDY_EGRESS_MODE`, `SANDY_WORKSPACE`) are spoofable and the *absence* of a path proves nothing, so an in-container probe that distrusts env vars otherwise cannot tell a sandy container apart from the bare host VM — the `sandy-isolation-test` red-team hit exactly this, running in sandy `=0` on macOS/OrbStack but concluding it was not in sandy at all (uid `501`, OrbStack `mac` virtiofs mounts, and `CapBnd` retaining sandy's documented `--cap-add` set all read as "ordinary VM" without an anchor). Because the marker is a `:ro` bind mount, a committed workspace config cannot forge it.
 
@@ -147,7 +150,7 @@ Sandy loads configuration from four sources in order: `$HOME/.sandy/config`, `$H
 
 - **Passive-safe keys** (allowed from any source):
   <!-- BEGIN AUTOGEN:passive-key-list Run `test/regen-config-docs.sh` to update. -->
-  `SANDY_AGENT`, `SANDY_MODEL`, `SANDY_CPUS`, `SANDY_MEM`, `SANDY_GPU`, `SANDY_SKILL_PACKS`, `SANDY_CHANNELS`, `SANDY_CHANNEL_TARGET_PANE`, `SANDY_VERBOSE`, `SANDY_VENV_OVERLAY`, `SANDY_EGRESS_PROXY`, `SANDY_EGRESS_NO_ISOLATION`, `SANDY_EGRESS_STRICT`, `SANDY_EGRESS_LOG`, `SANDY_ALLOW_WORKFLOW_EDIT`, `CLAUDE_CODE_MAX_OUTPUT_TOKENS`, `GEMINI_MODEL`, `SANDY_GEMINI_AUTH`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, `GOOGLE_GENAI_USE_VERTEXAI`, `CODEX_MODEL`, `SANDY_CODEX_AUTH`, `OPENCODE_MODEL`, `SANDY_OPENCODE_AUTH`, `GROK_MODEL`, `SANDY_GROK_AUTH`, `SANDY_TOOL_AUDIT`
+  `SANDY_AGENT`, `SANDY_MODEL`, `SANDY_EFFORT`, `SANDY_CPUS`, `SANDY_MEM`, `SANDY_GPU`, `SANDY_SKILL_PACKS`, `SANDY_CHANNELS`, `SANDY_CHANNEL_TARGET_PANE`, `SANDY_VERBOSE`, `SANDY_VENV_OVERLAY`, `SANDY_EGRESS_PROXY`, `SANDY_EGRESS_NO_ISOLATION`, `SANDY_EGRESS_STRICT`, `SANDY_EGRESS_LOG`, `SANDY_ALLOW_WORKFLOW_EDIT`, `CLAUDE_CODE_MAX_OUTPUT_TOKENS`, `GEMINI_MODEL`, `SANDY_GEMINI_AUTH`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, `GOOGLE_GENAI_USE_VERTEXAI`, `CODEX_MODEL`, `SANDY_CODEX_AUTH`, `OPENCODE_MODEL`, `SANDY_OPENCODE_AUTH`, `GROK_MODEL`, `SANDY_GROK_AUTH`, `SANDY_TOOL_AUDIT`
   <!-- END AUTOGEN:passive-key-list -->
 
 - **Value-aware exceptions** (passive for values that *strengthen* isolation, approval-gated for values that *weaken* it): a few passive keys are not uniformly safe from a committed `.sandy/config` because one of their values lowers the sandbox's protection. `_sandy_passive_value_privileged()` routes those weakening values through the same per-workspace approval prompt as a privileged key, while leaving the strengthening/neutral values frictionless — *"a repo may make the sandbox tighter, never looser."* The gated values are: `SANDY_EGRESS_NO_ISOLATION=1` (proxy off), `SANDY_EGRESS_STRICT=0` (downgrade a host-set strict), `SANDY_EGRESS_PROXY=0` (deprecated alias for proxy-off), and `SANDY_ALLOW_WORKFLOW_EDIT=1` (drops `.github/workflows/` protection). This closes the hole where a committed workspace config could silently disable network isolation (threat-model adversary #2) — on macOS with the proxy off that is *total* loss of network isolation. Guarded by `run-tests.sh §65`.

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Only allowlisted `KEY=VALUE` lines are parsed (not sourced as a shell script). U
 |---|---|---|
 | `SANDY_AGENT` | `claude` | AI agent(s) to run. Single: `claude`, `gemini`, `codex`, `opencode`. Multi (comma-separated, 2–4 panes in tmux): e.g. `claude,gemini` or `claude,gemini,codex,opencode`. Alias: `all` = `claude,gemini,codex,opencode` |
 | `SANDY_MODEL` | `claude-opus-4-8` | Claude model to use (applies whenever `claude` is in `SANDY_AGENT`) |
+| `SANDY_EFFORT` | _(Claude Code default, currently `high`)_ | Reasoning effort for claude: `low`\|`medium`\|`high`\|`xhigh`\|`max`. Applied as `claude --effort`; recorded in `sandy-session.json` so a run's effort is provable |
 | `GEMINI_API_KEY` | (unset) | Google API key for Gemini CLI. Put in `.sandy/.secrets` |
 | `GEMINI_MODEL` | (unset) | Gemini model override |
 | `SANDY_GEMINI_AUTH` | `auto` | Force Gemini auth path: `auto`, `api_key`, `oauth`, or `adc` |

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -149,7 +149,7 @@ Each call to `_load_sandy_config` takes a `tier` argument (`privileged` or `pass
 
 **Passive-safe keys** (allowed from any source):
 <!-- BEGIN AUTOGEN:passive-key-list Run `test/regen-config-docs.sh` to update. -->
-`SANDY_AGENT`, `SANDY_MODEL`, `SANDY_CPUS`, `SANDY_MEM`, `SANDY_GPU`, `SANDY_SKILL_PACKS`, `SANDY_CHANNELS`, `SANDY_CHANNEL_TARGET_PANE`, `SANDY_VERBOSE`, `SANDY_VENV_OVERLAY`, `SANDY_EGRESS_PROXY`, `SANDY_EGRESS_NO_ISOLATION`, `SANDY_EGRESS_STRICT`, `SANDY_EGRESS_LOG`, `SANDY_ALLOW_WORKFLOW_EDIT`, `CLAUDE_CODE_MAX_OUTPUT_TOKENS`, `GEMINI_MODEL`, `SANDY_GEMINI_AUTH`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, `GOOGLE_GENAI_USE_VERTEXAI`, `CODEX_MODEL`, `SANDY_CODEX_AUTH`, `OPENCODE_MODEL`, `SANDY_OPENCODE_AUTH`, `GROK_MODEL`, `SANDY_GROK_AUTH`, `SANDY_TOOL_AUDIT`
+`SANDY_AGENT`, `SANDY_MODEL`, `SANDY_EFFORT`, `SANDY_CPUS`, `SANDY_MEM`, `SANDY_GPU`, `SANDY_SKILL_PACKS`, `SANDY_CHANNELS`, `SANDY_CHANNEL_TARGET_PANE`, `SANDY_VERBOSE`, `SANDY_VENV_OVERLAY`, `SANDY_EGRESS_PROXY`, `SANDY_EGRESS_NO_ISOLATION`, `SANDY_EGRESS_STRICT`, `SANDY_EGRESS_LOG`, `SANDY_ALLOW_WORKFLOW_EDIT`, `CLAUDE_CODE_MAX_OUTPUT_TOKENS`, `GEMINI_MODEL`, `SANDY_GEMINI_AUTH`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, `GOOGLE_GENAI_USE_VERTEXAI`, `CODEX_MODEL`, `SANDY_CODEX_AUTH`, `OPENCODE_MODEL`, `SANDY_OPENCODE_AUTH`, `GROK_MODEL`, `SANDY_GROK_AUTH`, `SANDY_TOOL_AUDIT`
 <!-- END AUTOGEN:passive-key-list -->
 
 ### `SANDY_ALLOW_LAN_HOSTS` Sanity Check
@@ -186,6 +186,7 @@ The table below is generated from `sandy --print-schema` (the `_sandy_key_metada
 | `DISCORD_ALLOWED_SENDERS` | privileged | unset | 0.7.6 | stable | Comma-separated Discord user IDs allowed to send messages. |
 | `SANDY_AGENT` | passive | `claude` | 0.9.0 | stable | Agent(s) to launch. Comma-separated (e.g. 'claude,codex'). 'all' = 'claude,gemini,codex,opencode'. |
 | `SANDY_MODEL` | passive | `claude-opus-4-8` | 0.1.0 | stable | Model ID for the Claude agent. |
+| `SANDY_EFFORT` | passive | unset | 1.6.0 | stable | Reasoning effort for the Claude agent (claude only), applied as 'claude --effort <level>'. Empty leaves Claude Code's own default (currently 'high'). Levels are model-dependent; an unsupported level falls back to the highest supported at or below it. Passive-safe (effort does not affect isolation). Recorded in sandy-session.json. |
 | `SANDY_CPUS` | passive | unset | 0.1.0 | stable | CPU limit for container (default: auto-detected). |
 | `SANDY_MEM` | passive | unset | 0.1.0 | stable | Memory limit for container (e.g. '8g'; default: auto-detected). |
 | `SANDY_GPU` | passive | unset | 0.7.5 | stable | GPU passthrough: 'all', or device IDs like '0' / '0,1'. |
@@ -1993,19 +1994,21 @@ Written to `$SANDBOX_DIR/sandy-session.json` on every launch and bind-mounted re
   "host_uid": 501,
   "host_gid": 20,
   "launched_at": "2026-06-11T12:00:00Z",
-  "session_nonce": "3f1c…"
+  "session_nonce": "3f1c…",
+  "effort": "high"
 }
 ```
 
 | Field | Meaning |
 |---|---|
-| `schema` | Marker schema version (currently `1`). |
+| `schema` | Marker schema version (currently `1`; the `effort` field is additive). |
 | `sandy_version` | Full version incl. git short hash (`sandy_full_version()`). |
 | `egress_mode` | Resolved posture: `off` \| `permissive` \| `strict`. |
 | `workspace` | Container-side workspace path (matches `SANDY_WORKSPACE`). |
 | `host_uid` / `host_gid` | Host identity sandy mapped the container to. |
 | `launched_at` | UTC ISO-8601 launch timestamp (host clock). |
 | `session_nonce` | Per-launch random hex; printed host-side under `SANDY_VERBOSE!=0` so an external verifier can match the file to a specific launch. Not exported as an env var. |
+| `effort` | Reasoning effort sandy PINNED for the claude agent via `SANDY_EFFORT` (JSON string, e.g. `"high"`), or `null` when sandy did not pin it (agent ran at Claude Code's own default). Makes a run's effort provable after teardown (1.6.0). |
 
 Because the file is a `:ro` bind mount, a committed workspace `.sandy/config` cannot forge it. In-container tooling (the `sandy-isolation-test` kit, CI) should assert on this file rather than on env vars or uid/cap heuristics.
 

--- a/sandy
+++ b/sandy
@@ -17,7 +17,7 @@ set -euo pipefail
 #   sandy --agent claude,gemini   Override agent selection for this run
 # =============================================================================
 
-SANDY_VERSION="1.5.1-dev"
+SANDY_VERSION="1.6.0-dev"
 SANDY_COMMIT=""  # baked in by install.sh; empty = detect from git at runtime
 
 # Schema contract version for --print-schema / --print-state / --validate-config.
@@ -68,6 +68,7 @@ SANDY_PRIVILEGED_KEYS=(
 SANDY_PASSIVE_KEYS=(
     SANDY_AGENT
     SANDY_MODEL
+    SANDY_EFFORT
     SANDY_CPUS
     SANDY_MEM
     SANDY_GPU
@@ -663,6 +664,7 @@ GOOGLE_API_KEY|secret|||0.9.0|stable|Google API key for Vertex AI / ADC.
 CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS|bool|||0.1.0|experimental|Enable Claude Code experimental agent-teams feature.
 SANDY_AGENT|agent_combo|claude||0.9.0|stable|Agent(s) to launch. Comma-separated (e.g. 'claude,codex'). 'all' = 'claude,gemini,codex,opencode'.
 SANDY_MODEL|string|claude-opus-4-8|^[a-zA-Z0-9._-]+$|0.1.0|stable|Model ID for the Claude agent.
+SANDY_EFFORT|enum:low,medium,high,xhigh,max|||1.6.0|stable|Reasoning effort for the Claude agent (claude only), applied as 'claude --effort <level>'. Empty leaves Claude Code's own default (currently 'high'). Levels are model-dependent; an unsupported level falls back to the highest supported at or below it. Passive-safe (effort does not affect isolation). Recorded in sandy-session.json.
 SANDY_CPUS|int|||0.1.0|stable|CPU limit for container (default: auto-detected).
 SANDY_MEM|string|||0.1.0|stable|Memory limit for container (e.g. '8g'; default: auto-detected).
 SANDY_GPU|string|||0.7.5|stable|GPU passthrough: 'all', or device IDs like '0' / '0,1'.
@@ -2453,6 +2455,8 @@ Usage:
 
 Environment variables:
   SANDY_MODEL        Model to use (default: claude-opus-4-8)
+  SANDY_EFFORT       Reasoning effort for claude: low|medium|high|xhigh|max
+                     (default: Claude Code's own, currently high)
   ANTHROPIC_API_KEY  API key (not needed with Claude Max / OAuth)
   SANDY_HOME         Sandy config directory (default: ~/.sandy)
   SANDY_SSH          Git SSH method: "token" (default) uses gh CLI token
@@ -3964,6 +3968,10 @@ _sandy_wrap_cmd_exit_pause() {
 
 build_claude_cmd() {
     local cmd="claude --model ${SANDY_MODEL:-claude-opus-4-8} --teammate-mode tmux"
+    # SANDY_EFFORT (#effort): pin Claude Code's reasoning effort so a run isn't
+    # silently at the model default. Validated host-side; a separate axis from
+    # --model. Empty → omit the flag → Claude Code's own default applies.
+    [ -n "${SANDY_EFFORT:-}" ] && cmd+=" --effort ${SANDY_EFFORT}"
     if [ "${SANDY_SKIP_PERMISSIONS:-true}" = "true" ]; then
         # Use --permission-mode (the documented modern flag) instead of the
         # legacy --dangerously-skip-permissions. Claude 2.1.x added runtime
@@ -8779,8 +8787,24 @@ if [ -n "$SANDY_MODEL" ] && ! [[ "$SANDY_MODEL" =~ ^[a-zA-Z0-9._-]+$ ]]; then
     error "Invalid SANDY_MODEL: $SANDY_MODEL (only alphanumeric, hyphens, dots, underscores allowed)"
     exit 1
 fi
+# Validate SANDY_EFFORT — Claude Code reasoning effort (claude only), applied as
+# `claude --effort <level>` in build_claude_cmd. Empty = Claude Code's own default
+# (currently 'high'). Cleared when claude isn't in the agent set so it's never a
+# meaningless forward. An invalid level fails loud rather than silently running at
+# default — the whole point is a provable, pinned effort.
+if _sandy_agent_has claude; then
+    if [ -n "${SANDY_EFFORT:-}" ]; then
+        case "$SANDY_EFFORT" in
+            low|medium|high|xhigh|max) ;;
+            *) error "Invalid SANDY_EFFORT: $SANDY_EFFORT (allowed: low, medium, high, xhigh, max)"; exit 1 ;;
+        esac
+    fi
+else
+    SANDY_EFFORT=""
+fi
 RUN_FLAGS+=(-e "SANDY_AGENT=$SANDY_AGENT")
 RUN_FLAGS+=(-e "SANDY_MODEL=$SANDY_MODEL")
+RUN_FLAGS+=(-e "SANDY_EFFORT=${SANDY_EFFORT:-}")
 RUN_FLAGS+=(-e "SANDY_SKIP_PERMISSIONS=${SANDY_SKIP_PERMISSIONS:-true}")
 RUN_FLAGS+=(-e "SANDY_NEW_SESSION=$SANDY_NEW_SESSION")
 RUN_FLAGS+=(-e "SANDY_REMOTE_CONTROL=$SANDY_REMOTE_CONTROL")
@@ -8816,9 +8840,14 @@ _sandy_session_nonce="$( (openssl rand -hex 16 2>/dev/null) \
     || (head -c 16 /dev/urandom 2>/dev/null | od -An -tx1 | tr -d ' \n') \
     || printf '%04x%04x%04x%04x' "$RANDOM" "$RANDOM" "$RANDOM" "$RANDOM" )"
 _sandy_session_file="$SANDBOX_DIR/sandy-session.json"
-printf '{\n  "schema": 1,\n  "sandy_version": "%s",\n  "egress_mode": "%s",\n  "workspace": "%s",\n  "host_uid": %s,\n  "host_gid": %s,\n  "launched_at": "%s",\n  "session_nonce": "%s"\n}\n' \
+# effort (#effort): the reasoning effort sandy PINNED for this run, so it's
+# provable after the fact rather than inferred from a live statusline. A JSON
+# string when set; null when sandy did not pin it (the agent ran at Claude
+# Code's own default). Only meaningful for the claude agent.
+_sandy_effort_json="null"; [ -n "${SANDY_EFFORT:-}" ] && _sandy_effort_json="\"$SANDY_EFFORT\""
+printf '{\n  "schema": 1,\n  "sandy_version": "%s",\n  "egress_mode": "%s",\n  "workspace": "%s",\n  "host_uid": %s,\n  "host_gid": %s,\n  "launched_at": "%s",\n  "session_nonce": "%s",\n  "effort": %s\n}\n' \
     "$(sandy_full_version)" "$_sandy_egress_mode" "$SANDY_WORKSPACE" \
-    "$(id -u)" "$(id -g)" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$_sandy_session_nonce" \
+    "$(id -u)" "$(id -g)" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$_sandy_session_nonce" "$_sandy_effort_json" \
     > "$_sandy_session_file"
 RUN_FLAGS+=(-v "$_sandy_session_file":/etc/sandy-session.json:ro)
 [ "${SANDY_VERBOSE:-0}" != "0" ] && info "Session marker /etc/sandy-session.json nonce=${_sandy_session_nonce} egress=${_sandy_egress_mode}"

--- a/templates/user-setup.sh.tmpl
+++ b/templates/user-setup.sh.tmpl
@@ -723,6 +723,10 @@ _sandy_wrap_cmd_exit_pause() {
 
 build_claude_cmd() {
     local cmd="claude --model ${SANDY_MODEL:-claude-opus-4-8} --teammate-mode tmux"
+    # SANDY_EFFORT (#effort): pin Claude Code's reasoning effort so a run isn't
+    # silently at the model default. Validated host-side; a separate axis from
+    # --model. Empty → omit the flag → Claude Code's own default applies.
+    [ -n "${SANDY_EFFORT:-}" ] && cmd+=" --effort ${SANDY_EFFORT}"
     if [ "${SANDY_SKIP_PERMISSIONS:-true}" = "true" ]; then
         # Use --permission-mode (the documented modern flag) instead of the
         # legacy --dangerously-skip-permissions. Claude 2.1.x added runtime

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -6666,6 +6666,39 @@ check "_sandy_head_display: refs/heads/<b>→<b>; detached:<sha>→detached HEAD
     test "$_hd_out" = "feature/x|detached HEAD (abc1234)"
 
 # ============================================================
+echo ""
+echo "§84: SANDY_EFFORT — pin Claude Code reasoning effort + record it (#effort)"
+# ============================================================
+# Plumbs a reasoning-effort knob to the inner claude (mirrors SANDY_MODEL):
+# passive key, validated host-side, applied as `claude --effort <level>`, and
+# recorded in sandy-session.json so a run's effort is provable after the fact.
+_S84="$SANDY_SCRIPT"
+check "SANDY_EFFORT is a passive-safe key (schema)" \
+    bash -c 'awk "/^SANDY_PASSIVE_KEYS=\(/,/^\)/" "$1" | grep -qx "    SANDY_EFFORT"' -- "$_S84"
+check "SANDY_EFFORT has a _sandy_key_metadata row (enum type)" \
+    bash -c 'awk "/^_sandy_key_metadata\(\)/,/^EOF\$/" "$1" | grep -q "^SANDY_EFFORT|enum:low,medium,high,xhigh,max|"' -- "$_S84"
+check "build_claude_cmd applies --effort, gated on SANDY_EFFORT" \
+    bash -c 'awk "/^build_claude_cmd\(\)/,/^}/" "$1" | grep -q "SANDY_EFFORT.*cmd+=.* --effort "' -- "$_S84"
+check "SANDY_EFFORT validated to low|medium|high|xhigh|max (fails loud on invalid)" \
+    bash -c 'grep -q "low|medium|high|xhigh|max)" "$1" && grep -q "Invalid SANDY_EFFORT" "$1"' -- "$_S84"
+check "SANDY_EFFORT forwarded into the container" \
+    grep -q 'RUN_FLAGS+=(-e "SANDY_EFFORT=' "$_S84"
+check "sandy-session.json records the pinned effort" \
+    bash -c 'grep -q "\"effort\": %s" "$1" && grep -q "_sandy_effort_json" "$1"' -- "$_S84"
+check "--help documents SANDY_EFFORT" \
+    bash -c 'grep -q "SANDY_EFFORT" "$1"' -- "$_S84"
+# --print-schema exposes it as a passive enum key
+check "--print-schema lists SANDY_EFFORT as a passive enum key" \
+    bash -c '"$1" --print-schema 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); e=[k for k in d[\"config\"][\"passive_keys\"] if k[\"name\"]==\"SANDY_EFFORT\"]; assert e and e[0][\"type\"]==\"enum\", e"' -- "$_S84"
+# marker effort field: string when set, null when unset (behavioral, no docker)
+_eff_mk() { local SANDY_EFFORT="$1" j="null"; [ -n "${SANDY_EFFORT:-}" ] && j="\"$SANDY_EFFORT\""; printf '{"effort":%s}\n' "$j"; }
+check "marker effort field: set→JSON string, unset→null" \
+    bash -c '
+      set="$(SANDY_EFFORT=high; j="null"; [ -n "${SANDY_EFFORT:-}" ] && j="\"$SANDY_EFFORT\""; printf "%s" "$j")"
+      unset="$(j="null"; printf "%s" "$j")"
+      [ "$set" = "\"high\"" ] && [ "$unset" = "null" ]'
+
+# ============================================================
 # Summary
 # ============================================================
 COMPLETED=true   # suppress the early-abort message in the EXIT trap


### PR DESCRIPTION
sandy plumbs the **model** (`SANDY_MODEL` → `claude --model`) but had **no knob for reasoning effort** — so an inner Claude Code run silently used the model default, and nothing recorded which effort it ran at (the statusLine reads `.effort.level` but is ephemeral/display-only). For a red-team, "was the boundary pushed at high effort or the default?" was unanswerable after the fact.

## What this adds — `SANDY_EFFORT`, mirroring `SANDY_MODEL`
- **Passive-safe config key** (effort doesn't affect isolation) + a `_sandy_key_metadata` row (`enum:low,medium,high,xhigh,max`) → shows up in `--print-schema`, `--help`, and the autogen config tables.
- **Validated host-side** — an invalid level *fails loud*, because the whole point is a **provable pin**, not a silent fallback. Cleared when `claude` isn't in the agent set.
- **Applied** in `build_claude_cmd` as `claude --effort <level>` (a separate axis from `--model`; empty omits the flag → Claude Code's own default).
- **Recorded** in `sandy-session.json` as `"effort"` — the pinned level when set, `null` when not (agent ran at the default). So a run's effort is **provable after teardown**, closing the "silently at default" gap. `schema` stays `1` (additive field).

## Claude Code effort surface (verified against docs)
Confirmed via `code.claude.com/docs` (`model-config.md` §Adjust effort level, `settings.md`): a real **`--effort` CLI flag** (used here), plus `CLAUDE_CODE_EFFORT_LEVEL` env and `effortLevel` in settings.json. Levels `low|medium|high|xhigh|max` (model-dependent; unsupported falls back to highest-at-or-below). **Default is `high`** on effort-supporting models — so, reassuringly, a default run wasn't as weak as feared, but pinning + recording it is still the right control.

## Scope / semver
- **claude-only** for v1 (codex/gemini/grok have their own effort concepts — a natural follow-up).
- New config key = **additive**, so `SANDY_VERSION` bumps `1.5.1-dev` → **`1.6.0-dev`** (next release is a minor, not a `1.5.1` patch). `schema_version` stays `1`.

## Tests / docs
- `run-tests.sh §84` — 9 checks (passive tier, metadata row, `--effort` application + gating, validation, forward, marker records effort, `--help`, schema enum, marker string-vs-null behavior).
- CLAUDE.md marker section, README config table, SPEC C.9 + the autogen tables; template mirror regenerated (`build_claude_cmd` lives in the user-setup heredoc). All regen `--check`s pass.

## Usage
```sh
# .sandy/config or env
SANDY_EFFORT=high        # or low|medium|xhigh|max
```
Then `cat /etc/sandy-session.json` in-container (or `$SANDBOX_DIR/sandy-session.json` host-side) shows `"effort": "high"` — provable per run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)