### PR TITLE
fix(help): document the daemon family, and ratchet --help against cli_flags (#162)

### DIFF
--- a/sandy
+++ b/sandy
@@ -3052,11 +3052,31 @@ Flags:
   --upgrade          Update sandy to the latest version
   --agent <list>     Agent(s) to launch (overrides SANDY_AGENT and
                      .sandy/config). One of: claude, gemini, codex,
-                     opencode. Comma-separated for multi-agent,
+                     opencode, grok. Comma-separated for multi-agent,
                      e.g. --agent claude,gemini or --agent=claude,opencode
+  --workspace <path> Target workspace directory (defaults to the current
+                     directory). Honored by the bare launch path (including
+                     -p/--rebuild/--build-only), --start, --attach, --stop,
+                     --update-sessions, --reset-sandbox, and --remove-sandbox.
   -v                 Verbose: show startup sections, pause on exit
   -vv                Debug: add bash trace to user-setup.sh
   -vvv               Full trace: also trace entrypoint.sh and show docker flags
+
+Daemon sessions (survive a closed terminal; a session outlives the client
+that started it, so a closed tab/dropped SSH/IDE quit does not end it):
+  --start            Start a detached daemon session for this workspace and
+                     return once attachable. Sub-options: --workspace PATH
+  --attach           Attach an interactive client to a running daemon
+                     session (last-wins: a second attach displaces the
+                     first). Exit codes: 0 = session ended while attached,
+                     3 = clean detach (session lives on), 4 = no such
+                     session. Sub-options: --workspace PATH
+  --stop             Stop a running daemon session (full teardown: container,
+                     proxy, networks, lock). Sub-options: --workspace PATH
+  --update-sessions  Fleet image refresh + rolling restart across every
+                     daemon session on the host; scope to one session with
+                     --workspace PATH. Sub-options: --dry-run, --yes,
+                     --idle-for <minutes>, --rebuild, --workspace PATH
 
 Maintenance (no config/mutex/build — needs only a reachable Docker daemon):
   --stop-all         Fleet emergency stop: enumerate every daemon session on the
@@ -3093,7 +3113,8 @@ Introspection (machine-readable JSON; no Docker required):
   --print-version         Emit {schema_version, version, commit, full_version}
                           as JSON. full_version is the stable cache key.
 
-All other arguments are forwarded to the agent (claude or gemini).
+All other arguments are forwarded to the agent (claude, gemini, codex,
+opencode, or grok).
 EOF
     exit 0
 fi

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -7378,9 +7378,94 @@ check "§91(6a) anti-rot: extracted set contains --start/--workspace/--gc/--agen
 check "§91(6b) anti-rot: extracted parser set has >=20 entries (scope has not silently shrunk)" \
     bash -c '[ "$1" -ge 20 ]' -- "$_S91_EXTRACTED_COUNT"
 
+# (7)/(8) parser<->cli_flags lockstep (above) says nothing about --help TEXT --
+# a flag can be a real cli_flags entry with full parser support and still be
+# undocumented in --help (#162: --start/--attach/--stop/--update-sessions were
+# exactly this). This block extracts the --flag tokens --help actually PRINTS
+# and diffs that against cli_flags, independently of the parser-source
+# extraction above.
+_S91_HELP_OUT="$(mktemp)"
+# Guarded for the same reason as the extraction below: a --help that EXITS
+# non-zero must fail a check, not abort the suite before any check runs.
+bash "$_S91_SANDY" --help > "$_S91_HELP_OUT" 2>&1 || true
+_S91_HELP_TOKENS_FILE="$(mktemp)"
+# `|| true` is load-bearing: grep exits 1 on no matches, and under the suite's
+# `set -euo pipefail` + ERR trap that ABORTS THE WHOLE RUN rather than failing a
+# check -- reporting "N passed, 0 failed" with no failing assertion. Latent while
+# --help works, which is exactly what makes it dangerous: a --help regression is
+# the one condition these checks exist to catch, and it is the same condition
+# that would silence them. Guarded, an empty --help fails (7) cleanly instead.
+grep -oE -- '--[a-z][a-z-]+' "$_S91_HELP_OUT" | sort -u > "$_S91_HELP_TOKENS_FILE" || true
+
+# (7) FORWARD: every cli_flags name must be documented (printed as a token) in --help.
+_S91_HELP_FWD_MISSING="$(grep -Fxvf "$_S91_HELP_TOKENS_FILE" "$_S91_NAMES_FILE" 2>/dev/null || true)"
+check "§91(7) cli_flags subset of --help tokens (every real flag is documented)" \
+    bash -c '[ -z "$1" ]' -- "$_S91_HELP_FWD_MISSING"
+
+# (8) REVERSE: every token --help prints, minus real cli_flags names, must be a
+# known SUBOPT (a sub-option of some parent flag, e.g. --dry-run/--idle-for) --
+# not a stray or misspelled token with no home in cli_flags at all.
+_S91_HELP_UNION_FILE="$(mktemp)"
+cat "$_S91_NAMES_FILE" "$_S91_EXCLUDE_FILE" | sort -u > "$_S91_HELP_UNION_FILE"
+_S91_HELP_REV_MISSING="$(grep -Fxvf "$_S91_HELP_UNION_FILE" "$_S91_HELP_TOKENS_FILE" 2>/dev/null || true)"
+check "§91(8) --help tokens subset of (cli_flags union SUBOPT) (no undocumented-origin token)" \
+    bash -c '[ -z "$1" ]' -- "$_S91_HELP_REV_MISSING"
+
+# (9) --agent help text must name exactly the same agent list --print-schema
+# advertises via "agents" -- bound to the machine-readable source so a 6th
+# agent added to sandy without a --help edit is caught here, not by hand.
+_S91_HELP_FLAT="$(tr '\n' ' ' < "$_S91_HELP_OUT" | tr -s ' ')"
+_S91_AGENTS_PY="$(mktemp)"
+cat > "$_S91_AGENTS_PY" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+print(", ".join(a["name"] for a in d["agents"]))
+PY
+_S91_AGENTS_LIST="$(python3 "$_S91_AGENTS_PY" "$_S91_SCHEMA_JSON")"
+case "$_S91_HELP_FLAT" in
+    *"One of: $_S91_AGENTS_LIST."*) _S91_AGENTS_MATCH=1 ;;
+    *) _S91_AGENTS_MATCH=0 ;;
+esac
+check "§91(9) --help --agent list matches --print-schema agents ($_S91_AGENTS_LIST)" \
+    bash -c '[ "$1" = "1" ]' -- "$_S91_AGENTS_MATCH"
+
+# (10) the --workspace help ENTRY (not the whole help text) must name the same
+# command tokens as the --workspace cli_flags description asserted in
+# §91(5b) above -- mirrored here so the two copies cannot drift independently.
+_S91_WS_HELP_PY="$(mktemp)"
+cat > "$_S91_WS_HELP_PY" <<'PY'
+import re, sys
+text = open(sys.argv[1]).read()
+m = re.search(r'--workspace <path>.*?(?=\n  --|\n  -v|\n\n)', text, re.S)
+assert m, "could not locate a --workspace <path> entry in --help output"
+block = m.group(0)
+for tok in ("--start", "--attach", "--stop", "--update-sessions", "--reset-sandbox", "--remove-sandbox"):
+    assert tok in block, "help --workspace entry missing " + tok
+PY
+check "§91(10) --help --workspace entry names --start/--attach/--stop/--update-sessions/--reset-sandbox/--remove-sandbox" \
+    python3 "$_S91_WS_HELP_PY" "$_S91_HELP_OUT"
+
+# (11) every cli_flags flag must appear as its OWN left-column entry in --help
+# (a line beginning with exactly two spaces then the flag), not merely be
+# NAME-DROPPED inside another entry's cross-reference prose (the --workspace
+# entry above legitimately mentions --start/--attach/--stop/etc. by name --
+# that must not be mistaken for --start's OWN documentation). This is what
+# actually proves "the flag has a documented entry", closing a real gap in
+# (7)/(8) above: deleting just the --start entry while --workspace's
+# cross-reference prose still says "--start" leaves the token present
+# somewhere in the help text, so (7) alone would not catch it.
+_S91_HELP_ANCHORED_FILE="$(mktemp)"
+# Guarded like the token extraction above -- same reason, same failure mode.
+grep -oE '^  --[a-z][a-z-]+' "$_S91_HELP_OUT" | sed 's/^  //' | sort -u > "$_S91_HELP_ANCHORED_FILE" || true
+_S91_ENTRY_MISSING="$(grep -Fxvf "$_S91_HELP_ANCHORED_FILE" "$_S91_NAMES_FILE" 2>/dev/null || true)"
+check "§91(11) every cli_flags name has its own left-column --help entry (not just a cross-reference mention)" \
+    bash -c '[ -z "$1" ]' -- "$_S91_ENTRY_MISSING"
+
 rm -f "$_S91_EXTRACTED_FILE" "$_S91_SCHEMA_JSON" "$_S91_NAMES_FILE" "$_S91_DESC_FILE" \
       "$_S91_NAMES_PY" "$_S91_DESC_PY" "$_S91_EXCLUDE_FILE" "$_S91_FORWARDED_FILE" \
-      "$_S91_FWD_CHECK_FILE" "$_S91_NAMES_MINUS_FWD_FILE" "$_S91_WS_CHECK_PY" 2>/dev/null || true
+      "$_S91_FWD_CHECK_FILE" "$_S91_NAMES_MINUS_FWD_FILE" "$_S91_WS_CHECK_PY" \
+      "$_S91_HELP_OUT" "$_S91_HELP_TOKENS_FILE" "$_S91_HELP_UNION_FILE" "$_S91_AGENTS_PY" \
+      "$_S91_WS_HELP_PY" "$_S91_HELP_ANCHORED_FILE" 2>/dev/null || true
 
 # ============================================================
 echo ""


### PR DESCRIPTION
Closes #162.

`sandy --help` had drifted from the code in four user-visible ways, none of which anything could have caught:

1. **The entire daemon family was absent** — `--start`, `--attach`, `--stop`, `--update-sessions` (and `--idle-for`). The feature that makes a session survive a closed terminal, and the surface `sandy-ui` is built on, was invisible in `--help`.
2. **`--workspace` had no entry of its own** — it appeared *only* as a sub-option inside the `--reset-sandbox` and `--remove-sandbox` entries, despite being honored by the bare launch path, `--start`, `--attach`, `--stop`, `--update-sessions`, `--reset-sandbox` and `--remove-sandbox`.
3. **`--agent` omitted grok.** Help said "One of: claude, gemini, codex, opencode" while `sandy:6386` accepts grok. A grok user reading `--help` was told their agent was invalid — a shipped bug, not merely a docs gap.
4. **The footer** said arguments go to "the agent (claude or gemini)". Five agents are supported.

## The deliverable is the ratchet, not the text

#162 exists precisely because `--help` rotted while `cli_flags` stayed correct. §91 is extended **in place** (no new section — #178 took §99, #179 took §100):

| check | asserts |
|---|---|
| (7) | `cli_flags ⊆ help_tokens` — **exception list empty** |
| (8) | `help_tokens ⊆ (cli_flags ∪ SUBOPT)` — **exception list empty** |
| (9) | the `--agent` list **equals** `--print-schema`'s `agents`, matched including its trailing period so the list is closed at both ends |
| (10) | the `--workspace` help entry names the same command tokens §91(5b) already asserts for the cli_flags description |
| (11) | every cli_flags name has its **own left-column entry**, not merely a mention somewhere in the page |

Empty exception lists in (7)/(8) are the point — there's nothing to quietly grow. (8) is empty only because #178 put `--orphans`/`--sandbox` in `_S91_SUBOPT`.

(11) exists because (7) is vacuous alone: deleting the `--start` *entry* while `--workspace`'s cross-reference still said "--start" left the token present somewhere in the page, so (7) and (8) both passed. Confirmed by mutation — deleting all four daemon entries fails **only** (11).

## Validation finding: the guard could be silenced by the very thing it guards against

Three pipelines reading `--help` were unguarded — the invocation, the token extraction, and (11)'s anchored extraction. Under the suite's `set -euo pipefail` + ERR trap, a `--help` that emits nothing makes `grep -oE` exit 1, which **aborts the whole run** reporting "N passed, **0 failed**" with no failing assertion.

So the single condition these checks exist to catch — a broken `--help` — was also the condition that would stop them from ever reporting it. Same class that cost #178 a CI round trip, but worse here because it's self-silencing.

Verified by shimming `--help` to emit nothing: **before**, an ERR-trap abort before any check ran; **after**, four clean failures naming exactly what's wrong (7, 9, 10, 11).

*Observed but deliberately not changed:* three older pipelines from #156 (`run-tests.sh:7278/7309/7311`) have the same shape over non-empty literals. Out of scope here; noted so it isn't re-discovered as new.

## Mutations, each killing exactly the intended check

| mutation | fails |
|---|---|
| delete all four daemon entries | (11) only |
| add a 6th agent to the schema, don't touch help | (9) only |
| omit grok from help (the real defect 3) | (9) only |
| help lists a stale **extra** agent the schema lacks | (9) only — the trailing period closes the reverse direction |
| drop the `--stop` token from the `--workspace` entry | (10) only |
| inject a stray undocumented left-column entry | (8) only |

§91 15/15 · §92 28/28 · §98 9/9 · §99 50/50 · §100 27/27, all under a harness replicating the real preamble. `lint-bash32` + `--self-test`, `regen-config-docs --check`, `regen-template --check`, `bash -n` clean. `cli_flags - help_tokens` is now empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
