### PR TITLE
ci(integration): authenticate via workload identity federation (#190)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,6 +28,14 @@ on:
         required: false
         default: ''
 
+# `id-token: write` lets the job mint a GitHub OIDC token, which is exchanged for
+# short-lived Anthropic API access (Workload Identity Federation, #190). Explicitly
+# listing permissions also drops the default write-all token down to read-only for
+# everything else.
+permissions:
+  contents: read
+  id-token: write
+
 # Never run two integration jobs at once: sections 19-21 manipulate host-wide
 # daemon state (containers, networks, the workspace mutex), so concurrent runs
 # would interfere. Do not cancel an in-progress run either — a half-torn-down
@@ -60,11 +68,63 @@ jobs:
           docker image prune -af || true
           echo "after:"; df -h / | tail -1
 
+      # Build BEFORE minting the token. The federated credential is capped at the
+      # GitHub JWT's life -- MEASURED at 300s, not the 600 the console form
+      # implies. An agent image build costs 3-6 minutes, so minting first would
+      # spend the entire credential before the first claude call. --build-only
+      # needs no credentials, so it belongs outside the token window; the suite's
+      # own ensure_image_built then no-ops.
+      - name: Pre-build agent images (outside the token window)
+        if: vars.ANTHROPIC_FEDERATION_RULE_ID != ''
+        run: ./sandy --build-only
+
+      # Workload Identity Federation (#190). Skipped entirely unless the rule ID
+      # repository variable is set, so the API-key path below keeps working
+      # untouched until this is proven out.
+      #
+      # The IDs are repository VARIABLES, not secrets: they are identifiers, and a
+      # rule scoped to this repo means a leaked ID grants nothing. Only the minted
+      # token is sensitive, and it never leaves this job.
+      - name: Mint a federated Anthropic token (OIDC)
+        if: vars.ANTHROPIC_FEDERATION_RULE_ID != ''
+        run: |
+          set -euo pipefail
+          # Anthropic's default audience; the rule leaves "Expected audience" blank,
+          # which means exactly this value is required.
+          _aud="https://api.anthropic.com"
+          _tok="$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+                    "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${_aud}" | jq -r '.value')"
+          if [ -z "$_tok" ] || [ "$_tok" = "null" ]; then
+            echo "::error::OIDC token request returned no value"; exit 1
+          fi
+          echo "::add-mask::$_tok"
+          echo "ANTHROPIC_IDENTITY_TOKEN=$_tok" >> "$GITHUB_ENV"
+          # Report the ACTUAL lifetime rather than assuming it -- every budget in
+          # docs/CI-KEYLESS-AUTH.md depends on this number.
+          _pay="$(printf '%s' "$_tok" | cut -d. -f2)"
+          _pay="$_pay$(printf '%*s' $(( (4 - ${#_pay} % 4) % 4 )) '' | tr ' ' '=')"
+          _life="$(printf '%s' "$_pay" | tr '_-' '/+' | base64 -d 2>/dev/null \
+                    | jq -r 'if .exp and .iat then (.exp - .iat | tostring) else "unknown" end' 2>/dev/null || echo unknown)"
+          echo "minted at $(date -u +%H:%M:%SZ); JWT lifetime: ${_life}s"
+
       - name: Run integration suite
         env:
           # Missing keys are NOT a failure: every keyed section probes for its
           # credential and skips cleanly (the suite has ~22 such skips). So this
           # workflow still yields signal on a fork-less repo with no secrets set.
+          # WIF identifiers (repository variables; empty when not configured).
+          # ANTHROPIC_WORKSPACE_ID is included even though the docs call it optional
+          # for a single-workspace rule: the smoke test that PROVED this setup did
+          # pass workspace_id, so whether it succeeded because of it is untested.
+          # Setting it costs nothing and removes the question.
+          ANTHROPIC_FEDERATION_RULE_ID: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
+          ANTHROPIC_ORGANIZATION_ID: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
+          ANTHROPIC_SERVICE_ACCOUNT_ID: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
+          ANTHROPIC_WORKSPACE_ID: ${{ vars.ANTHROPIC_WORKSPACE_ID }}
+          # Sandy only forwards env vars it recognizes; these are not sandy keys, so
+          # name them explicitly. SANDY_EXTRA_ENV is privileged-tier, but the suite
+          # exports SANDY_AUTO_APPROVE_PRIVILEGED=1, so no prompt blocks it.
+          SANDY_EXTRA_ENV: ANTHROPIC_FEDERATION_RULE_ID,ANTHROPIC_ORGANIZATION_ID,ANTHROPIC_SERVICE_ACCOUNT_ID,ANTHROPIC_WORKSPACE_ID,ANTHROPIC_IDENTITY_TOKEN
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -77,7 +137,21 @@ jobs:
           # CI runners are slower than the maintainer host; the default 300s
           # per-test timeout is tuned for the latter.
           SANDY_INTEG_TIMEOUT: '600'
-        run: bash test/run-integration-tests.sh
+        run: |
+          set -euo pipefail
+          if [ -n "${ANTHROPIC_FEDERATION_RULE_ID:-}" ]; then
+            # ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN outrank WIF in the client's
+            # credential resolution EVEN WHEN SET TO THE EMPTY STRING. Actions cannot
+            # conditionally omit an `env:` entry -- a conditional expression yields
+            # '', which still counts as set -- so they must be unset here, in the
+            # shell that launches the suite. Leaving them blank silently falls back
+            # to "no credentials" rather than using the federated token.
+            unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
+            echo "auth: workload identity federation (rule ${ANTHROPIC_FEDERATION_RULE_ID})"
+          else
+            echo "auth: ANTHROPIC_API_KEY secret (WIF not configured)"
+          fi
+          bash test/run-integration-tests.sh
 
       # Runs even on failure: a failed section often leaves containers or
       # networks behind, and the runner is ephemeral anyway — but printing what


### PR DESCRIPTION
Replaces the long-lived `ANTHROPIC_API_KEY` secret with a short-lived federated token, now that the exchange is **proven end to end** — HTTP 200, `access_token` issued for the service account (`anthropic-wif-test`).

**Staged behind the existing key path.** Every WIF step is gated on the `ANTHROPIC_FEDERATION_RULE_ID` repository variable, so clearing that variable reverts to the secret with no code change. All four variables are set.

## Three things that are easy to get wrong

Each learned from a real failure or measurement, not from the docs:

**`permissions: id-token: write`** — without it `ACTIONS_ID_TOKEN_REQUEST_URL` is never populated and the mint step gets an empty token. Listing permissions explicitly also drops the default write-all token to read-only for everything else.

**`unset ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` when WIF is active** — both outrank WIF in credential resolution **even when set to the empty string**, and Actions *cannot* conditionally omit an `env:` entry (a conditional expression yields `''`, which still counts as set). Leaving them blank would silently fall back to *no credentials* rather than using the federated token.

**Build before minting** — the usable credential is **~598s** (measured; the JWT itself is 300s, and the form's *"upper-bounded by JWT expiry"* does not behave as written). An image build costs 3–6 minutes, so minting first would spend most of the budget before the first `claude` call. `--build-only` needs no credentials, so it runs outside the token window and `ensure_image_built` then no-ops.

## Wiring details

Sandy only forwards env vars it recognizes, and none of the WIF variables are sandy config keys — so they're named in `SANDY_EXTRA_ENV`. That key is privileged-tier, but the suite already exports `SANDY_AUTO_APPROVE_PRIVILEGED=1`, so no approval prompt blocks it.

`ANTHROPIC_WORKSPACE_ID` is forwarded even though the docs call it optional for a single-workspace rule: the smoke test that proved this setup **did** pass `workspace_id`, so whether it succeeded because of it is untested. Setting it costs nothing and removes the question.

The IDs are repository **variables**, not secrets — they're identifiers, and a rule scoped to this repo means a leaked ID grants nothing. Only the minted token is sensitive, and it never leaves the job.

## Not yet addressed

The full suite runs ~27 min against a ~10 min credential, so this covers **short and targeted runs**. Per-section re-minting (loop `SANDY_INTEG_ONLY`, mint per iteration) is what retires the API key entirely — and every section fits inside one token, so no section surgery is needed.

## After merge

```sh
gh workflow enable Integration --repo rappdw/sandy    # currently disabled_manually
gh workflow run Integration --repo rappdw/sandy -f only=7 -f skip=19,20,21
```

Expect `auth: workload identity federation (rule fdrl_…)` in the log, and §7 **not** skipping. A skip means the credential never reached the container.

Related: #190, #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)