### PR TITLE
chore: bump to 1.7.0-dev

### DIFF
--- a/sandy
+++ b/sandy
@@ -17,7 +17,7 @@ set -euo pipefail
 #   sandy --agent claude,gemini   Override agent selection for this run
 # =============================================================================
 
-SANDY_VERSION="1.6.1-dev"
+SANDY_VERSION="1.7.0-dev"
 SANDY_COMMIT=""  # baked in by install.sh; empty = detect from git at runtime
 
 # Schema contract version for --print-schema / --print-state / --validate-config.


### PR DESCRIPTION
`SANDY_HANDOFF_DIRS` (#140) is a **new config key**, which per the 1.x semver discipline in `CLAUDE.md` is *additive* — so the next release is **1.7.0**, not 1.6.1.

Its `_sandy_key_metadata` row already declares `since=1.7.0`, so `main` was advertising a key as arriving in a version the script did not claim to be heading for:

```
sandy.version:                1.6.1-dev     ← script
SANDY_HANDOFF_DIRS since:     1.7.0         ← schema
```

Now consistent (`sandy.version 1.7.0-dev`).

**This does not cut a release.** It is the one-line bump that makes the two agree; 1.7.0 gets tagged when the #132 relay lands or when a consumer needs a pinnable version rather than a commit hash.

`SANDY_SANDBOX_MIN_COMPAT` is untouched at `0.7.10` — the 1.x forward-compat promise caps it at `1.0.0`, and a minor bump does not move it (§60).

Verified: both `SANDY_VERSION` guards (well-formed semver, defined exactly once), `--version`, `--print-schema`, both doc-drift checks, and the §89 portability lint.
