### PR TITLE
ci: temporary WIF smoke test (#190)

### DIFF
--- a/.github/workflows/anthropic-wif-test.yml
+++ b/.github/workflows/anthropic-wif-test.yml
@@ -1,0 +1,49 @@
+name: anthropic-wif-test
+# Scoped to main deliberately. The federation rule's subject pattern is exactly
+# `repo:rappdw/sandy:ref:refs/heads/main`, so a push to any OTHER branch mints a
+# JWT whose `sub` will not match and the exchange fails with a rule mismatch --
+# which reads as a broken setup but is the scoping working correctly.
+# main is protected, so merging the PR that adds this file IS a push to main:
+# the merge itself triggers the first run.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  call-claude:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch GitHub OIDC token
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const token = await core.getIDToken('https://api.anthropic.com');
+            core.setSecret(token);
+            core.exportVariable('JWT', token);
+      # The ~10 minute budget in docs/CI-KEYLESS-AUTH.md is an assumption until
+      # something measures it. Do that here, where it is cheap and isolated.
+      - name: Report the JWT's actual lifetime
+        run: |
+          set -euo pipefail
+          _pay="$(printf '%s' "$JWT" | cut -d. -f2)"
+          _pay="$_pay$(printf '%*s' $(( (4 - ${#_pay} % 4) % 4 )) '' | tr ' ' '=')"
+          printf '%s' "$_pay" | tr '_-' '/+' | base64 -d \
+            | jq '{sub, aud, iat, exp, lifetime_seconds: (.exp - .iat)}'
+
+      - name: Exchange for an Anthropic access token
+        run: |
+          curl -sS https://api.anthropic.com/v1/oauth/token \
+            -H "content-type: application/json" \
+            --data @- <<JSON | jq 'with_entries(if (.key | test("token$")) then .value = "<redacted>" else . end)'
+          {
+            "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            "assertion": "$JWT",
+            "federation_rule_id": "fdrl_016DVS3aoiaRui1LxwX4YC6U",
+            "organization_id": "f42a421a-321a-452c-9eb9-860dbccdc4cc",
+            "service_account_id": "svac_01JEjiEmiBLdabESCFbppKhG",
+            "workspace_id": "wrkspc_01Chw1A9mY3LBx9xJr4rgC87"
+          }
+          JSON


### PR DESCRIPTION
A minimal end-to-end check that the workload identity federation setup works, before wiring it into the integration suite: mint a GitHub OIDC token, exchange it at `/v1/oauth/token`, print the redacted response.

**Temporary — delete once WIF is proven in `integration.yml`.** It exists to fail fast and in isolation, not to be maintained. Note it will run on **every push to `main`** until removed.

## Why `branches: [main]` rather than bare `on: push`

The federation rule's subject pattern is exactly `repo:rappdw/sandy:ref:refs/heads/main`. A push to any other branch mints a JWT whose `sub` won't match, and the exchange fails with a rule mismatch — which reads as a broken setup but is the scoping working correctly.

An unfiltered `on: push` would produce exactly that confusing red run on the PR branch that adds this file. `main` is protected, so **merging this PR is itself a push to `main`** and triggers the first real run. `workflow_dispatch` is included so it can be re-run without another commit.

## It measures the thing everything else assumes

The added step decodes the JWT and prints `sub`, `aud`, and `lifetime_seconds`.

The ~10 minute ceiling that the entire budget analysis in `docs/CI-KEYLESS-AUTH.md` rests on is an **assumption read off a console form** ("Token lifetime … upper-bounded by JWT expiry"). This is the cheapest possible place to turn it into a measurement — and the number determines whether per-section minting is sufficient or `§20` needs splitting.

The printed `sub` is also what to diff against the rule's subject pattern when an exchange fails, which is otherwise guesswork.

## Expected result

HTTP 200 with `<redacted>` in place of the token fields.

- `400 workspace_id_required` → set `ANTHROPIC_WORKSPACE_ID` as a fourth repository variable
- rule mismatch → compare the printed `sub` against the subject pattern

The heredoc delimiter is deliberately **unquoted** (`<<JSON`, not `<<'JSON'`) so `$JWT` expands; quoting it would send the literal string and fail on a malformed assertion.

Related: #190, #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)