### PR TITLE
chore: bump to 1.6.1-dev after cutting 1.6.0

### DIFF
--- a/sandy
+++ b/sandy
@@ -17,7 +17,7 @@ set -euo pipefail
 #   sandy --agent claude,gemini   Override agent selection for this run
 # =============================================================================
 
-SANDY_VERSION="1.6.0"
+SANDY_VERSION="1.6.1-dev"
 SANDY_COMMIT=""  # baked in by install.sh; empty = detect from git at runtime
 
 # Schema contract version for --print-schema / --print-state / --validate-config.


### PR DESCRIPTION
Routine post-release housekeeping, per the CLAUDE.md versioning convention.

`SANDY_VERSION` 1.6.0 → **1.6.1-dev**. Two reasons this matters beyond bookkeeping:

1. The next release number stays **reserved** until it's actually cut.
2. `_sandy_proxy_ref` switches back to its `*-dev` case, so the proxy builds from the current branch rather than pinning the `v1.6.0` tag — which is what makes `./sandy` work on a feature branch before it merges.

v1.6.0 is tagged, published, and showing as **Latest**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)