### PR TITLE
chore: commit accumulated docs; delete delivered handoffs and shipped plans

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,20 @@
+# GitHub "Sponsor" button configuration.
+#
+# IMPORTANT: this file only *renders* the button — it does not enable receiving
+# money. The `github:` entry works only after GitHub Sponsors onboarding for the
+# account is complete and approved. External platforms below work as soon as the
+# account exists (the entry is just a link-out).
+#
+# This file takes effect only on the default branch (main), after commit + push.
+
+# --- GitHub Sponsors (0% platform fee) ---
+# Uncomment once your Sponsors account is live and approved:
+# github: [rappdw]
+
+# --- External platforms (uncomment any you set up; each renders as a link) ---
+# ko_fi: rappdw
+# buy_me_a_coffee: rappdw
+# open_collective: sandy
+# polar: rappdw
+# liberapay: rappdw
+# custom: ["https://your-donate-url"]

--- a/cleanup-remote-branches.sh
+++ b/cleanup-remote-branches.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Delete remote branches whose pull request is MERGED.
+#
+#   bash cleanup-remote-branches.sh            # dry run — lists, deletes nothing
+#   bash cleanup-remote-branches.sh --yes      # actually delete
+#   bash cleanup-remote-branches.sh --yes --include-release   # also release/*
+#
+# Safety model: a branch is deleted ONLY if GitHub reports a MERGED pull request
+# whose head branch is exactly that name. That is the strongest available signal
+# and the only one that works here — every PR in this repo is SQUASH-merged, so
+# the branch tip is NOT an ancestor of main and `git branch --merged` /
+# `--no-merged` would wrongly report all of them as unmerged.
+#
+# Branches with no merged PR (long-lived work, closed-without-merge PRs, old
+# release branches) are listed for review and never touched. `main` is excluded
+# unconditionally.
+#
+# Requires: git, gh (authenticated). bash 3.2 / BSD-userland safe.
+
+set -uo pipefail
+
+YES=false
+INCLUDE_RELEASE=false
+for a in "$@"; do
+    case "$a" in
+        --yes|-y) YES=true ;;
+        --include-release) INCLUDE_RELEASE=true ;;
+        -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+        *) echo "unknown argument: $a" >&2; exit 2 ;;
+    esac
+done
+
+command -v gh >/dev/null 2>&1 || { echo "gh not found" >&2; exit 2; }
+git rev-parse --git-dir >/dev/null 2>&1 || { echo "not a git repository" >&2; exit 2; }
+
+REMOTE="${REMOTE:-origin}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "Querying $REMOTE and GitHub..."
+
+# Live remote branches (authoritative — asks the remote, not stale local refs).
+git ls-remote --heads "$REMOTE" 2>/dev/null \
+    | sed 's|.*refs/heads/||' | sort -u > "$TMP/remote.txt"
+
+# Head-branch names of MERGED PRs. --limit is generous; raise if this repo has
+# more than 200 merged PRs and old branches are being missed.
+gh pr list --state merged --limit 200 --json headRefName \
+    --jq '.[].headRefName' 2>/dev/null | sort -u > "$TMP/merged.txt"
+
+# Closed-but-not-merged, reported separately: the work may or may not have
+# landed some other way, so it is a human call.
+gh pr list --state closed --limit 200 --json headRefName,number,title \
+    --jq '.[] | select(.headRefName != null) | .headRefName' 2>/dev/null \
+    | sort -u > "$TMP/closed_all.txt"
+comm -23 "$TMP/closed_all.txt" "$TMP/merged.txt" > "$TMP/closed.txt"
+
+# Never touch these.
+printf 'main\nmaster\nHEAD\n' | sort -u > "$TMP/protected.txt"
+
+comm -12 "$TMP/remote.txt" "$TMP/merged.txt" | comm -23 - "$TMP/protected.txt" > "$TMP/merged_live.txt"
+# Release branches: merged like any other, but a maintainer may keep them on
+# purpose and the tags already pin those releases. Held back unless asked.
+if [ "$INCLUDE_RELEASE" = true ]; then
+    cp "$TMP/merged_live.txt" "$TMP/delete.txt"; : > "$TMP/keep_release.txt"
+else
+    grep -vE '^release[/-]' "$TMP/merged_live.txt" > "$TMP/delete.txt" || true
+    grep -E  '^release[/-]' "$TMP/merged_live.txt" > "$TMP/keep_release.txt" || true
+fi
+comm -23 "$TMP/remote.txt" "$TMP/merged.txt" | comm -23 - "$TMP/protected.txt" > "$TMP/keep.txt"
+comm -12 "$TMP/keep.txt" "$TMP/closed.txt" > "$TMP/keep_closed.txt"
+comm -23 "$TMP/keep.txt" "$TMP/closed.txt" > "$TMP/keep_nopr.txt"
+
+# `grep -c . f || echo 0` double-counts: grep prints 0 AND exits 1, so the
+# fallback appends a second 0. awk has no exit-code coupling.
+count() { awk 'END{print NR}' "$1"; }
+n_del=$(count "$TMP/delete.txt")
+n_cl=$(count "$TMP/keep_closed.txt")
+n_no=$(count "$TMP/keep_nopr.txt")
+n_rel=$(count "$TMP/keep_release.txt")
+
+echo
+echo "=== WILL DELETE — PR merged ($n_del) ==="
+[ "$n_del" -gt 0 ] && sed 's/^/  /' "$TMP/delete.txt" || echo "  (none)"
+
+echo
+echo "=== KEEPING — release branches, merged ($n_rel) ==="
+echo "    Held back by default; tags already pin these. Add --include-release to delete."
+[ "$n_rel" -gt 0 ] && sed 's/^/  /' "$TMP/keep_release.txt" || echo "  (none)"
+
+echo
+echo "=== KEEPING — PR closed without merging ($n_cl) ==="
+echo "    Review by hand: the work may have landed another way, or been abandoned."
+[ "$n_cl" -gt 0 ] && sed 's/^/  /' "$TMP/keep_closed.txt" || echo "  (none)"
+
+echo
+echo "=== KEEPING — no PR found ($n_no) ==="
+echo "    Long-lived branches, old release branches, or never-PR'd work."
+[ "$n_no" -gt 0 ] && sed 's/^/  /' "$TMP/keep_nopr.txt" || echo "  (none)"
+
+echo
+if [ "$n_del" -eq 0 ]; then
+    echo "Nothing to delete."
+    exit 0
+fi
+
+if [ "$YES" != true ]; then
+    echo "Dry run — nothing deleted. Re-run with --yes to delete the $n_del branch(es) above."
+    exit 0
+fi
+
+echo "Deleting $n_del branch(es) from $REMOTE..."
+ok=0; fail=0
+while IFS= read -r b; do
+    [ -n "$b" ] || continue
+    if git push "$REMOTE" --delete "$b" >/dev/null 2>&1; then
+        echo "  deleted  $b"; ok=$((ok + 1))
+    else
+        echo "  FAILED   $b" >&2; fail=$((fail + 1))
+    fi
+done < "$TMP/delete.txt"
+
+echo
+echo "Deleted $ok, failed $fail."
+# Local refs tracking deleted remotes linger until pruned. Note rather than do:
+# `git remote prune` mutates local state the caller may not expect.
+echo "Tip: 'git remote prune $REMOTE' clears the stale local tracking refs."
+[ "$fail" -eq 0 ]

--- a/research/INTEGRATION-OPPORTUNITIES-2026-08.md
+++ b/research/INTEGRATION-OPPORTUNITIES-2026-08.md
@@ -1,0 +1,55 @@
+# Sandy — Potential Integration Opportunities (August 2026)
+
+Companion to `sandbox-landscape-synthesis-2026-08.md`. Where the synthesis asks *"who competes and what do we steal,"* this doc asks *"what could sandy plug into, ride on, or be plugged into"* — ranked by leverage, each with the concrete mechanism, effort, spike-gate, and recommendation. **Observation / inference / recommendation kept distinct; confidence H/M/L.**
+
+The guiding rule from the corpus holds: **sandy integrates by reusing what it already has (a container it can swap the runtime under, a proxy it already owns, an introspection surface others can call) — not by adopting another project's control plane, backend abstraction, or agent loop.** Every "integration" that would import that complexity is rejected below, by name.
+
+---
+
+## 1. Coexist cleanly with Claude Code's native `/sandbox` — *near-term, cheap, timely* — **REC: DO**
+
+- **Observation.** Claude Code now ships its own Bash-tool OS sandbox (`sandbox.*` in settings.json), including an HTTP/SOCKS egress proxy and a `enableWeakerNestedSandbox` mode explicitly for running *inside* Docker. Sandy already seeds `settings.json` every launch and points the agent's DNS at *its own* Go egress proxy.
+- **Risk (inference).** Two uncoordinated proxies (sandy's DNS-redirect proxy vs CC's own HTTP/SOCKS proxy) can collide or double-prompt; CC's sandbox `/sandbox` prompts and `dangerouslyDisableSandbox` fallback can confuse sandy's own posture. CC docs also note `docker` commands fail inside its sandbox — irrelevant in-container but a symptom of the fragility.
+- **Mechanism.** In the seeded settings.json, explicitly set CC's native sandbox to a known state — most likely **`sandbox.enabled: false` in-container**, since sandy's container *is* the isolation boundary and the inner sandbox is redundant/conflicting (this is precisely the scenario `enableWeakerNestedSandbox`'s own caveat describes: "only when the outer container already provides the boundary"). Add a `run-tests.sh` assertion pinning the coexistence choice.
+- **Effort:** **S** (one settings.json key + one structural test). **Spike:** none. **Confidence:** H.
+
+## 2. `SANDY_RUNTIME=runsc|kata` — the honest "stronger boundary" opt-in — *reinforces POST_1.0* — **REC: DO (spike first)**
+
+- **Observation.** The realistic escalation past shared-kernel namespaces is an **OCI runtime swap**, not a microVM library: `--runtime=runsc` (gVisor userspace kernel) or `--runtime=kata-runtime` (real lightweight VMs) both preserve sandy's entire model — same images, same `docker run` flags, same mounts, same proxy topology — and only need a `docker info` runtime-presence probe + a documented env knob.
+- **Explicitly not hyperlight.** Hyperlight isolates *typed function calls* in a kernel-less VM for FaaS; it has no OCI image, no process model, no filesystem/network stack, and guests must be purpose-compiled. `SANDY_RUNTIME=hyperlight` is not buildable. (Confidence: H — from hyperlight's own README disclaimer.)
+- **Mechanism (already sketched in `POST_1.0_IDEAS.md`).** After config load, if `SANDY_RUNTIME` set and present in `docker info --format '{{.Runtimes}}'`, append `--runtime`; warn-and-continue if absent. Privileged-tier.
+- **Effort:** **M.** **Spike (the real gate, already flagged):** does gVisor's netstack break the proxy's DNS/SNI/CONNECT path? Unverified — must soak-test before shipping. **Confidence:** H on the mechanism, M on gVisor compatibility.
+
+## 3. `srt` nested as in-container defense-in-depth — *new, spike-gated* — **REC: SPIKE, then decide**
+
+- **Observation.** Anthropic's `srt` ships `enableWeakerNestedSandbox`, documented and end-to-end tested for unprivileged containers, giving per-syscall filesystem + network policy *inside* an existing container — a second, syscall-granular layer under sandy's own container boundary, covering non-Bash paths CC's own sandbox doesn't.
+- **The open technical risk (inference).** srt's nested mode was tested under `seccomp=unconfined`; whether unprivileged user-namespace creation works under sandy's **`--cap-drop ALL` + default Docker seccomp** posture is **unverified**. That is the gate, not a blocker in principle.
+- **Mechanism (if the spike passes).** Bake `bubblewrap`+`socat`+`@anthropic-ai/sandbox-runtime` into `sandy-base`; wrap the agent (or its Bash subprocesses) under an `srt` policy mapping sandy's existing protected-path list. Belt-and-suspenders inside sandy's boundary.
+- **Effort:** **M** (plus the spike). **Recommendation:** run the spike; if unprivileged-userns fails under sandy's stock posture, drop it (don't relax the container's seccomp/caps to make it work — that trades away more than it buys). **Confidence:** M.
+
+## 4. Sandy as the hardening layer *others call* — *reinforces the transparent-launch primitive* — **REC: HIGH-LEVERAGE, DO**
+
+- **Observation.** Two concrete callers emerged this round. (a) **alice**'s `alice_forge.dispatcher` spawns a raw `claude` to write diffs for selected issues overnight — the single riskiest, least-isolated step in an otherwise home-trusted agent; swapping that spawn to `sandy -p "<task>"` isolates exactly that step. (b) The broader **worktree-manager ecosystem** (cmux, vibe-kanban, Superset, …) already interoperates with sandy at the terminal level and would call a transparent launch.
+- **Mechanism (already in the July doc).** A **transparent-launch primitive** — `SANDY_LAUNCH=raw` / `sandy --exec` (no inner tmux, headless-clean stdio) — is the seam that turns orchestrators from bystanders into "point-and-harden front-ends." alice's catch: its dispatcher runs *inside* alice's own container today, so wiring it to sandy needs either a docker-socket mount into that container (an ironic trust expansion) or relocating the spawn to the host — a decision for alice, not sandy.
+- **Effort:** **M** for the primitive (sandy side). **Confidence:** H that the primitive unlocks the pattern; M on any single caller adopting it.
+
+## 5. Embed nono (`SANDY_NONO=1`) — *possible but low-priority* — **REC: SKIP for now, steal the patterns instead**
+
+- **Observation.** nono's own docs endorse "container + nono inside," and it ships a Docker example. Sandy *could* run the agent as `nono run --profile claude -- claude` for Landlock-on-top-of-Docker defense-in-depth.
+- **Why low-priority (inference).** It duplicates srt's role (§3) with a second toolchain and a second egress proxy that would fight sandy's own. The *value* in nono is its **patterns** (phantom-token credentials → #121; hash-chain audit → new issue), which sandy can adopt into its own proxy/audit hook without embedding nono. **REC:** steal the patterns; revisit embedding only if the srt spike (§3) fails and a Landlock layer is still wanted. **Confidence:** M.
+
+## 6. Explicitly rejected integrations (do not revisit without new signal)
+
+- **agentbox** — no clean library/interop boundary; its box *is* a live git-worktree bind-mounted against host `.git/` with a host relay. Bolting sandy's proxy onto it would be a reimplementation, not reuse. (Its **UX** — pause/checkpoint/IDE-attach — is worth *stealing* as features, per the synthesis; the *project* is not an integration.)
+- **OpenShell** — adopting any of its machinery (gRPC gateway, OPA policy, Z3 prover, compute-driver abstraction) is the exact "platform" complexity sandy's anti-roadmap rejects. Watch-item only.
+- **openworker** — has *less* isolation than sandy (zero container/VM); nothing to consume. Its agent loop + connectors are coupled to its own `aisuite` engine; sandy wraps *other* agents' CLIs and doesn't own the loop.
+- **hyperlight** — different problem category (see §2); not an option.
+- **Docker Sandboxes (`sbx`) as a backend** — carried-forward open question (compete/compose/coexist), unresolved; not actioned here.
+
+---
+
+## 7. Recommended sequencing
+
+1. **Now / cheap:** §1 CC-sandbox coexistence guard (S) + the tamper-evident audit log and `--doctor` from the synthesis (S–M) — all additive, no spike.
+2. **Next / spike-gated:** §2 `SANDY_RUNTIME` (gVisor-netstack spike) and §3 `srt` nested (unprivileged-userns spike) — run both spikes before committing.
+3. **Strategic / larger:** §4 transparent-launch primitive (unlocks the orchestrator-calls-sandy pattern, incl. alice) and the phantom-token/Family-2 broker (#121) — the two moves that most extend sandy's reach and close its credential-visibility gap.

--- a/research/sandbox-landscape-2026-07.md
+++ b/research/sandbox-landscape-2026-07.md
@@ -1,0 +1,46 @@
+# sandy — competitive positioning brief: the AI-coding-agent sandbox / isolation landscape
+
+*Researched 2026-07-04. Every row is cited; unverified items are flagged in Caveats.
+Surfaced from a LinkedIn launch-thread exchange (a prospect referenced Daytona +
+nool.dev). Companion to `POSITIONING-DEEP-DIVE-2026-07.md` and
+`per-project-isolation-landscape.md`.*
+
+## 1. Comparison table (sandbox / runtime-containment category)
+
+| Tool | Open source? | Local vs cloud | Isolation tech | Runtimes / platforms | Pricing (free tier?) | Target user |
+|---|---|---|---|---|---|---|
+| **sandy** *(reference)* | Yes, MIT | **Local** (your machine) | Container hardening: `--cap-drop ALL`, read-only rootfs, `--internal` net + egress-proxy sidecar, ephemeral per-project cred mounts | **Any `docker` CLI**: Docker Desktop, Rancher, Colima, Lima, OrbStack; macOS + Linux | **Free** (self-hosted) | Individual dev running coding agents locally |
+| **Daytona** | AGPL-3.0, but **repo frozen — core went closed-source June 2026** [1][2] | **Cloud/SaaS** first (managed infra; on-prem for enterprise) [1][3] | "Full composable computer" — dedicated kernel/FS/net stack (microVM-class) [3] | Managed cloud (regions); on-prem for enterprise [3] | Cloud free tier: $200 credits + 5 GB, then per-second (~$0.083/hr for 1vCPU+2GB) [4] | Agent builders / enterprise fleets [3] |
+| **Docker Sandboxes** (`sbx`) | Not stated (appears closed tool) [5] | **Local** (standalone `sbx` CLI) [5] | **microVM** per sandbox (own kernel/daemon/FS/net); host-side credential proxy [5][6] | Standalone CLI, **not** Docker-Desktop-required; macOS + Windows installers shown, Linux unclear [5] | Free core; **paid** team admin (net/FS policy) [5] | Dev running coding agents in "YOLO mode" [7] |
+| **E2B** | Yes, OSS core [8] | **Cloud/SaaS** (self-host = enterprise) [8] | **Firecracker microVM** (<200ms start, up to 24h) [8] | Cloud SDK; BYOC/on-prem/self-host on Enterprise [8] | Hobby free ($100 one-time credit); Pro $150/mo; Enterprise custom [8] | Agent/LLM-app builders, enterprise [8] |
+| **Modal** | No (closed SaaS) [9] | **Cloud/serverless** | Sandboxes within broader ML infra; ~25ms cold start [9] | Cloud only; Python-first | $200 free credit, then per-second; **sandbox rate ~3× base** [9] | Enterprise / GPU + agent workloads [9] |
+| **hopx.ai** | Partial (GitHub org exists) [10] | **Cloud** (also powers Bunnyshell's sandbox infra) [11] | **Firecracker microVM**, ~100ms [10] | Cloud; Python/JS/Go [10] | $200 early credits; per-second rates **contact-sales** [10] | Agent builders [10] |
+| **Bunnyshell** | No (commercial EaaS) [11] | **Cloud** + **self-host onto your own k8s** [11] | Firecracker microVM sandboxes; ~100ms [11] | Deploys to your Kubernetes (AWS/GCP/Azure/on-prem) [11] | $0.007/min running; $0 sleeping [11] | Teams / enterprise [11] |
+| **yoloai** (kstenerud) | Yes (Go; license unconfirmed) [12] | **Local** (disposable docker container) | Container, but **all caps + seccomp/AppArmor unconfined** (deliberately permissive; relies on disposability) [12] | Local docker; multi-agent (Claude/Codex/Gemini/Aider/OpenCode) [12] | Free | Individual dev wanting throwaway "full-send" containers [12] |
+
+## 2. Where sandy sits
+
+sandy occupies a distinct whitespace: **local, runtime-agnostic, free/OSS, individual-developer-first runtime containment expressed as one auditable bash script over standard `docker run` primitives.** The cloud players (Daytona, E2B, Modal, hopx, Bunnyshell) all optimize a different axis — *elastic fleets of ephemeral microVMs* for programmatic, at-scale agent code execution, billed per-second — which is genuinely stronger for cloud burst, thousands of concurrent sessions, and team governance/audit trails, but means your code leaves your machine and you pay to run. Against the *local* peers, sandy's differentiators are sharper: **Docker Sandboxes** delivers stronger microVM isolation but is a closed `sbx` binary with paid team controls and no clear Linux story, whereas sandy is fully inspectable and cross-runtime; **yoloai** shares the local-OSS-disposable model but runs *unconfined* (all caps, seccomp/AppArmor off) and leans on throwaway containers, where sandy instead *hardens* the container (cap-drop, read-only rootfs, network egress control, credential trust-tiering). Be honest about the trade: a shared-kernel hardened container is a weaker boundary than a per-sandbox microVM — the microVM crowd wins on raw isolation strength and on managed scale; sandy wins on auditability, zero cost, no data egress, and "works on the docker you already have."
+
+## 3. One-line positioning statement
+
+> **sandy is the free, open-source, single-script way to run any coding agent inside a hardened local Docker container — runtime containment you can audit line-by-line, on the Docker you already have, with nothing leaving your machine.**
+
+(Alt, sharper contrast: *"The cloud sandboxes rent you a microVM fleet; sandy hardens the container on your own laptop — auditable, free, and offline-friendly."*)
+
+## 4. nool complement note (governance — NOT a competitor)
+
+nool.dev operates at a **different layer**: it bounds blast radius on the *codebase*, not the *machine*. It does semantic blast-radius / intent-drift analysis of an agent's diff against its declared scope, Git-native, with an immutable intent ledger (`nool propose` / `blast-radius` / `visualize`) — commercial, hybrid local-eval + SaaS [13]. It answers "did the agent change more than it was supposed to?", while sandy answers "the agent physically cannot touch your host, network, or credentials." They **stack**: run sandy for runtime containment and nool for change governance — complementary guardrails, not overlapping ones.
+
+## 5. Caveats (unverified / soft)
+
+- **Daytona OSS status is the big one:** the AGPL-3.0 repo is still public and forkable, but Daytona explicitly announced going closed-source, with the public repo receiving **no further updates/fixes/releases as of June 2026** [1][2]. Treat "Daytona is open source" as *effectively deprecated OSS + closed cloud product*. Its exact isolation tech (microVM vs. hardened container) is described as "dedicated kernel" but never explicitly named [3].
+- **Docker Sandboxes:** product page says Docker Desktop is *not* required and it installs standalone [5] — so an earlier assumption of Docker-Desktop-lock is **wrong**; correct the pitch accordingly. But its OSS status is **not stated** (appears to be a closed tool with its own bundled microVM runtime), and no Linux installer is shown — both unconfirmed.
+- **hopx.ai / Daytona / Modal exact pricing:** hopx per-second rates are contact-sales / not marketplace-verified [10]; Modal's effective sandbox cost carries multipliers over advertised base [9] — cite as "per-second, premium applies," not exact.
+- **yoloai license** (MIT vs other) not confirmed from the search snippet — verify on the repo before quoting [12].
+- **E2B self-host** exists on Enterprise (BYOC/on-prem) but practical difficulty/cost not established [8]; "OSS core" is accurate but self-hosting the full stack is non-trivial.
+- All per-second cloud prices are **as-advertised** and move; re-check before publishing.
+
+## Sources
+
+[1] https://github.com/daytonaio/daytona · [2] https://www.daytona.io/dotfiles/updates/daytona-is-going-closed-source · [3] https://www.daytona.io/ · [4] https://blaxel.ai/blog/daytona-dev-environment-pricing-alternatives · [5] https://www.docker.com/products/docker-sandboxes/ · [6] https://docs.docker.com/ai/sandboxes/security/isolation/ · [7] https://www.docker.com/blog/docker-sandboxes-run-agents-in-yolo-mode-safely/ · [8] https://e2b.dev/ · [9] https://modal.com/resources/best-code-execution-sandboxes-ai-agents · [10] https://hopx.ai/ · [11] https://www.bunnyshell.com/ai-sandbox-environments/ · [12] https://github.com/kstenerud/yoloai · [13] https://www.nool.dev/

--- a/research/sandbox-landscape-synthesis-2026-08.md
+++ b/research/sandbox-landscape-synthesis-2026-08.md
@@ -1,0 +1,75 @@
+# Sandy — Landscape Synthesis (August 2026)
+
+## 0. Header / method note
+
+- **Subject:** `sandy` @ ~`1.5.1-dev`, origin/main `459dade`, analysis date **2026-08-05**.
+- **Scope:** delta pass triggered by two newly-added `research/` submodules (**nono**, **openworker**) plus a bump of every existing pin (claude-code v2.1.168, agentbox v0.15.0, alice, bulkhead v0.1.3, sandbox-runtime v0.0.54, hyperlight v0.15.x, OpenShell v0.0.57, nono v0.71.0). Builds on `POSITIONING-DEEP-DIVE-2026-07.md` (the prior authoritative synthesis) — this is the August delta, not a from-scratch survey.
+- **Method:** one subagent per project/cluster (nono, openworker, agentbox, alice, bulkhead, sandbox-runtime+CC-native-sandbox, hyperlight+OpenShell) reading actual source, each answering the same three lenses (competitor / integration / ideas-to-steal), plus one agent digesting the prior corpus so findings are tagged **new** vs **reinforces-known**. Synthesis by the orchestrator (Opus).
+- **Confidence** H/M/L on non-trivial claims. **Observation / inference / recommendation** kept distinct.
+- **Anti-roadmap honored:** no re-proposal of the settled rejections (L7/TLS-MITM, deny-first default, YAML policy files, gRPC control-plane, persistent-service mode, driver/backend abstraction, Windows). Where a new idea grazes one (credential *masking* needs TLS termination), the tension is flagged, not hand-waved.
+
+---
+
+## 1. Executive summary
+
+**The ground moved in one material way since July: the wrapped agent grew its own sandbox.** Claude Code now ships a first-party OS sandbox (`/sandbox`, `sandbox.*` in settings.json) built on the **exact same `srt` primitives** (bubblewrap/Seatbelt + seccomp) that Anthropic also publishes standalone. This **narrows sandy's oldest pitch** — "Claude Code has no isolation, you need a wrapper" — but only partially. CC's sandbox is **Bash-tool-only, single-agent, escape-hatchable** (`dangerouslyDisableSandbox` lets the model retry unsandboxed unless a *managed* admin config forbids it), and covers **none** of sandy's multi-agent, host-config-protection, per-project credential-sandbox, or daemon story. Sandy's positioning shifts from *"the only isolation"* to *"an **unconditional, whole-process, multi-agent, host-managed** boundary around agents that increasingly have their own partial, single-tool sandboxes."* That's a legitimate but **narrower** moat than three months ago, and it will keep narrowing if Anthropic extends OS enforcement past Bash — **the #1 trajectory item to watch.** (Confidence: H on scope, from the live CC docs.)
+
+**The competitive relief valve:** of every *"competitor"* examined this round, **bulkhead, agentbox, and openworker all have zero outbound egress isolation** — none. Sandy's egress proxy + host-config protection remain the widest, most-defensible axis in the field; no local-launcher peer matches it.
+
+**Most reinforced own-finding (unchanged from July):** `.env`/`.env.*`/`.env.local` secret-file protection is still missing (only `.envrc` is protected). Nothing this round changes that verdict; it remains the cheapest high-value gap.
+
+**Genuinely-new adopt candidates this round (detail §4):** tamper-evident hash-chained audit log (nono); `sandy --doctor` (bulkhead); daemon `docker pause`/`unpause` (agentbox); clone-mode git isolation as *prevention* vs sandy's *detection-only* sweep (bulkhead); a settings.json coexistence guard for CC's native sandbox (srt/CC).
+
+---
+
+## 2. Competitor map (August delta)
+
+| Project | Category | Verdict (one line) | Conf |
+|---|---|---|---|
+| **Claude Code `/sandbox`** (+ `srt`) | Vendor-native, **strategic** | Narrows the single-agent pitch; Bash-only, single-agent, escape-hatchable — can't touch multi-agent / host-config / daemon / cred-sandbox. **The trajectory to watch.** | H |
+| **bulkhead** `pmembrey` | **Direct competitor — weaker** | Nearest framing-match (Rust, devcontainer, "fallible agent" threat model), but **no egress isolation** (own README) and protects almost no host config in default mode. Sandy is materially ahead. | H |
+| **agentbox** `madarco` | Partial competitor | Great velocity UX (5 backends incl. Firecracker clouds, `pause`/checkpoint, VNC/IDE attach) but **no outbound egress control** and runs `SYS_ADMIN`/`seccomp:unconfined` for DinD. | H |
+| **nono** `nolabs-ai` (NEW) | Partial competitor, different mechanism | OS-capability sandbox (Landlock/Seatbelt, no container), Sigstore team. Same "fallible agent" goal; its **credential-injection + tamper-evident audit are more rigorous than sandy's** — steal those. | H |
+| **OpenShell** `NVIDIA` | Anti-sandy — **watch-item, growing** | ~8k★ (+600 since July), NVIDIA/GTC, same agent roster, but a gRPC/mTLS/K8s/OPA/Z3 control plane — the architecture sandy explicitly rejects. Not sandy's user; well-funded for the enterprise segment. | H |
+| **openworker** `andrewyng` (NEW) | **Not a competitor** | Desktop "AI coworker" app, own agent engine, 25+ SaaS connectors — and **zero OS/container isolation** (its own code marks `ContainerExecutor` as unbuilt). Makes sandy look stronger by comparison. | H |
+| **alice** `jcronq` | **Not a competitor — a consumer** | Persistent home-server personal agent (memory, Signal, self-merging PR pipeline). Its overnight "spawn a worker to write code" step is a candidate *caller* of sandy, not a rival. | H |
+| **hyperlight** `hyperlight-dev` | **Not a viable backend** | Kernel-less microVM for *typed function calls* (FaaS), not general Linux userspace — cannot run an agent toolchain. The real "stronger boundary" path is gVisor/Kata (OCI runtime swap), not this. | H |
+
+**Two corrections to the prior corpus's from-afar reads, now that the code was inspected:**
+- **nono** was previously logged only by star-count as "ships L7 egress + credential broker — closest analog to sandy+broker+L7." Code inspection refines this: nono's isolation is **OS-capability (Landlock), not a container**, and its own docs recommend layering *inside* a container for real isolation — so it is a **partial competitor whose patterns to steal are credential-injection and audit-integrity**, not a "sandy+L7" substitute.
+- **OpenShell**'s "vm-runtime" is genuinely just **one of four (Docker/Podman/K8s/VM) compute drivers, and the least mature** (libkrun, "experimental," CPU/mem limits unwired). The real isolation work happens *inside* the sandbox (Landlock/seccomp/OPA), not at the VM boundary — reinforcing "watch what it is (NVIDIA weight), ignore what it builds (control plane)."
+
+---
+
+## 3. Where sandy stands (positioning delta)
+
+- **Still unique:** the *combination* — per-project credential-isolated whole-session sandbox wrapping **any** of 5 agents (or several side-by-side) in one hardened container with one uniform egress proxy + an unusually thorough untrusted-workspace posture. No project in this set matches the combination; most match zero of the egress + host-config axes.
+- **Newly contested (narrowed, not lost):** "the isolation Claude Code lacks" — CC now has a partial one. Reframe the pitch to the *unconditional/whole-process/multi-agent/host-managed* framing above.
+- **Honestly behind (say so):** kernel-grade boundary (shared-kernel container vs microVMs) — concede, and note the real opt-in path is `SANDY_RUNTIME=runsc|kata` (§ integration doc), **not** hyperlight; `.env` protection (must-fix); credential *visibility* in-container (a forwarded token is fully readable — the phantom-token/broker work addresses this).
+- **Anti-roadmap reaffirmed** by this round: every "platform" peer (OpenShell) traded away the hardened-container edge for a control plane; every velocity-first peer (agentbox) traded away egress isolation. Sandy's single-file minimalism + egress-first posture remains the differentiator.
+
+---
+
+## 4. Ideas — prioritized (new vs reinforces-known)
+
+**Top tier (new security wins, on-brand):**
+1. **Tamper-evident audit log** — *new (nono)*. Extend `SANDY_TOOL_AUDIT`'s JSONL with a rolling hash-chain head + session-end Merkle root so the log is *provably un-edited*. Turns "what did this session do" into "prove it wasn't edited after." Effort **S–M**. → **new issue.**
+2. **Phantom-token / credential masking** — *reinforces #121 + POST_1.0 broker*. nono **and** srt independently converged: agent never sees the real secret; injected only at the upstream hop. **Caveat:** LLM-API-key masking needs TLS termination (violates the never-terminate-TLS invariant) — but the **git/gh/SSH version is exactly the already-planned Family-2 Unix-socket broker**, so this is strong convergence evidence to prioritize the broker and to *scope out* the API-key case. → **enhance #121.**
+3. **Clone-mode git isolation** — *reinforces-known, sharpened (bulkhead)*. `git clone --no-local --no-hardlinks` into a scratch dir so `.git/hooks`/workflows are never mounted: **prevention** vs sandy's current **detection-only** exit sweep (whose threat window sandy's own docs admit). Effort **M**. → **new issue.**
+
+**Second tier (ops/ergonomics gaps competitors exposed):**
+4. **`sandy --doctor [--fix]`** — *new (bulkhead)*. Standalone preflight diagnostics (docker reachable, buildx health, image staleness), callable independent of a launch. Effort **S**. → **new issue.**
+5. **Daemon `docker pause`/`unpause`** — *new (agentbox)*. Pause on detach / unpause on `--attach` to cut idle CPU/RAM across a daemon fleet. Effort **S**. → **new issue.**
+6. **Coexist with CC's native `/sandbox`** — *new (srt/CC)*. Seed settings.json so sandy's DNS-redirect proxy and CC's own HTTP/SOCKS proxy don't collide or double-prompt (likely `sandbox.enabled:false` in-container, since sandy *is* the boundary). Guard with a `run-tests.sh` assertion. Effort **S**, strategically timely. → **new issue.**
+7. **`SANDY_RUNTIME=runsc|kata`** — *reinforces POST_1.0*. The honest microVM answer is an **OCI runtime swap**, not hyperlight. Effort **M** + the known gVisor-netstack-vs-proxy spike. → **new issue (from POST_1.0).**
+8. **Unix-socket-creation seccomp block** — *new (srt)*. A compromised agent can open local Unix sockets the egress topology never sees; add a seccomp profile to the agent container. Effort **M**.
+
+**Third tier (candidate follow-ups, not filed yet):** session rollback/undo (`SANDY_ROLLBACK`, nono); `sandy --code` VS Code / Dev-Containers attach (agentbox); pinned-agent-version knob (bulkhead — demand evidence for a POST_1.0 idea); denial→propose-`SANDY_ALLOW_HOSTS` `/allow-host` skill (OpenShell UX, no OPA); Signal channel (alice); `event-log` query CLI over the audit trail (alice); per-target "standing rule" approvals + persona manifests (openworker); `docker commit` checkpoint/warm-restart (agentbox — bigger design lift given `--read-only` root); devcontainer.json-compatible emission mode (bulkhead — reduced-fidelity companion, **L**).
+
+**Unchanged top own-finding:** `.env`/secret-file protection (still the cheapest high-value gap; no project this round changes the verdict).
+
+---
+
+## 5. Open questions (carried forward, maintainer-only)
+
+Unchanged from the July doc §8 and still live: growth ambition (solo vs scale); 2.0 appetite (batch broker + stronger-boundary runtime, or keep 1.x additive); alice-collaboration intent (now with a concrete "alice-calls-sandy" mechanism); willingness to ship a 2nd host-side helper (for the broker); Docker-Sandboxes stance (compete / compose / coexist); `.env` protect-by-default vs opt-in. **New for August:** how aggressively to reframe positioning now that Claude Code sandboxes itself — proactively ("layered defense around a self-sandboxing agent") or wait until CC's sandbox scope expands past Bash.

--- a/use-cases/supply-chain-attack-mitigation.md
+++ b/use-cases/supply-chain-attack-mitigation.md
@@ -1,0 +1,91 @@
+# Supply Chain Attack Mitigation
+
+How sandy limits blast radius when a dependency in your AI coding workflow is compromised.
+
+## Background: The LiteLLM Incident (March 2026)
+
+In March 2026, attackers compromised the LiteLLM Python package through a poisoned Trivy GitHub Action. The compromised CI action exfiltrated LiteLLM's PyPI publishing token, allowing the attackers to push malicious versions (1.82.7 and 1.82.8) to PyPI. The attack was sophisticated and multi-staged:
+
+**Stage 1 — Harvest everything.** The payload collected system metadata, SSH keys, `.env` files, shell history, cloud credentials (with full IMDSv2 signing), Kubernetes configs and service account tokens, and cryptocurrency wallet files.
+
+**Stage 2 — Exfiltrate.** Collected data was encrypted with AES-256-CBC and a hardcoded RSA public key, bundled as a tarball, and POSTed to a public HTTPS endpoint (`models.litellm.cloud`).
+
+**Stage 3 — Persist and spread.** A backdoor was installed as a systemd user service polling a C2 server every 5 minutes. If Kubernetes tokens were found, the payload read all secrets across namespaces and deployed privileged pods for host-level persistence.
+
+For the full technical breakdown, see [Snyk's analysis](https://snyk.io/articles/poisoned-security-scanner-backdooring-litellm/).
+
+## The Scenario
+
+Imagine you're using LiteLLM inside sandy to route Claude Code's API traffic through AWS Bedrock instead of Anthropic's first-party API. LiteLLM runs as a dependency inside the container, and you've configured it with Bedrock credentials. One day, `pip install --upgrade litellm` pulls the compromised version.
+
+What happens next depends entirely on the environment the code is running in.
+
+## What Sandy Blocks
+
+### Cloud credential theft via IMDS
+
+The attack's most dangerous capability was querying the cloud Instance Metadata Service (IMDS) at `169.254.169.254` to steal IAM role credentials. On an unprotected EC2 instance, this gives the attacker access to whatever AWS permissions the instance role has — potentially S3 buckets, databases, other services.
+
+Sandy blocks the entire `169.254.0.0/16` range via iptables rules in the `DOCKER-USER` chain. The IMDS query never leaves the container.
+
+### Kubernetes lateral movement
+
+The attack read Kubernetes service account tokens and used them to enumerate secrets across namespaces and deploy privileged pods. Sandy containers have no access to `~/.kube/`, no service account tokens are mounted, and no Kubernetes tooling is present. There is nothing to exploit.
+
+### SSH key theft
+
+The payload harvested SSH private keys from `~/.ssh/`. In sandy's default configuration (`SANDY_SSH=token`), no SSH keys are mounted into the container. Git authentication uses a scoped GitHub CLI token over HTTPS instead. Even in the opt-in `SANDY_SSH=agent` mode, only the agent socket is forwarded — private key files never enter the container.
+
+### Host filesystem harvesting
+
+The attack collected `.env` files, shell history, and cryptocurrency wallets from the user's home directory. Sandy containers cannot see the host home directory. The container's `/home/claude` is a 2GB tmpfs that exists only for the duration of the session. The only host paths accessible are the mounted workspace directory and the per-project sandbox volumes.
+
+### Persistence via systemd
+
+The attack installed a backdoor at `~/.config/sysmon/sysmon.py` and registered it as a systemd user service. Sandy's container has no systemd, no cron, no init system of any kind. The root filesystem is read-only (`--read-only`). Even if the malicious code writes to the tmpfs home directory, everything is destroyed when the container exits. There is no mechanism for background processes to survive a session.
+
+### Privilege escalation
+
+The container runs with `--cap-drop ALL` and `--security-opt no-new-privileges:true`. Only the minimum capabilities needed for file ownership operations (`SETUID`, `SETGID`, `CHOWN`, `DAC_OVERRIDE`, `FOWNER`) are added back. The attack cannot escalate privileges, load kernel modules, or access raw sockets.
+
+### LAN lateral movement
+
+Sandy blocks all RFC 1918 ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`), link-local (`169.254.0.0/16`), and CGNAT/Tailscale (`100.64.0.0/10`). The container cannot reach other machines on your network, NAS devices, internal APIs, or VPN endpoints.
+
+## What Sandy Does Not Block
+
+### Exfiltration to public endpoints
+
+The LiteLLM payload POSTed stolen data to `https://models.litellm.cloud/` — a public HTTPS endpoint. Sandy allows outbound internet access by design (Claude Code needs it for the Anthropic API, GitHub, package registries, etc.). A compromised dependency can exfiltrate data to any public URL.
+
+This is the fundamental trade-off: AI coding agents need internet access to function, and that same access can be used for exfiltration.
+
+### Credentials that must be in the container
+
+If LiteLLM is routing to Bedrock, the container must have AWS credentials (access key, secret key, or session token). These are exposed to any code running in the container, including compromised dependencies. Similarly, `ANTHROPIC_API_KEY` or `GIT_TOKEN` are available in the container's environment when configured.
+
+### Workspace source code
+
+The workspace directory is bind-mounted read-write. Any code, configuration, or secrets stored in the project directory are accessible to the compromised dependency.
+
+## Defense in Depth Summary
+
+| Attack vector | Without sandy | With sandy |
+|---|---|---|
+| IMDS credential theft | Full IAM role access | Blocked (`169.254.0.0/16` dropped) |
+| Kubernetes secrets | All namespaces readable | No k8s access exists |
+| SSH private keys | All keys in `~/.ssh/` | Not mounted (default) |
+| Host home directory | Full read access | Not accessible (tmpfs home) |
+| Shell history / `.env` files | Readable from host filesystem | Only workspace `.env` visible |
+| Systemd persistence | Backdoor survives reboot | No systemd, tmpfs wiped on exit |
+| LAN lateral movement | Full network access | All private ranges blocked |
+| C2 polling loop | Runs indefinitely | Dies with container session |
+| Privilege escalation | Possible via setuid binaries | `no-new-privileges`, capabilities dropped |
+| Exfiltration to public internet | Possible | **Still possible** |
+| In-container credentials | Possible | **Still possible** |
+
+## Takeaways
+
+Sandy converts what would be a complete system compromise into a contained incident limited to the current session's workspace and explicitly provided credentials. The attack loses its most dangerous capabilities: cloud credential theft, lateral movement, and persistence. What remains — exfiltration of in-container data to public endpoints — is a harder problem that would require egress filtering (allowlisting specific API endpoints), which imposes significant usability trade-offs.
+
+The broader lesson: supply chain attacks are inevitable in ecosystems with deep dependency trees. The question isn't whether a dependency will be compromised, but what the blast radius will be when it happens. Sandboxing tools like sandy don't eliminate the risk, but they dramatically reduce the blast radius from "full infrastructure compromise" to "one session's worth of accessible data."


### PR DESCRIPTION
Untracked files had built up over months. Sorted by whether they still carry information, not by age. Each deletion was read before removing, since untracked files aren't recoverable.

## Committing

| | |
|---|---|
| `.github/FUNDING.yml` | repo config |
| `cleanup-remote-branches.sh` | maintenance tool, reusable |
| `use-cases/supply-chain-attack-mitigation.md` | how sandy limits blast radius in the March 2026 LiteLLM compromise — substantive, and the only use-case doc |
| `research/INTEGRATION-OPPORTUNITIES-2026-08.md`<br>`research/sandbox-landscape-2026-07.md`<br>`research/sandbox-landscape-synthesis-2026-08.md` | fit the existing `research/` pattern, which already holds 17 committed analyses |

## Deleting as cruft

| | why |
|---|---|
| `fuzz-flake-fix.patch` | applied and pushed weeks ago |
| `architecture_handoff.md` | one-time handoff to sandy-ui; sent, acted on, and the surfaces it described are now covered by `SPEC_INTROSPECTION.md` and the 1.7.0 notes |
| `inbox_lab_handoff.md` | one-time handoff to inbox-lab; delivered |
| `mcp.handback.md` | delivered; its verified findings about `mcpServers` in `.claude.json` are now asserted by `run-tests.sh` §87 and referenced from #124 |
| `plans/` (10 batch plans) | implementation plans for the 1.0.1 and 1.1.0 milestones against baseline SHAs from months ago. That work shipped; the plans are scaffolding |

## The pattern worth naming

**Handoff documents are transient by construction.** They exist to move information to another workspace, and once delivered the durable part lives in tests, issues, or the spec — not in a file at the repo root. Left in place they read as current documentation, which is worse than absent.