### PR TITLE
test(§89): lint for the bash-3.2/BSD hazards CI structurally cannot see

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,26 @@ Since Claude Code running inside sandy cannot access Docker, running tests requi
 
 See `TESTING_PLAN.md` for manual validation steps that require interactive TUI sessions.
 
+### bash-3.2 / BSD portability lint (`test/lint-bash32.sh`)
+
+CI is Ubuntu + bash 5 + GNU userland; the maintainer's machine is macOS + bash 3.2 + BSD. Three constructs parse or expand **differently** there, so `bash -n` in CI passes and the break surfaces only on one machine — and each fails in a way that doesn't announce itself:
+
+| Code | Construct | How it failed here |
+|---|---|---|
+| `SRCSUB` | nested `source <(...)` inside `$( )` | bash 3.2 sources nothing → exit 127 → ERR trap aborted the run (§83) |
+| `PYBACK` | backtick or `$(` inside a **double-quoted** `python3 -c "..."` body | bash expands it regardless of Python comment syntax — a `` `sandy` `` in a comment made the suite **execute the real sandy binary** (§68) |
+| `APOSCS` | apostrophe in a comment inside a multi-line `$( )` | bash 3.2 doesn't skip comments when scanning a command substitution → unterminated quote → **parse abort**, while the summary still printed "945 passed, 0 failed" (§86) |
+
+```sh
+bash test/lint-bash32.sh              # lint the repo's shell scripts
+bash test/lint-bash32.sh --self-test  # prove the detectors still detect
+bash test/lint-bash32.sh --list       # the target set, for coverage assertions
+```
+
+`run-tests.sh §89` runs it and asserts both that the tree is clean **and** that the detectors fire on known-bad fixtures — a linter whose patterns quietly stopped matching would otherwise report success forever. Validated by replay against this repo's own history: pointed at the commits *before* each fix, it flags all three original defects at their exact lines. Deliberately **not** checked: `set -E` ERR traps firing in command-substitution subshells (real — see `sandy:1043` — but not reliably detectable statically, and a false positive is worse than a miss here).
+
+Fixes: `SRCSUB` → extract-then-`eval`; `PYBACK` → a **quoted** heredoc (`python3 - arg <<'PY'`); `APOSCS` → reword the comment.
+
 ## Git branch work inside sandy (`.git/HEAD` is writable as of 1.5.0, #80)
 
 As of 1.5.0 (#80) sandy leaves `.git/HEAD` **read-write**, so `git switch <branch>` / `git checkout <branch>` / `git checkout -b` **work inside the container** — HEAD is a symref (which branch is checked out), not a host-code-execution vector. What stays bind-mounted **read-only** (the anti-ref-spoofing / hook-injection defense — see "Protected Files"): `.git/config`, `.gitmodules`, `.git/packed-refs`, `.git/hooks`, `.git/info`, and submodule gitdirs. Consequences of *those* staying `:ro`:

--- a/test/lint-bash32.sh
+++ b/test/lint-bash32.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Static lint for bash-3.2 / BSD-userland hazards that CI structurally CANNOT see.
+#
+#   bash test/lint-bash32.sh              # lint the repo's shell scripts
+#   bash test/lint-bash32.sh FILE...      # lint specific files
+#   bash test/lint-bash32.sh --self-test  # prove the detectors actually detect
+#
+# Why this exists. CI runs Ubuntu with bash 5 and GNU userland; the maintainer
+# runs macOS with bash 3.2 and BSD userland. Several constructs parse fine on
+# the former and break on the latter, so `bash -n` in CI passes and the failure
+# only ever appears on one machine, usually mid-task. Every pattern below has
+# ALREADY broken this repo at least once — none is speculative:
+#
+#   SRCSUB  nested `source <(...)` inside `$(...)`. bash 3.2 yields an empty
+#           source; the calls that follow exit 127 and the ERR trap aborts the
+#           whole run. Hit in run-tests.sh §83 — every section after it silently
+#           never executed.
+#
+#   PYBACK  backticks or $( ) inside a DOUBLE-quoted `python3 -c "..."` body.
+#           Bash expands them regardless of Python comment syntax, so the shell
+#           runs whatever is in the backticks and splices its stdout into the
+#           program. Hit in §68: a `sandy` in a Python comment made the test
+#           suite EXECUTE the real sandy binary and corrupt its own script.
+#
+#   APOSCS  an apostrophe in a comment inside a multi-line `$( )`. bash 3.2
+#           scans command substitutions WITHOUT skipping comments, so the
+#           apostrophe opens a quote that never closes and the file dies with
+#           "unexpected EOF while looking for matching quote". Hit in §86 —
+#           and it is a PARSE error, so it killed the entire file while the
+#           summary still printed "945 passed, 0 failed".
+#
+# Deliberately NOT checked: `set -E` ERR traps firing in command-substitution
+# subshells (real — see sandy:1043 — but not reliably detectable statically, and
+# a false positive here is worse than a miss).
+
+set -uo pipefail
+
+SELF_TEST=false
+LIST_ONLY=false
+FILES=()
+for a in "$@"; do
+    case "$a" in
+        --self-test) SELF_TEST=true ;;
+        # --list reports the target set WITHOUT linting, so a caller can assert
+        # coverage independently of the pass/fail outcome. Folding the two
+        # together would make "we still scan everything" unverifiable on exactly
+        # the runs where it matters — the failing ones.
+        --list) LIST_ONLY=true ;;
+        -h|--help) sed -n '2,12p' "$0"; exit 0 ;;
+        *) FILES+=("$a") ;;
+    esac
+done
+
+_repo="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Default target set: every shell script the repo ships or tests with — except
+# this file, whose --self-test fixtures are deliberate instances of all three
+# bugs and would otherwise report themselves.
+if [ "${#FILES[@]}" -eq 0 ]; then
+    FILES=("$_repo/sandy")
+    for f in "$_repo"/test/*.sh "$_repo"/*.sh; do
+        [ -f "$f" ] || continue
+        [ "$(basename "$f")" = "lint-bash32.sh" ] && continue
+        FILES+=("$f")
+    done
+fi
+
+if [ "$LIST_ONLY" = true ]; then
+    printf '%s\n' "${FILES[@]}"
+    exit 0
+fi
+
+_scanner="$(mktemp)"
+trap 'rm -f "$_scanner"' EXIT
+
+# Quoted heredoc: nothing here is expanded by bash. (Writing this scanner with
+# an UNquoted heredoc would trip the very hazards it detects.)
+cat > "$_scanner" <<'SCANNER_PY'
+import re, sys
+
+# A block that never terminates within this many lines is abandoned rather than
+# reported. Runaway scanning is the main false-positive risk in all three
+# detectors, and a lint that cries wolf gets switched off.
+MAX_BLOCK = 80
+
+def scan(path):
+    try:
+        lines = open(path, encoding="utf-8", errors="replace").read().split("\n")
+    except OSError as e:
+        return [(0, "IOERR", str(e))]
+    out = []
+
+    # SRCSUB — process substitution fed to source/dot, in code (not comments).
+    for i, l in enumerate(lines, 1):
+        if re.match(r"^\s*#", l):
+            continue
+        if re.search(r"(^|[^\w-])(source|\.)\s+<\(", l):
+            out.append((i, "SRCSUB", l.strip()[:88]))
+
+    # PYBACK — backticks / $( inside a double-quoted `python3 -c "` body. Only
+    # multi-line bodies are considered (the line ends with the opening quote);
+    # a single-line `python3 -c "..."` cannot straddle a comment.
+    #
+    # Terminator: inside a double-quoted bash string every literal quote must be
+    # written \" , so the first UNESCAPED " closes the body. It is usually at the
+    # END of a line (`... m[0]"' -- "$1"`), not the start — an anchored ^\s*"
+    # rule misses it and the scan runs on into unrelated code as false positives.
+    i = 0
+    while i < len(lines):
+        if re.search(r'python3?\s+-c\s+"\s*$', lines[i]):
+            j, start = i + 1, i
+            while j < len(lines) and j - start < MAX_BLOCK:
+                bare = lines[j].replace('\\"', "")
+                head = bare.split('"')[0] if '"' in bare else bare
+                if "`" in head or "$(" in head:
+                    out.append((j + 1, "PYBACK", lines[j].strip()[:88]))
+                if '"' in bare:
+                    break
+                j += 1
+            i = j
+        i += 1
+
+    # APOSCS — apostrophe in a comment inside a multi-line $( ).
+    depth, opened_at = 0, 0
+    for i, l in enumerate(lines, 1):
+        if re.search(r"\$\(\s*$", l):
+            if depth == 0:
+                opened_at = i
+            depth += 1
+        elif re.match(r'^\s*\)"?\s*$', l) and depth > 0:
+            depth -= 1
+        elif depth > 0:
+            if i - opened_at > MAX_BLOCK:
+                depth = 0
+                continue
+            if re.match(r"^\s*#", l) and "'" in l:
+                out.append((i, "APOSCS", l.strip()[:88]))
+    return out
+
+rc = 0
+for p in sys.argv[1:]:
+    for ln, code, txt in scan(p):
+        rc = 1
+        print("%s:%d: %s: %s" % (p, ln, code, txt))
+sys.exit(rc)
+SCANNER_PY
+
+if [ "$SELF_TEST" = true ]; then
+    # Positive controls. A linter nobody has proven can DETECT is decoration —
+    # each fixture below is a real instance of the bug it names.
+    _fx="$(mktemp -d)"
+    printf '%s\n' '#!/bin/bash' 'x="$(bash -c '"'"'source <(sed -n "1p" f); g'"'"')"' > "$_fx/srcsub.sh"
+    printf '%s\n' '#!/bin/bash' 'python3 -c "' '# the `sandy` binary' 'print(1)' '" arg' > "$_fx/pyback.sh"
+    printf '%s\n' '#!/bin/bash' 'out="$(' '  # shellcheck can'"'"'t see this' '  echo hi' ')"' > "$_fx/aposcs.sh"
+    _fails=0
+    for probe in srcsub pyback aposcs; do
+        if python3 "$_scanner" "$_fx/$probe.sh" >/dev/null 2>&1; then
+            echo "SELF-TEST FAIL: $probe fixture was NOT detected" >&2; _fails=$((_fails + 1))
+        else
+            echo "  detector OK: $probe"
+        fi
+    done
+    # Negative control: a clean file must produce nothing.
+    printf '%s\n' '#!/bin/bash' 'x="$(echo hi)"' '# a normal comment with an apostrophe, outside any $( )' > "$_fx/clean.sh"
+    if python3 "$_scanner" "$_fx/clean.sh" >/dev/null 2>&1; then
+        echo "  negative control OK: clean file produced no findings"
+    else
+        echo "SELF-TEST FAIL: clean file produced findings" >&2; _fails=$((_fails + 1))
+    fi
+    rm -rf "$_fx"
+    [ "$_fails" -eq 0 ] || exit 1
+    echo "self-test passed"
+    exit 0
+fi
+
+if python3 "$_scanner" "${FILES[@]}"; then
+    echo "bash-3.2 lint: clean (${#FILES[@]} files)"
+    exit 0
+else
+    echo "" >&2
+    echo "bash-3.2 lint FAILED — the above parse or expand differently on macOS" >&2
+    echo "  SRCSUB  use extract-then-eval: v=\"\$(sed -n '/^f()/,/^}/p' x)\"; bash -c \"\$v; f\"" >&2
+    echo "  PYBACK  use a QUOTED heredoc: python3 - arg <<'PY' ... PY" >&2
+    echo "  APOSCS  reword the comment to avoid apostrophes" >&2
+    exit 1
+fi

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -6990,6 +6990,51 @@ check "no cd-then-reinvoke site expands \$(_sandy_self_path) late" \
     bash -c '! grep -nE "cd [^&;]*(&&|;)[^&;]*_sandy_self_path" "$1"' -- "$_S88"
 
 # ============================================================
+echo ""
+echo "§89: bash-3.2 / BSD portability lint (the class CI structurally cannot see)"
+# ============================================================
+# CI is Ubuntu + bash 5 + GNU userland; the maintainer is macOS + bash 3.2 + BSD.
+# Three constructs parse or expand DIFFERENTLY there, so `bash -n` in CI passes
+# and the break only ever shows up on one machine. All three have already bitten
+# this repo, and each was silent in a way that made it expensive:
+#
+#   §83  nested source <(...) inside $( )  -> exit 127, ERR trap, run aborted
+#   §68  backtick inside python3 -c "..."  -> the suite EXECUTED the real sandy
+#   §86  apostrophe in a comment in $( )   -> parse abort, yet the summary still
+#                                             printed "945 passed, 0 failed"
+#
+# So the guard is not "be tidy" — it is that a portability break here does not
+# announce itself as a failure. test/lint-bash32.sh is the detector and is
+# independently runnable; this section asserts BOTH that it detects (its own
+# positive controls) and that the tree is currently clean.
+_S89="$(cd "$(dirname "$0")" && pwd)/lint-bash32.sh"
+
+check "lint-bash32.sh exists and is executable-by-bash" \
+    bash -c '[ -f "$1" ] && bash -n "$1"' -- "$_S89"
+
+# The detectors must be proven to DETECT before a clean run means anything —
+# a linter whose patterns silently stopped matching would report success forever.
+check "detectors self-test: all three fire on known-bad fixtures" \
+    bash -c 'bash "$1" --self-test >/dev/null 2>&1' -- "$_S89"
+
+check "detectors self-test: clean file yields no findings (no false positives)" \
+    bash -c 'bash "$1" --self-test 2>&1 | grep -q "negative control OK"' -- "$_S89"
+
+# The actual guard.
+check "repo shell scripts are free of bash-3.2 hazards" \
+    bash -c 'bash "$1" >/dev/null 2>&1' -- "$_S89"
+
+# Scope: silently dropping sandy or run-tests.sh from the target set would make
+# the check above pass vacuously — the failure mode a lint is most prone to.
+# Asserted via --list so coverage is measured independently of the lint's own
+# pass/fail (a scope assertion that only holds on clean runs is worthless).
+check "lint target set includes sandy itself" \
+    bash -c 'bash "$1" --list | grep -qx ".*/sandy"' -- "$_S89"
+check "lint target set includes run-tests.sh and the acceptance harnesses" \
+    bash -c '_l="$(bash "$1" --list)"; printf "%s" "$_l" | grep -q "test/run-tests.sh" \
+        && [ "$(printf "%s\n" "$_l" | grep -c "test/acceptance-")" -ge 3 ]' -- "$_S89"
+
+# ============================================================
 # Summary
 # ============================================================
 COMPLETED=true   # suppress the early-abort message in the EXIT trap


### PR DESCRIPTION
CI is Ubuntu + bash 5 + GNU userland. The maintainer's machine is macOS + bash 3.2 + BSD. Three constructs parse or expand **differently** there, so `bash -n` in CI passes and the break appears on exactly one machine — usually mid-task.

All three have already bitten this repo. **None is speculative.**

| Code | Construct | How it failed here |
|---|---|---|
| `SRCSUB` | nested `source <(...)` inside `$( )` | bash 3.2 sources nothing → following calls exit 127 → ERR trap aborts the run (**§83** — every section after it silently never executed) |
| `PYBACK` | backtick / `$(` inside a **double-quoted** `python3 -c "..."` body | bash expands it regardless of Python comment syntax — a `` `sandy` `` in a *comment* made the test suite **execute the real sandy binary** (**§68**) |
| `APOSCS` | apostrophe in a comment inside a multi-line `$( )` | bash 3.2 doesn't skip comments while scanning a command substitution → unterminated quote → **parse abort** (**§86**) |

## Why this is worth a guard

These don't surface as red tests. They surface as **a green run that did less than it claimed.**

§86 is the clearest case: a parse error killed the entire file, and the summary still printed `945 passed, 0 failed`. §83 aborted the run at section 83 of 88. §68 corrupted the suite's own working tree by executing sandy. In each case the signal said "fine."

## What's here

`test/lint-bash32.sh` — the detector, independently runnable:

```sh
bash test/lint-bash32.sh              # lint the repo's shell scripts (14 files)
bash test/lint-bash32.sh --self-test  # prove the detectors still detect
bash test/lint-bash32.sh --list       # the target set
```

`--list` exists so coverage can be asserted **separately from the lint's own pass/fail**. My first version derived coverage from the success message, which meant the scope assertion only held on runs that already passed — worthless precisely when it matters.

## Validated against this repo's own history

Not "does it look right" — pointed at the commit *before* each fix, it flags all three original defects at their exact lines:

```
73a118c^:6831  APOSCS: # shellcheck disable=SC2034  # consumed by the eval'd $_hb_blk below,
d8b685c^:6681  SRCSUB: _hd_out="$(bash -c 'source <(sed -n "/^_sandy_head_display()/,/^}/p" "$1"); ...
d8b685c^:5146  PYBACK: # Regression: the proxy of a `sandy`-named workspace must join to sandy-...
```

That last line is §68's actual bug: a backticked `sandy` inside a Python comment.

## §89 and mutation testing

§89 asserts the tree is clean **and** that the detectors still fire on known-bad fixtures — a linter whose patterns quietly stopped matching would report success forever.

Each mutation is caught by the check designed for it, with no cross-coupling:

| Mutation | Check that caught it |
|---|---|
| reintroduce the real §86 bug in-tree | `repo shell scripts are free of bash-3.2 hazards` |
| APOSCS detector rots (stops matching) | `detectors self-test: all three fire` |
| target set silently narrowed | `lint target set includes run-tests.sh and the acceptance harnesses` |
| **unmutated control** | **6/6 pass** |

## False positives were the main design risk

A lint that cries wolf gets switched off, so: blocks that don't terminate within 80 lines are abandoned rather than reported; `PYBACK` terminates on the first **unescaped** quote (usually at end-of-line — an anchored `^\s*"` rule ran on into unrelated code and produced 9 false hits on §77/§78); and the linter **excludes itself**, since its own fixtures are deliberate instances of all three bugs. Current tree: clean, 14 files.

## Scope

**No workflow change** — CI already runs `run-tests.sh`, so §89 rides along.

**Deliberately not checked:** `set -E` ERR traps firing in command-substitution subshells (real — see `sandy:1043` — but not reliably detectable statically, and here a false positive is worse than a miss). Also unchecked: BWK-awk `\$` anchoring and BSD `wc -l` whitespace, both from the same family but needing semantic context this pass doesn't have.