### PR TITLE
fix(daemon): resolve `$0` before re-invoking self across a `cd`

### DIFF
--- a/sandy
+++ b/sandy
@@ -452,6 +452,27 @@ sandy_full_version() {
     [ -n "$hash" ] && ver="$ver-$hash"
     echo "$ver"
 }
+# Absolute path to this script, for the places that `cd` somewhere else and
+# then re-invoke sandy as a child. Left unresolved, a relative $0 ("./sandy")
+# resolves to nothing after the cd and the child silently fails. No
+# `readlink -f` (GNU-only, absent on BSD/macOS readlink) — cd+pwd+basename is
+# portable to both. A bare name (found via PATH) is returned unchanged, since
+# PATH lookup still works from any cwd.
+# shellcheck disable=SC2120  # the arg is optional and defaults to $0; callers
+# pass nothing, but run-tests.sh calls it WITH a path to exercise each shape.
+_sandy_self_path() {
+    local _p="${1:-$0}" _d
+    case "$_p" in
+        /*) printf '%s' "$_p" ;;
+        */*)
+            _d="$(cd "$(dirname "$_p")" 2>/dev/null && pwd)" || _d=""
+            if [ -n "$_d" ]; then printf '%s/%s' "$_d" "$(basename "$_p")"
+            else printf '%s' "$_p"; fi
+            ;;
+        *) printf '%s' "$_p" ;;
+    esac
+}
+
 if [[ "${1:-}" == "-v" || "${1:-}" == "--version" ]]; then
     echo "sandy $(sandy_full_version)"
     exit 0
@@ -4685,7 +4706,13 @@ if [ "$SANDY_START" = "true" ] && [ "${SANDY_DAEMON_SUPERVISOR:-0}" != "1" ]; th
     # (run `sandy --start` once from a terminal) or SANDY_AUTO_APPROVE_PRIVILEGED
     # set.
     if [ -t 0 ] && [ -t 2 ]; then
-        ( cd "$WORK_DIR" 2>/dev/null && SANDY_APPROVE_ONLY=1 "$0" ) </dev/tty >/dev/tty 2>&1 || true
+        # "$0" must be resolved to an absolute path FIRST: this subshell cd's to
+        # the workspace, so a relative invocation (./sandy) would resolve to
+        # nothing there, the child would die with "No such file or directory",
+        # and the `|| true` would swallow it — silently skipping the approval
+        # pre-pass this block exists to perform.
+        # shellcheck disable=SC2119  # optional arg intentionally omitted
+        ( cd "$WORK_DIR" 2>/dev/null && SANDY_APPROVE_ONLY=1 "$(_sandy_self_path)" ) </dev/tty >/dev/tty 2>&1 || true
     fi
 
     # D1 — daemonize the supervisor with `nohup … & disown`, deliberately NOT
@@ -5017,25 +5044,12 @@ if [ "$SANDY_UPDATE_SESSIONS" = "true" ]; then
     #
     # Resolve $0 to an absolute, cwd-independent path BEFORE any `cd` below
     # (step 2 does `cd "$workspace" && "$_sandy_self" --build-only` per
-    # session). A bare command name (no slash — the common installed case,
-    # `sandy` found via PATH) is left as-is: every bash observed sets $0 to
-    # the already-resolved absolute path in that case. An already-absolute
-    # $0 is also left as-is. The one case that needs fixing is a literal
-    # relative invocation WITH a slash (`./sandy`, `../bin/sandy` — common
-    # when running from a dev checkout, exactly this repo's own workflow):
-    # left unresolved, a later `cd` into some OTHER workspace would make
-    # "./sandy" resolve to nothing there and every per-session build would
-    # fail with "no such file". No `readlink -f` (GNU-only, absent on BSD/
-    # macOS readlink) — cd+pwd+basename is portable to both platforms.
-    _sandy_self="$0"
-    case "$_sandy_self" in
-        /*) : ;;
-        */*)
-            _sandy_self_dir="$(cd "$(dirname "$_sandy_self")" 2>/dev/null && pwd)" || _sandy_self_dir=""
-            [ -n "$_sandy_self_dir" ] && _sandy_self="$_sandy_self_dir/$(basename "$_sandy_self")"
-            ;;
-        *) : ;;
-    esac
+    # session). Step 2 below does `cd "$workspace" && "$_sandy_self" ...`, so a
+    # relative $0 ("./sandy" — a dev checkout, this repo's own workflow) must be
+    # resolved first or every per-session build dies with "no such file". See
+    # _sandy_self_path for the portability reasoning.
+    # shellcheck disable=SC2119  # optional arg intentionally omitted
+    _sandy_self="$(_sandy_self_path)"
 
     _sandy_upd_raw="$(_sandy_update_enum_sessions)"
     if [ -z "$_sandy_upd_raw" ]; then

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -6943,6 +6943,37 @@ check "--reset-sandbox scopes to the sandbox dir, not the sibling .claude.json" 
              && ! printf "%s" "$_f" | grep -q "claude.json"' -- "$_S87"
 
 # ============================================================
+echo ""
+echo "§88: self-path resolution — a relative \$0 must survive a cd (Fix B regression)"
+# ============================================================
+# sandy re-invokes itself as a child in two places that FIRST cd elsewhere: the
+# --start approval pre-pass (Fix B) and --update-sessions step 2. With a
+# relative $0 (./sandy — a dev checkout, and what the acceptance scripts use)
+# the child resolves to nothing after the cd. Fix B swallows that with
+# `|| true`, so the failure is silent and the passive-privileged approval it
+# exists to perform never happens — reviving the very CLAUDE_CODE_OAUTH_TOKEN
+# drop it was written to fix. Found by acceptance-handoff-dirs.sh printing
+# "./sandy: No such file or directory".
+_S88="$(cd "$(dirname "$0")/.." && pwd)/sandy"
+_s88_fn="$(sed -n '/^_sandy_self_path()/,/^}$/p' "$_S88")"
+
+check "_sandy_self_path exists" bash -c '[ -n "$1" ]' -- "$_s88_fn"
+check "_sandy_self_path makes a relative path absolute" \
+    bash -c 'cd /home/claude 2>/dev/null || cd /tmp; r="$(eval "$1"; _sandy_self_path ./sandy)"; case "$r" in /*/sandy) exit 0 ;; *) exit 1 ;; esac' -- "$_s88_fn"
+check "_sandy_self_path leaves an absolute path unchanged" \
+    bash -c 'r="$(eval "$1"; _sandy_self_path /opt/x/sandy)"; [ "$r" = "/opt/x/sandy" ]' -- "$_s88_fn"
+check "_sandy_self_path leaves a bare PATH name unchanged" \
+    bash -c 'r="$(eval "$1"; _sandy_self_path sandy)"; [ "$r" = "sandy" ]' -- "$_s88_fn"
+check "resolved path still resolves after a cd (the actual bug)" \
+    bash -c 'cd "$(dirname "$2")"; r="$(eval "$1"; _sandy_self_path ./sandy)"; cd /tmp; [ -f "$r" ]' -- "$_s88_fn" "$_S88"
+
+# Both cd-then-reinvoke sites must use the helper, never a bare "$0".
+check "Fix B (--start approval pre-pass) uses the resolved self path" \
+    bash -c 'grep -q "cd \"\$WORK_DIR\" 2>/dev/null && SANDY_APPROVE_ONLY=1 \"\$(_sandy_self_path)\"" "$1"' -- "$_S88"
+check "no cd-then-reinvoke site uses a bare \$0" \
+    bash -c '! grep -nE "cd [^&;]*(&&|;)[^&;]*\"\\\$0\"" "$1"' -- "$_S88"
+
+# ============================================================
 # Summary
 # ============================================================
 COMPLETED=true   # suppress the early-abort message in the EXIT trap


### PR DESCRIPTION
Surfaced by `test/acceptance-handoff-dirs.sh`:

```
./sandy: line 4688: ./sandy: No such file or directory
```

## The bug

sandy re-invokes itself as a child in two places that **first `cd` elsewhere**. With a relative `$0` — `./sandy`, i.e. a dev checkout, which is exactly what the acceptance scripts and this repo's own workflow use — the child resolves to nothing after the `cd`.

**The `--start` approval pre-pass (Fix B) is the one that matters.** Its own comment says why it exists:

> grant any passive-privileged approval with the CLIENT's TTY BEFORE forking the non-TTY supervisor… the supervisor's stdin is `/dev/null`, so its own approval resolution can only fail closed — **silently dropping workspace-config privileged keys, including credentials in a workspace `.sandy/.secrets` (the `CLAUDE_CODE_OAUTH_TOKEN` drop reported against daemon-mode)**

That invocation is guarded with `|| true`. So when it failed, the error was swallowed and **Fix B silently did not run** — reviving the exact bug it was written to fix, for anyone launching `./sandy --start` from a checkout.

A fix that silently no-ops depending on how you invoked the script is worse than no fix, because the failure looks like nothing.

## Why it only hit now

`--update-sessions` had already hit this and solved it inline — its comment even spells out the failure mode and why `readlink -f` is unusable on BSD. The daemon path has the identical shape and never got the same treatment.

So this consolidates rather than patches: extracted that logic into `_sandy_self_path` and pointed **both** sites at it, so there is one implementation instead of one fixed site and one broken one.

Absolute paths and bare PATH names pass through unchanged; only a relative path *with a slash* is resolved, via `cd`+`pwd`+`basename` (portable — `readlink -f` is GNU-only, absent on BSD/macOS).

```
./sandy          -> /home/claude/dev/sandy/sandy
../sandy         -> /home/claude/dev/sandy/sandy
/abs/path/sandy  -> /abs/path/sandy      (unchanged)
sandy            -> sandy                (unchanged; PATH lookup works from any cwd)
```

## Guarded by §88

The helper's three input shapes, the resolved path surviving a real `cd`, Fix B using the helper, and a **negative check that no `cd`-then-reinvoke site uses a bare `$0`** — so a third such site added later is caught too.

**Mutation-tested:**

| Mutation | Checks failed |
|---|---|
| revert Fix B to a bare `$0` | 3 |
| helper stops resolving relative paths | 2 |
| unmutated control | 0 (7/7) |

Zero new shellcheck codes — the helper's optional test-only argument needs scoped `SC2119`/`SC2120` disables, with the reason recorded inline.

## Note on the acceptance script

The stray `No such file or directory` line it printed was the *symptom*, not a script bug. `acceptance-handoff-dirs.sh` and `acceptance-daemon.sh` both default to `SANDY="${SANDY:-./sandy}"`, which is correct usage — sandy should tolerate it, and now does.