### PR TITLE
fix(daemon): resolve SANDY_SELF at script top, not inside the cd chain

### DIFF
--- a/sandy
+++ b/sandy
@@ -473,6 +473,16 @@ _sandy_self_path() {
     esac
 }
 
+# Resolve ONCE, here, at the top of the script — while the cwd is still the one
+# the user invoked sandy from. Every consumer must use this value rather than
+# calling the helper at the point of use: the call sites sit inside
+# `cd <elsewhere> && "$(...)"`, and command substitution in the second half of
+# an && list is expanded AFTER the cd has run, so calling the helper there
+# resolves a relative $0 against the wrong directory — which is the exact bug
+# the helper exists to prevent, just moved later.
+# shellcheck disable=SC2119  # optional arg intentionally omitted; defaults to $0
+SANDY_SELF="$(_sandy_self_path)"
+
 if [[ "${1:-}" == "-v" || "${1:-}" == "--version" ]]; then
     echo "sandy $(sandy_full_version)"
     exit 0
@@ -4706,13 +4716,13 @@ if [ "$SANDY_START" = "true" ] && [ "${SANDY_DAEMON_SUPERVISOR:-0}" != "1" ]; th
     # (run `sandy --start` once from a terminal) or SANDY_AUTO_APPROVE_PRIVILEGED
     # set.
     if [ -t 0 ] && [ -t 2 ]; then
-        # "$0" must be resolved to an absolute path FIRST: this subshell cd's to
-        # the workspace, so a relative invocation (./sandy) would resolve to
-        # nothing there, the child would die with "No such file or directory",
-        # and the `|| true` would swallow it — silently skipping the approval
-        # pre-pass this block exists to perform.
-        # shellcheck disable=SC2119  # optional arg intentionally omitted
-        ( cd "$WORK_DIR" 2>/dev/null && SANDY_APPROVE_ONLY=1 "$(_sandy_self_path)" ) </dev/tty >/dev/tty 2>&1 || true
+        # $SANDY_SELF, not "$0" and not "$(_sandy_self_path)": this subshell cd's
+        # to the workspace, so a relative invocation (./sandy) resolves to nothing
+        # there, the child dies with "No such file or directory", and the
+        # `|| true` swallows it — silently skipping the approval pre-pass this
+        # block exists to perform. Calling the helper HERE would not help: the
+        # substitution is expanded after the cd. It must already be resolved.
+        ( cd "$WORK_DIR" 2>/dev/null && SANDY_APPROVE_ONLY=1 "$SANDY_SELF" ) </dev/tty >/dev/tty 2>&1 || true
     fi
 
     # D1 — daemonize the supervisor with `nohup … & disown`, deliberately NOT
@@ -5042,14 +5052,11 @@ if [ "$SANDY_UPDATE_SESSIONS" = "true" ]; then
     # self "$0" --stop / --start child process, which manages its own lock
     # exactly as it does for a normal interactive invocation.
     #
-    # Resolve $0 to an absolute, cwd-independent path BEFORE any `cd` below
-    # (step 2 does `cd "$workspace" && "$_sandy_self" --build-only` per
-    # session). Step 2 below does `cd "$workspace" && "$_sandy_self" ...`, so a
-    # relative $0 ("./sandy" — a dev checkout, this repo's own workflow) must be
-    # resolved first or every per-session build dies with "no such file". See
-    # _sandy_self_path for the portability reasoning.
-    # shellcheck disable=SC2119  # optional arg intentionally omitted
-    _sandy_self="$(_sandy_self_path)"
+    # Step 2 below does `cd "$workspace" && "$_sandy_self" --build-only` per
+    # session, so this must already be cwd-independent. $SANDY_SELF was resolved
+    # at script top, before any cd — see the note there for why resolving at the
+    # point of use is too late.
+    _sandy_self="$SANDY_SELF"
 
     _sandy_upd_raw="$(_sandy_update_enum_sessions)"
     if [ -z "$_sandy_upd_raw" ]; then

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -6967,11 +6967,27 @@ check "_sandy_self_path leaves a bare PATH name unchanged" \
 check "resolved path still resolves after a cd (the actual bug)" \
     bash -c 'cd "$(dirname "$2")"; r="$(eval "$1"; _sandy_self_path ./sandy)"; cd /tmp; [ -f "$r" ]' -- "$_s88_fn" "$_S88"
 
-# Both cd-then-reinvoke sites must use the helper, never a bare "$0".
-check "Fix B (--start approval pre-pass) uses the resolved self path" \
-    bash -c 'grep -q "cd \"\$WORK_DIR\" 2>/dev/null && SANDY_APPROVE_ONLY=1 \"\$(_sandy_self_path)\"" "$1"' -- "$_S88"
+# The value must be resolved ONCE at script top, while the cwd is still the
+# user's. The first attempt at this fix called the helper AT the call site —
+# inside `cd "$WORK_DIR" && ... "$(_sandy_self_path)"` — which is too late:
+# command substitution in the second half of an && list is expanded AFTER the
+# cd, so a relative $0 resolved against the WORKSPACE and the child died with
+# "<workspace>/sandy: No such file or directory". Same bug, moved later. So it
+# is not enough to assert the helper is used; assert WHERE it is evaluated.
+check "SANDY_SELF is resolved once at script top" \
+    bash -c 'grep -q "^SANDY_SELF=\"\$(_sandy_self_path)\"" "$1"' -- "$_S88"
+check "SANDY_SELF is assigned before any cd in the script (resolution order)" \
+    bash -c '_a="$(grep -n "^SANDY_SELF=" "$1" | head -1 | cut -d: -f1)";
+             _c="$(grep -nE "^[[:space:]]*\(?[[:space:]]*cd " "$1" | head -1 | cut -d: -f1)";
+             [ -n "$_a" ] && [ -n "$_c" ] && [ "$_a" -lt "$_c" ]' -- "$_S88"
+check "Fix B (--start approval pre-pass) uses the pre-resolved value" \
+    bash -c 'grep -q "cd \"\$WORK_DIR\" 2>/dev/null && SANDY_APPROVE_ONLY=1 \"\$SANDY_SELF\"" "$1"' -- "$_S88"
 check "no cd-then-reinvoke site uses a bare \$0" \
     bash -c '! grep -nE "cd [^&;]*(&&|;)[^&;]*\"\\\$0\"" "$1"' -- "$_S88"
+# The late-expansion trap itself: the helper must never be CALLED inside a cd
+# chain, however correct the helper is.
+check "no cd-then-reinvoke site expands \$(_sandy_self_path) late" \
+    bash -c '! grep -nE "cd [^&;]*(&&|;)[^&;]*_sandy_self_path" "$1"' -- "$_S88"
 
 # ============================================================
 # Summary


### PR DESCRIPTION
**#147 fixed the wrong half of the problem.** Reported from a real macOS acceptance run:

```
./sandy: line 4715: /private/var/.../mbx-accept-46671/sandy: No such file or directory
```

Note the path — it is now `<workspace>/sandy`, not `./sandy`. The error moved; it did not go away.

## Cause

#147 added `_sandy_self_path` and called it **at the call site**:

```sh
( cd "$WORK_DIR" && SANDY_APPROVE_ONLY=1 "$(_sandy_self_path)" )
```

Command substitution in the second half of an `&&` list is expanded **after** the `cd` runs. So the helper did exactly its job — resolving a relative `$0` against the current directory — except the current directory was by then the workspace.

The block's own comment said the path *"must be resolved to an absolute path FIRST"*, and then did not do that.

## Fix

Resolve **once** into `$SANDY_SELF` at the top of the script, while the cwd is still the one the user invoked sandy from. Both `cd`-then-reinvoke sites (Fix B, `--update-sessions` step 2) consume that value.

Resolution order is now a property of **where the assignment sits**, not of how each call site happens to be written — which is what makes it hard to get wrong again.

Confirmed against the exact failing shape (relative `$0`, subshell `cd` to the workspace):

```
OLD (helper called inside the cd chain):  <workspace>/sandy   ← does not exist
NEW (pre-resolved global):                <repo>/sandy        ← correct
```

Consequence is unchanged from #147: with Fix B broken its `|| true` swallows the failure, the `--start` approval pre-pass silently does not run, and workspace passive-privileged keys — including a `CLAUDE_CODE_OAUTH_TOKEN` in a workspace `.sandy/.secrets` — are dropped.

## Why §88 didn't catch it

It asserted the helper was **used**. The broken form used it. That check passed on shipped-broken code, which makes it the more useful lesson here: it tested the presence of a mechanism rather than the property the mechanism was for.

§88 now asserts **where the value is produced**:

- `SANDY_SELF` is resolved once at script top
- the assignment is ordered **before the first `cd`** in the file
- both call sites consume the pre-resolved value
- negative: no `cd` chain expands `$(_sandy_self_path)` late

| Mutation | Checks failed |
|---|---|
| revert to the shipped-broken form (helper called in the cd chain) | **5** (was 0) |
| assign `SANDY_SELF` after a `cd` | 3 |
| unmutated control | 0 (10/10) |

## Verified

`--version`, `--print-schema` (20 flags), `--validate-config` fast paths all work; both doc-drift checks clean; `bash -n` clean.
