### PR TITLE
fix: jq seeder uses has() for booleans; lint gains APOSQ

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ CI is Ubuntu + bash 5 + GNU userland; the maintainer's machine is macOS + bash 3
 |---|---|---|
 | `SRCSUB` | nested `source <(...)` inside `$( )` | bash 3.2 sources nothing → exit 127 → ERR trap aborted the run (§83) |
 | `PYBACK` | backtick or `$(` inside a **double-quoted** `python3 -c "..."` body | bash expands it regardless of Python comment syntax — a `` `sandy` `` in a comment made the suite **execute the real sandy binary** (§68) |
+| `APOSQ` | apostrophe in a comment inside a multi-line **single-quoted** program argument (`jq '...'`, `awk '...'`) | the apostrophe closes the string and the shell reinterprets the rest as code — `bash -n` fails while `APOSCS` reports clean, since it only scans `$( )` |
 | `APOSCS` | apostrophe in a comment inside a multi-line `$( )` | bash 3.2 doesn't skip comments when scanning a command substitution → unterminated quote → **parse abort**, while the summary still printed "945 passed, 0 failed" (§86) |
 
 ```sh
@@ -95,7 +96,7 @@ bash test/lint-bash32.sh --list       # the target set, for coverage assertions
 
 `run-tests.sh §89` runs it and asserts both that the tree is clean **and** that the detectors fire on known-bad fixtures — a linter whose patterns quietly stopped matching would otherwise report success forever. Validated by replay against this repo's own history: pointed at the commits *before* each fix, it flags all three original defects at their exact lines. Deliberately **not** checked: `set -E` ERR traps firing in command-substitution subshells (real — see `sandy:1043` — but not reliably detectable statically, and a false positive is worse than a miss here).
 
-Fixes: `SRCSUB` → extract-then-`eval`; `PYBACK` → a **quoted** heredoc (`python3 - arg <<'PY'`); `APOSCS` → reword the comment.
+Fixes: `SRCSUB` → extract-then-`eval`; `PYBACK` → a **quoted** heredoc (`python3 - arg <<'PY'`); `APOSCS` and `APOSQ` → reword the comment to avoid apostrophes.
 
 ## Git branch work inside sandy (`.git/HEAD` is writable as of 1.5.0, #80)
 

--- a/sandy
+++ b/sandy
@@ -7216,14 +7216,15 @@ if _sandy_agent_has claude; then
         [ -z "$_base_src" ] && _base_src=/dev/null
         jq --arg skip "$skip_perm" --argjson prev "$_prev_plugins" '
             (if . == null then {} else . end) |
-            .spinnerTipsEnabled //= false |
-            .skipDangerousModePermissionPrompt //= ($skip == "true") |
-            # NOTE: the //= operator treats an explicit false as unset, so this and the
-            # sibling skipDangerousModePermissionPrompt / spinnerTipsEnabled lines
-            # will overwrite a user-set false on THIS fallback path, where the node
-            # path above preserves it. Pre-existing quirk of the jq branch, kept
-            # consistent rather than fixed piecemeal for one key.
-            .skipAutoPermissionPrompt //= ($skip == "true") |
+            # only-if-absent for the BOOLEAN keys via has(), not //=. The //=
+            # operator treats an explicit false as unset, so it would overwrite a
+            # user-set false -- silently disagreeing with the node branch above,
+            # which uses a real absence test. false is a meaningful value for all
+            # three of these, so the distinction matters. Object-valued //= uses
+            # below are unaffected: an object is always truthy.
+            (if has("spinnerTipsEnabled") then . else .spinnerTipsEnabled = false end) |
+            (if has("skipDangerousModePermissionPrompt") then . else .skipDangerousModePermissionPrompt = ($skip == "true") end) |
+            (if has("skipAutoPermissionPrompt") then . else .skipAutoPermissionPrompt = ($skip == "true") end) |
             .statusLine //= {"type":"command","command":"/usr/local/bin/sandy-claude-statusline","padding":0} |
             (if $skip == "true"
                 then .permissions = ((.permissions // {}) | .defaultMode = "bypassPermissions")

--- a/test/lint-bash32.sh
+++ b/test/lint-bash32.sh
@@ -29,6 +29,14 @@
 #           and it is a PARSE error, so it killed the entire file while the
 #           summary still printed "945 passed, 0 failed".
 #
+#   APOSQ   an apostrophe in a comment inside a multi-line SINGLE-quoted program
+#           argument (jq/awk/python passed as 'one big string'). The apostrophe
+#           closes the string and the shell reinterprets the rest as code. Same
+#           failure as APOSCS in a different container — APOSCS only looks inside
+#           $( ), so a "jq's" in a jq program broke `bash -n` while APOSCS was
+#           clean. Detected via an explicit opener, NOT quote parity: parity was
+#           tried and floods false positives on any ordinary "don't" in prose.
+#
 # Deliberately NOT checked: `set -E` ERR traps firing in command-substitution
 # subshells (real — see sandy:1043 — but not reliably detectable statically, and
 # a false positive here is worse than a miss).
@@ -120,6 +128,31 @@ def scan(path):
             i = j
         i += 1
 
+    # APOSQ — apostrophe in a comment inside a multi-line SINGLE-QUOTED program
+    # argument (jq / awk / python passed as 'one big quoted string'). Inside that
+    # region an apostrophe CLOSES the string and the shell reinterprets the rest
+    # as code. Same failure as APOSCS, different container: APOSCS only looks
+    # inside $( ), and this bit exactly there — a "jq's" in a comment inside a jq
+    # program broke bash -n while APOSCS reported clean.
+    #
+    # Deliberately NARROW. A parity-of-quotes approach was tried first and was
+    # unusable: any lone apostrophe in ordinary prose ("don't") flips parity and
+    # floods the rest of the file with false positives. So this requires an
+    # explicit opener — a known program-taking command whose line ENDS with the
+    # opening quote — and closes on a line whose first character is that quote.
+    i = 0
+    while i < len(lines):
+        if re.search(r"\b(jq|awk|gawk|sed|perl|python3?|node)\b[^']*'\s*$", lines[i]):
+            j, start = i + 1, i
+            while j < len(lines) and j - start < MAX_BLOCK:
+                if re.match(r"^\s*'", lines[j]):
+                    break
+                if re.match(r"^\s*#", lines[j]) and "'" in lines[j]:
+                    out.append((j + 1, "APOSQ", lines[j].strip()[:88]))
+                j += 1
+            i = j
+        i += 1
+
     # APOSCS — apostrophe in a comment inside a multi-line $( ).
     depth, opened_at = 0, 0
     for i, l in enumerate(lines, 1):
@@ -152,8 +185,9 @@ if [ "$SELF_TEST" = true ]; then
     printf '%s\n' '#!/bin/bash' 'x="$(bash -c '"'"'source <(sed -n "1p" f); g'"'"')"' > "$_fx/srcsub.sh"
     printf '%s\n' '#!/bin/bash' 'python3 -c "' '# the `sandy` binary' 'print(1)' '" arg' > "$_fx/pyback.sh"
     printf '%s\n' '#!/bin/bash' 'out="$(' '  # shellcheck can'"'"'t see this' '  echo hi' ')"' > "$_fx/aposcs.sh"
+    printf '%s\n' '#!/bin/bash' "jq --arg s x '" '  .a //= 1 |' "  # note: jq's //= is odd here" '  .b' "' file" > "$_fx/aposq.sh"
     _fails=0
-    for probe in srcsub pyback aposcs; do
+    for probe in srcsub pyback aposcs aposq; do
         if python3 "$_scanner" "$_fx/$probe.sh" >/dev/null 2>&1; then
             echo "SELF-TEST FAIL: $probe fixture was NOT detected" >&2; _fails=$((_fails + 1))
         else
@@ -182,5 +216,6 @@ else
     echo "  SRCSUB  use extract-then-eval: v=\"\$(sed -n '/^f()/,/^}/p' x)\"; bash -c \"\$v; f\"" >&2
     echo "  PYBACK  use a QUOTED heredoc: python3 - arg <<'PY' ... PY" >&2
     echo "  APOSCS  reword the comment to avoid apostrophes" >&2
+    echo "  APOSQ   reword the comment; an apostrophe closes the single-quoted program" >&2
     exit 1
 fi

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -7744,8 +7744,11 @@ _s95_seed="$(sed -n '/SEED_SETTINGS="\$SANDBOX_DIR\/claude\/settings.json"/,/See
 
 check "§95(1) node branch seeds skipAutoPermissionPrompt" \
     bash -c 'printf "%s" "$1" | grep -q "skipAutoPermissionPrompt:skip"' -- "$_s95_seed"
+# NOTE: matches the has() form, not //= — see §96. The jq branch moved off //=
+# because it treats an explicit false as unset; this check pinned the old form
+# and correctly failed when that changed.
 check "§95(2) jq branch seeds skipAutoPermissionPrompt" \
-    bash -c 'printf "%s" "$1" | grep -q "\.skipAutoPermissionPrompt //="' -- "$_s95_seed"
+    bash -c 'printf "%s" "$1" | grep -q "if has(\"skipAutoPermissionPrompt\") then . else"' -- "$_s95_seed"
 check "§95(3) first-launch printf branch seeds skipAutoPermissionPrompt" \
     bash -c 'printf "%s" "$1" | grep -q "\"skipAutoPermissionPrompt\":true"' -- "$_s95_seed"
 

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -6995,7 +6995,7 @@ echo "§89: bash-3.2 / BSD portability lint (the class CI structurally cannot se
 # ============================================================
 # CI is Ubuntu + bash 5 + GNU userland; the maintainer is macOS + bash 3.2 + BSD.
 # Three constructs parse or expand DIFFERENTLY there, so `bash -n` in CI passes
-# and the break only ever shows up on one machine. All three have already bitten
+# and the break only ever shows up on one machine. All four have already bitten
 # this repo, and each was silent in a way that made it expensive:
 #
 #   §83  nested source <(...) inside $( )  -> exit 127, ERR trap, run aborted
@@ -7014,7 +7014,7 @@ check "lint-bash32.sh exists and is executable-by-bash" \
 
 # The detectors must be proven to DETECT before a clean run means anything —
 # a linter whose patterns silently stopped matching would report success forever.
-check "detectors self-test: all three fire on known-bad fixtures" \
+check "detectors self-test: all four fire on known-bad fixtures" \
     bash -c 'bash "$1" --self-test >/dev/null 2>&1' -- "$_S89"
 
 check "detectors self-test: clean file yields no findings (no false positives)" \
@@ -7769,6 +7769,36 @@ check "§95(5) node merge is only-if-absent (a user-set false is preserved)" \
 # NEGATIVE: the key sandy already had is a DIFFERENT prompt; both must survive.
 check "§95(6) NEGATIVE: skipDangerousModePermissionPrompt is still seeded too (distinct prompt)" \
     bash -c 'printf "%s" "$1" | grep -q "skipDangerousModePermissionPrompt"' -- "$_s95_seed"
+
+# ============================================================
+echo ""
+echo "§96: jq seeder uses has() for booleans, not //= (node/jq parity)"
+# ============================================================
+# jq's //= treats an explicit false as UNSET, so `.k //= true` overwrites a
+# user-set false. The node branch uses a real absence test and preserves it, so
+# the two seeder paths silently disagreed depending on which host tool exists.
+# false is a meaningful value for all three of these keys, so it matters.
+#
+# Object-valued //= (statusLine, extraKnownMarketplaces) is fine and stays: an
+# object is always truthy, so //= never misfires on it.
+_S96="$(cd "$(dirname "$0")/.." && pwd)/sandy"
+_s96_seed="$(sed -n '/SEED_SETTINGS="\$SANDBOX_DIR\/claude\/settings.json"/,/Seeded settings.json/p' "$_S96")"
+
+for _s96_k in spinnerTipsEnabled skipDangerousModePermissionPrompt skipAutoPermissionPrompt; do
+    check "§96 jq branch uses has() for $_s96_k" \
+        bash -c 'printf "%s" "$1" | grep -q "if has(\"$2\") then . else"' -- "$_s96_seed" "$_s96_k"
+    check "§96 NEGATIVE: jq branch no longer uses //= for $_s96_k" \
+        bash -c '! printf "%s" "$1" | grep -qE "^[[:space:]]*\.$2 //="' -- "$_s96_seed" "$_s96_k"
+done
+
+# Behavioral, if jq is present: an explicit false must survive, an absent key
+# must be filled. This is the property; the greps above are just the shape.
+check "§96 behavioral: jq preserves a user-set false and fills an absent key" \
+    bash -c 'command -v jq >/dev/null 2>&1 || exit 0
+        prog="if has(\"skipAutoPermissionPrompt\") then . else .skipAutoPermissionPrompt = (\$skip == \"true\") end"
+        kept="$(printf "%s" "{\"skipAutoPermissionPrompt\":false}" | jq --arg skip true "$prog" | jq -r ".skipAutoPermissionPrompt")"
+        made="$(printf "%s" "{}" | jq --arg skip true "$prog" | jq -r ".skipAutoPermissionPrompt")"
+        [ "$kept" = "false" ] && [ "$made" = "true" ]'
 
 # ============================================================
 # Summary


### PR DESCRIPTION
Two fixes for defects surfaced while adding `skipAutoPermissionPrompt` (#167).

## 1. jq seeder: `has()` instead of `//=` for boolean keys

`//=` treats an explicit `false` as **unset**, so `.k //= true` overwrites a user-set `false`. The node branch uses a real absence test and preserves it — so the two seeder paths silently disagreed depending on which host tool happened to be installed.

Verified before and after:

```
//=    user-set false -> true    (all three keys)
has()  user-set false -> false,  absent -> true
```

Fixed for `spinnerTipsEnabled`, `skipDangerousModePermissionPrompt`, and `skipAutoPermissionPrompt` — `false` is a meaningful value for all three. Object-valued `//=` (`statusLine`, `extraKnownMarketplaces`) is deliberately left alone: an object is always truthy, so `//=` can't misfire there.

**§96 (7 checks)** — `has()` per key, a NEGATIVE per key that `//=` hasn't returned, and one behavioral check that jq preserves a user-set `false` while still filling an absent key.

## 2. `lint-bash32.sh` gains `APOSQ`

Adding the comment for fix 1 **broke `bash -n`**: an apostrophe in `jq's` inside a single-quoted jq program closed the string, and the shell reinterpreted the rest as code. `lint-bash32` reported **clean**, because `APOSCS` only scans inside `$( )` — the same failure in a different container.

`APOSQ` covers a multi-line **single-quoted program argument** (`jq '...'`, `awk '...'`, `python '...'`).

**The first attempt was wrong, and that's worth recording.** I tried quote-parity tracking — any lone apostrophe in ordinary prose (`don't`) flips parity and floods every following comment. The repo scan produced pages of false positives. Since "a lint that cries wolf gets switched off" is this file's own stated principle, the detector now requires an **explicit opener** (a known program-taking command whose line ends with the opening quote) and closes on a line starting with that quote.

**Validated by replay** — the standard this linter sets for itself. Pointed at a copy of sandy with the real comment restored:

```
regress.sh:7219: APOSQ: # NOTE: jq's //= treats an explicit false as unset, so this and the
bash -n: line 7225: syntax error near unexpected token
```

It flags the exact line, and `bash -n` independently confirms that file is broken.

## Mutations

| Mutation | Caught by |
|---|---|
| revert `spinnerTipsEnabled` to `//=` | §96 positive + negative for that key |
| revert `skipAutoPermissionPrompt` to `//=` | §96 positive + negative for that key |
| gut the `APOSQ` opener list | §89 self-test anti-rot |
| **controls** | **§96 7/7 · §89 6/6** |

## Scope

Docs updated everywhere the detectors are enumerated: linter header, CLAUDE.md table, and §89's "all three" → "all four".

No config keys, `schema_version` unchanged. `bash -n` (3 files), `lint-bash32` + self-test, both regen `--check`s, and `--print-schema` (0 bytes stderr) all clean.

**Not covered:** full `test/run-tests.sh` needs Docker; only §89/§96 ran locally.
