### PR TITLE
ci(proxy): budget fuzzing by iterations, not wall-clock

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,12 +76,26 @@ jobs:
       # HF-incident Issue 1: the proxy parses attacker-influenced wire bytes, so
       # prove the parsers never panic under adversarial input — a short fuzz pass
       # per target (seed corpus + fuzzing). Any crasher fails the build.
+      #
+      # Budget is ITERATIONS (1000000x), not wall-clock. A duration budget makes
+      # the fuzzing coordinator derive a context deadline from it, and when that
+      # deadline fires while workers are still finishing, `go test` reports
+      # "--- FAIL: <target> ... context deadline exceeded" with NO crasher found
+      # and nothing written to testdata/ — a pure shutdown artifact that reds the
+      # build. It was already flaking main intermittently (FuzzExtractHTTPHost is
+      # the third and therefore most scheduling-pressured target). An iteration
+      # budget carries no deadline, so that failure mode cannot occur.
+      #
+      # 1000000x preserves the coverage the 30s budget was buying — CI was
+      # reaching ~1.45-1.65M execs per target in 30s — and is DETERMINISTIC:
+      # every runner now does the same work, instead of fast runners fuzzing more
+      # than slow ones. A real crasher still fails the build, which is the point.
       - name: go fuzz (short)
         working-directory: proxy
         run: |
           for t in FuzzExtractSNI FuzzParseServerName FuzzExtractHTTPHost; do
             echo "== fuzz $t =="
-            go test -run='^$' -fuzz="^${t}$" -fuzztime=30s .
+            go test -run='^$' -fuzz="^${t}$" -fuzztime=1000000x .
           done
 
       # HF-incident Issue 1: surface known vulnerabilities in the proxy's own


### PR DESCRIPTION
Fixes the intermittent `--- FAIL: <target> ... context deadline exceeded` in the proxy job.

Observed on **`main`** (run 12:13 UTC 2026-08-12) and on an unrelated PR (**#138**) — both times on `FuzzExtractHTTPHost`, the third and therefore most scheduling-pressured of the three targets.

## It is not a real finding

The fuzzer runs its full budget, **finds no crasher, and writes nothing to `testdata/`**. The failure is the coordinator's context deadline — derived from a *duration* `-fuzztime` — firing while workers are still finishing. A pure shutdown artifact.

An **iteration** budget carries no deadline, so the failure mode cannot occur. Raising the timeout would only make it rarer.

## Sizing

`1000000x` preserves the coverage the 30s budget was buying — CI was reaching **~1.45–1.65M execs per target** in 30s. It's also strictly better in one way the old form wasn't: **deterministic**. Every runner now does identical work, instead of fast runners fuzzing more than slow ones.

A real crasher still fails the build, which is the entire point of the step (HF-incident Issue 1: the proxy parses attacker-influenced wire bytes, so prove the parsers never panic).

## Verified

Locally, under the same Go 1.26 toolchain CI uses:

```
FuzzExtractSNI         8s  PASS
FuzzParseServerName    8s  PASS
FuzzExtractHTTPHost    9s  PASS
```

## Why it's worth fixing rather than re-running

Each false red burns a rerun and trains people to stop reading CI. This one has already cost two.

Note: **#143 currently also carries this change**, because it was branched from a local commit containing it. Merging this first makes #143 comment-only, as its description claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)