### PR TITLE
fix(integ): a cosmetic provenance footer must not fail the suite

### DIFF
--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -266,6 +266,14 @@ _emit_summary() {
     local code=$?
     printf '\033>' 2>/dev/null || true
     command -v tput >/dev/null 2>&1 && tput rmkx 2>/dev/null || true
+    # A non-zero exit AFTER the run completed means something in the tail work
+    # (timing table, ONLY-token warning, provenance footer) failed under `set -e`.
+    # Without this branch that is completely silent: the summary already printed
+    # "All N tests passed", COMPLETED is true, and the run just... exits 1. Say so.
+    if [ "$COMPLETED" = true ] && [ "$code" -ne 0 ] && [ "$FAIL" -eq 0 ]; then
+        printf "\033[0;31m✗ suite exited %d AFTER completing successfully — a post-summary step failed\033[0m\n" "$code" >&2
+        printf "\033[0;33m  Tests themselves passed. Look at the tail work: timing table, ONLY-token warning, provenance footer.\033[0m\n" >&2
+    fi
     if [ "$COMPLETED" = false ] && [ "$((PASS + FAIL))" -gt 0 ]; then
         echo ""
         printf "\033[0;31m✗ integration test suite aborted early (exit=%d)\033[0m\n" "$code" >&2
@@ -2245,5 +2253,12 @@ if [ -n "${SANDY_INTEG_ONLY:-}" ]; then
     done
 fi
 
-_run_provenance
+# `|| true` is not decoration. This is a COSMETIC footer -- a timestamp, a commit
+# id, clean/dirty -- and it runs AFTER COMPLETED=true, so a non-zero return here
+# aborts under `set -e` with _emit_summary staying silent (it only reports when
+# COMPLETED is false). That is exactly what happened on the first federated CI
+# run: all 5 tests passed, the summary and timing table printed, and the suite
+# then exited 1 with no diagnostic whatsoever. A provenance line must never be
+# able to fail a 27-minute suite.
+_run_provenance || true
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
The first fully-working federated run **reported failure**:

```
Claude:   ✓  (wif)
✓ claude headless responds without errors
All 5 tests passed.
Total wall-clock: 188s
^[>
##[error]Process completed with exit code 1.
```

**Every test passed.** WIF worked end to end — token minted, exchanged, forwarded through `SANDY_EXTRA_ENV` into the container, resolved by Claude Code, real headless call answered. Then the suite exited 1 with **no diagnostic at all**.

## Cause

`_run_provenance` — a cosmetic one-line footer printing a timestamp, commit id, and clean/dirty — returned non-zero under `set -e`.

**Why it was silent is the more interesting half.** `COMPLETED=true` is set *before* the summary, timing table, ONLY-token warning, and provenance footer. `_emit_summary` only reports an abort when `COMPLETED` is false — so anything failing in that tail work exits the suite with **no message whatsoever**. A 27-minute run can go red having passed everything, and the log says nothing about why.

## Two fixes

| | |
|---|---|
| `_run_provenance \|\| true` | a provenance line must never be able to fail a run — it has no bearing on whether tests passed |
| `_emit_summary` reports post-completion failures | *"suite exited N AFTER completing successfully — a post-summary step failed"*, plus a pointer at the tail work |

Verified by simulation: the old path exits 1 silently; the new path exits 0, and an injected tail failure prints the diagnostic instead of nothing.

## Root cause not confirmed

`_run_provenance` runs clean locally. Something about the CI checkout makes one of its `git` calls return non-zero despite each being individually guarded — shallow clone (`actions/checkout` defaults to depth 1, no tags) is the likely candidate but is **untested**.

The footer is cosmetic, so making it non-fatal is right regardless, and the new diagnostic means a recurrence names itself instead of hiding.

Related: #190, #106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)