### PR TITLE
test(§86): fix bash 3.2 parse abort — apostrophes in a comment inside `$( )`

### DIFF
--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -6828,8 +6828,13 @@ _hb_run() {
     out="$(
       warn() { echo "WARN:$*"; }
       SANDBOX_DIR="$dir"
-      # shellcheck disable=SC2034  # consumed by the eval'd $_hb_blk below,
-      # which shellcheck can't see into since it's a dynamic string.
+      # NOTE: no apostrophes in comments inside this $( ) — bash 3.2 (macOS)
+      # scans command substitutions WITHOUT skipping comments, so a lone
+      # apostrophe opens a quote it never closes and the whole file dies with
+      # "unexpected EOF while looking for matching quote". bash 4+ fixed it, so
+      # `bash -n` on Linux/CI passes and only the maintainer macOS run breaks.
+      # shellcheck disable=SC2034  # consumed by the evaluated $_hb_blk below,
+      # which shellcheck cannot see into because it is a dynamic string.
       SANDY_WORKSPACE="$ws"
       if [ -n "$key" ]; then SANDY_HANDOFF_DIRS="$key"; else unset SANDY_HANDOFF_DIRS; fi
       eval "$_hb_blk"


### PR DESCRIPTION
The maintainer's macOS run died with:

```
test/run-tests.sh: line 6854: unexpected EOF while looking for matching `''
✗ test suite aborted early (exit=0)
Partial results: 945 passed, 0 failed (of 945 run so far)
```

## Cause

§86's `_hb_run` helper carries a shellcheck-disable comment **inside a multi-line command substitution**, and that comment contained three apostrophes (`eval'd`, `can't`, `it's`).

**bash 3.2 scans `$( )` without skipping comments.** The first apostrophe opens a single quote that is never closed, and the parser runs to EOF. bash 4+ fixed this — which is why `bash -n` passes on Linux and in CI, and only the macOS run breaks.

Same invisible-to-CI class as the three macOS failures fixed earlier this cycle: nested `source <(…)`, backticks inside `python3 -c "…"`, and `set -E` ERR traps firing in command-substitution subshells.

## Why this one is especially nasty

- **It is a parse error**, so it kills the *entire file* rather than one section. 945 checks had run, but the suite reported **`exit=0` and 0 failures** — it reads like success unless you notice the abort line.
- **The reported line is misleading**: 6854 is where the parser gave up, ~23 lines *after* the actual apostrophe at 6831.

## Fix

Reworded to avoid apostrophes entirely, plus a `NOTE` at the site explaining the constraint so the next person editing that comment doesn't reintroduce it.

Swept every script in the repo (`sandy`, both suites, all four acceptance scripts) for the same pattern — apostrophe in a comment inside a multi-line `$( )`: **zero other instances**.

Comment-only; no assertion or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)