### PR TITLE
chore: bump to 1.7.1-dev after cutting 1.7.0

### DIFF
--- a/sandy
+++ b/sandy
@@ -17,7 +17,7 @@ set -euo pipefail
 #   sandy --agent claude,gemini   Override agent selection for this run
 # =============================================================================
 
-SANDY_VERSION="1.7.0"
+SANDY_VERSION="1.7.1-dev"
 SANDY_COMMIT=""  # baked in by install.sh; empty = detect from git at runtime
 
 # Schema contract version for --print-schema / --print-state / --validate-config.


### PR DESCRIPTION
Post-release convention from `CLAUDE.md`: bump to `X.Y.(Z+1)-dev` immediately after tagging, so `main` is never sitting on a version string that matches a shipped tag.

`v1.7.0` is tagged at `635870b` and the GitHub release is live and marked **Latest** (`prerelease=false`), so existing installs will see the update.

This also keeps `--print-version` honest for the two downstream consumers now keying caches on it:

```
main            full_version = 1.7.1-dev-<sha>   (changes every commit)
v1.7.0 install  full_version = 1.7.0             (stable)
```

That distinction is exactly what the field was added to make legible — a cache keyed on `version` alone would never invalidate across dev commits.

The update check strips everything after the first dash, so a `-dev` build compares equal to its base and nobody is nagged toward a release they're already ahead of.