### PR TITLE
fix(wif-test): send curl's writeout to stderr so jq sees only JSON

### DIFF
--- a/.github/workflows/anthropic-wif-test.yml
+++ b/.github/workflows/anthropic-wif-test.yml
@@ -39,7 +39,12 @@ jobs:
           # --fail-with-body: curl exits 0 on an HTTP error without it, so a
           # FAILED exchange reported a GREEN run on the first attempt. It still
           # prints the body, so the error is visible before the non-zero exit.
-          curl -sS --fail-with-body -w '\nHTTP %{http_code}\n' \
+          # %{stderr} sends the rest of the writeout to STDERR. Without it the
+          # status line lands on stdout, gets piped into jq along with the JSON
+          # body, and jq dies with "Invalid numeric literal" -- which masks
+          # whether the exchange succeeded or failed, since either outcome fails
+          # the same way. stdout must stay pure JSON for the pipe.
+          curl -sS --fail-with-body -w '%{stderr}HTTP %{http_code}\n' \
             https://api.anthropic.com/v1/oauth/token \
             -H "content-type: application/json" \
             --data @- <<JSON | jq 'with_entries(if (.key | test("token$")) then .value = "<redacted>" else . end)'


### PR DESCRIPTION
My bug, from the previous PR.

`-w '\nHTTP %{http_code}\n'` writes to **stdout**, so the status line got piped into `jq` along with the response body. `jq` died with `Invalid numeric literal at line 2, column 5`, exit 5.

## It didn't just fail noisily — it destroyed the diagnostic

A successful exchange and a failed one now die **the same way** in `jq`, so the run can no longer answer the only question it exists to answer. **The previous run's actual outcome is unknown** for this reason — it may well have succeeded.

`%{stderr}` redirects the remainder of the writeout to stderr, keeping stdout pure JSON for the pipe. The status code stays visible in the log; `jq` gets what it expects. Both shapes reproduced locally before and after — the old form fails `jq`, the new one doesn't.

## Salvaged from that run

- **`lifetime_seconds: 300`** — second independent measurement, confirming the runbook's corrected budget
- `sub` = `repo:rappdw/sandy:ref:refs/heads/main` and `aud` = `https://api.anthropic.com`, both correct

So the token side is right; only the reporting was broken.

Related: #190, #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)