### PR TITLE
ci(integration): eager per-section token exchange, so the suite outlives the JWT

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -117,12 +117,11 @@ jobs:
           docker image prune -af || true
           echo "after:"; df -h / | tail -1
 
-      # Build BEFORE minting the token. The federated credential is capped at the
-      # GitHub JWT's life -- MEASURED at 300s, not the 600 the console form
-      # implies. An agent image build costs 3-6 minutes, so minting first would
-      # spend the entire credential before the first claude call. --build-only
-      # needs no credentials, so it belongs outside the token window; the suite's
-      # own ensure_image_built then no-ops.
+      # Build BEFORE exchanging for a token. --build-only needs no credentials,
+      # so it belongs outside the token window; the suite's own
+      # ensure_image_built then no-ops. This still matters under the eager
+      # per-section exchange below -- it is 3-6 minutes that would otherwise
+      # eat into the first section's budget for no reason.
       - name: Pre-build agent images (outside the token window)
         if: vars.ANTHROPIC_FEDERATION_RULE_ID != ''
         run: ./sandy --build-only
@@ -131,37 +130,39 @@ jobs:
       # repository variable is set, so the API-key path below keeps working
       # untouched until this is proven out.
       #
-      # The IDs are repository VARIABLES, not secrets: they are identifiers, and a
-      # rule scoped to this repo means a leaked ID grants nothing. Only the minted
-      # token is sensitive, and it never leaves this job.
-      - name: Mint a federated Anthropic token (OIDC)
+      # The IDs are repository VARIABLES, not secrets: they are identifiers, and
+      # a rule scoped to this repo means a leaked ID grants nothing. Only the
+      # minted JWT and the exchanged access token are sensitive, and neither
+      # leaves this job.
+      #
+      # EAGER, host-side exchange -- not the lazy in-container exchange this
+      # workflow used before. Claude Code resolves credentials lazily (only
+      # when it first needs them), so forwarding the raw identity token bound
+      # the whole run to the GitHub JWT's measured ~300s lifetime, and two
+      # sections individually exceed that on their own regardless of anything
+      # cumulative. test/ci-wif-access-token.sh mints the JWT AND exchanges it
+      # for an access token in one step, right here, so the budget that
+      # matters becomes the ~598s access token instead -- see
+      # docs/CI-KEYLESS-AUTH.md "Token lifetimes". The suite's own section()
+      # hook (test/run-integration-tests.sh) re-runs this same script before
+      # any section whose current token is >=60s old, so no section ever
+      # starts on a stale one. Diagnostics (decoded JWT claims, the access
+      # token's expires_in) are printed by the script itself, to stderr.
+      - name: Exchange a federated Anthropic access token
         if: vars.ANTHROPIC_FEDERATION_RULE_ID != ''
+        env:
+          ANTHROPIC_FEDERATION_RULE_ID: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
+          ANTHROPIC_ORGANIZATION_ID: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
+          ANTHROPIC_SERVICE_ACCOUNT_ID: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
+          ANTHROPIC_WORKSPACE_ID: ${{ vars.ANTHROPIC_WORKSPACE_ID }}
         run: |
           set -euo pipefail
-          # Anthropic's default audience; the rule leaves "Expected audience" blank,
-          # which means exactly this value is required.
-          _aud="https://api.anthropic.com"
-          _tok="$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-                    "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${_aud}" | jq -r '.value')"
-          if [ -z "$_tok" ] || [ "$_tok" = "null" ]; then
-            echo "::error::OIDC token request returned no value"; exit 1
+          _tok="$(bash test/ci-wif-access-token.sh)"
+          if [ -z "$_tok" ]; then
+            echo "::error::WIF exchange returned no access token"; exit 1
           fi
           echo "::add-mask::$_tok"
-          echo "ANTHROPIC_IDENTITY_TOKEN=$_tok" >> "$GITHUB_ENV"
-          # Report the ACTUAL lifetime rather than assuming it -- every budget in
-          # docs/CI-KEYLESS-AUTH.md depends on this number.
-          _pay="$(printf '%s' "$_tok" | cut -d. -f2)"
-          _pay="$_pay$(printf '%*s' $(( (4 - ${#_pay} % 4) % 4 )) '' | tr ' ' '=')"
-          # Print sub/aud alongside the lifetime. When an exchange is rejected the
-          # API says only "Authentication failed"; the decoded `sub` is what you
-          # diff against the federation rule's subject pattern, and it is what
-          # actually identified the first failure. This diagnostic used to live in
-          # the anthropic-wif-test smoke test, which is deleted in this commit --
-          # removing the tool without keeping what made it useful would be a
-          # downgrade. `|| true` throughout: a diagnostic must never fail a run.
-          _claims="$(printf '%s' "$_pay" | tr '_-' '/+' | base64 -d 2>/dev/null \
-                      | jq -c '{sub, aud, lifetime_seconds: (.exp - .iat)}' 2>/dev/null || echo '{}')"
-          echo "minted at $(date -u +%H:%M:%SZ); claims: ${_claims}" || true
+          echo "ANTHROPIC_AUTH_TOKEN=$_tok" >> "$GITHUB_ENV"
 
       - name: Run integration suite
         env:
@@ -172,15 +173,14 @@ jobs:
           # ANTHROPIC_WORKSPACE_ID is included even though the docs call it optional
           # for a single-workspace rule: the smoke test that PROVED this setup did
           # pass workspace_id, so whether it succeeded because of it is untested.
-          # Setting it costs nothing and removes the question.
+          # Setting it costs nothing and removes the question. These four stay in
+          # this step's env regardless of WIF being active -- test/ci-wif-access-token.sh
+          # reads them again on every per-section refresh (SANDY_INTEG_CRED_REFRESH_CMD,
+          # WIF branch below), not just once at job start.
           ANTHROPIC_FEDERATION_RULE_ID: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
           ANTHROPIC_ORGANIZATION_ID: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
           ANTHROPIC_SERVICE_ACCOUNT_ID: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
           ANTHROPIC_WORKSPACE_ID: ${{ vars.ANTHROPIC_WORKSPACE_ID }}
-          # Sandy only forwards env vars it recognizes; these are not sandy keys, so
-          # name them explicitly. SANDY_EXTRA_ENV is privileged-tier, but the suite
-          # exports SANDY_AUTO_APPROVE_PRIVILEGED=1, so no prompt blocks it.
-          SANDY_EXTRA_ENV: ANTHROPIC_FEDERATION_RULE_ID,ANTHROPIC_ORGANIZATION_ID,ANTHROPIC_SERVICE_ACCOUNT_ID,ANTHROPIC_WORKSPACE_ID,ANTHROPIC_IDENTITY_TOKEN
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -196,14 +196,30 @@ jobs:
         run: |
           set -euo pipefail
           if [ -n "${ANTHROPIC_FEDERATION_RULE_ID:-}" ]; then
-            # ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN outrank WIF in the client's
-            # credential resolution EVEN WHEN SET TO THE EMPTY STRING. Actions cannot
-            # conditionally omit an `env:` entry -- a conditional expression yields
-            # '', which still counts as set -- so they must be unset here, in the
-            # shell that launches the suite. Leaving them blank silently falls back
-            # to "no credentials" rather than using the federated token.
-            unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
+            # ANTHROPIC_API_KEY outranks ANTHROPIC_AUTH_TOKEN in the client's
+            # credential resolution EVEN WHEN SET TO THE EMPTY STRING. Actions
+            # cannot conditionally omit an `env:` entry -- a conditional
+            # expression yields '', which still counts as set -- so it must be
+            # `unset` here, in the shell that launches the suite. Leaving it
+            # blank would silently fall back to ANTHROPIC_API_KEY (empty ->
+            # "no credentials") instead of using the federated token.
+            #
+            # ANTHROPIC_AUTH_TOKEN is deliberately NOT unset -- it is the
+            # credential this path forwards, set above (via GITHUB_ENV) by the
+            # "Exchange a federated Anthropic access token" step.
+            unset ANTHROPIC_API_KEY
             echo "auth: workload identity federation (rule ${ANTHROPIC_FEDERATION_RULE_ID})"
+            # Sandy only forwards env vars it recognizes, and ANTHROPIC_AUTH_TOKEN
+            # is not a sandy config key -- name it explicitly. Scoped to this
+            # branch (not the job's `env:` block above) so the API-key path
+            # below is byte-identical to before this change: no
+            # SANDY_EXTRA_ENV, no refresh hook, nothing WIF-shaped at all.
+            export SANDY_EXTRA_ENV=ANTHROPIC_AUTH_TOKEN
+            # Re-exchange before any section whose current token is >=60s old
+            # (test/run-integration-tests.sh's section() hook). This is what
+            # fixes the budget being the JWT's ~300s instead of the access
+            # token's ~598s -- see docs/CI-KEYLESS-AUTH.md "Token lifetimes".
+            export SANDY_INTEG_CRED_REFRESH_CMD='bash test/ci-wif-access-token.sh'
           else
             echo "auth: ANTHROPIC_API_KEY secret (WIF not configured)"
           fi

--- a/docs/CI-KEYLESS-AUTH.md
+++ b/docs/CI-KEYLESS-AUTH.md
@@ -61,6 +61,8 @@ Then the two steps below: register the issuer ("we trust GitHub"), then create a
 > The integration suite launches **many** sandy containers, each running its own `claude` process, and each exchanges the **same** `ANTHROPIC_IDENTITY_TOKEN` set once in the workflow env. One `jti`, N exchanges. With replay protection on, the first container authenticates and every later one fails — surfacing as a flaky mid-suite auth error rather than a configuration choice.
 >
 > Minting a fresh token per *section* is the plan (see [Bring-up order](#bring-up-order)) and `SANDY_INTEG_ONLY` is the seam for it — but that does not rescue replay protection. Even within a single section, sandy launches several containers that each exchange the same token, so one `jti` still sees N exchanges. Leave it off.
+>
+> **Update, shipped design:** the mechanism below no longer forwards the identity token into the sandbox at all — `test/ci-wif-access-token.sh` exchanges each minted JWT exactly **once**, host-side, and hands the *already-exchanged* access token to every container as `ANTHROPIC_AUTH_TOKEN`. Under that design one `jti` really does see one exchange, and replay protection **could** be turned back on. It is deliberately left off for now — flipping it is unverified and out of scope for this change, and a false rejection here fails the whole run, not one section. Tracked as a follow-up hardening step once the new path has soaked.
 
 ### Step 2 — Create a rule
 
@@ -115,13 +117,13 @@ Add `ANTHROPIC_WORKSPACE_ID` **only** if the rule spans multiple workspaces; oth
 
 1. **`permissions: id-token: write`** on the job, or `ACTIONS_ID_TOKEN_REQUEST_URL` is never populated and the mint step fails with an empty token.
 2. **An empty `ANTHROPIC_API_KEY` outranks WIF.** The resolution order is `ANTHROPIC_API_KEY` → `ANTHROPIC_AUTH_TOKEN` → OAuth profile → WIF, and *even the empty string counts as set*. GitHub Actions **cannot conditionally omit** an `env:` entry — a conditional expression yields `''`, which is still set. They must be `unset` in the shell that launches the suite. This is the failure mode where everything looks configured and auth silently falls back to nothing.
-3. **Sandy does not forward unrecognized env vars.** The WIF variables are not sandy config keys, so name them in `SANDY_EXTRA_ENV`. That key is privileged-tier, but the suite exports `SANDY_AUTO_APPROVE_PRIVILEGED=1`, so no prompt blocks it:
+3. **Sandy does not forward unrecognized env vars.** `ANTHROPIC_AUTH_TOKEN` is not a sandy config key either, so name it in `SANDY_EXTRA_ENV`. That key is privileged-tier, but the suite exports `SANDY_AUTO_APPROVE_PRIVILEGED=1`, so no prompt blocks it:
 
    ```
-   SANDY_EXTRA_ENV: ANTHROPIC_FEDERATION_RULE_ID,ANTHROPIC_ORGANIZATION_ID,ANTHROPIC_SERVICE_ACCOUNT_ID,ANTHROPIC_IDENTITY_TOKEN
+   SANDY_EXTRA_ENV: ANTHROPIC_AUTH_TOKEN
    ```
 
-Prefer `ANTHROPIC_IDENTITY_TOKEN` (the value) over `ANTHROPIC_IDENTITY_TOKEN_FILE` — the file variant would have to be mounted into the container.
+   This is the shipped design (see "Token lifetimes" below) and it is a smaller surface than an earlier draft: no federation identifiers or identity token cross into the sandbox at all, only the already-exchanged bearer token. `ANTHROPIC_AUTH_TOKEN` sits in the client's resolution order right below `ANTHROPIC_API_KEY` — both must be `unset` before delegating to WIF is even attempted (see item 2 above), and the WIF shell branch re-exports `ANTHROPIC_AUTH_TOKEN` immediately after doing so.
 
 ## 2. OpenAI
 
@@ -170,11 +172,7 @@ So: keep `XAI_API_KEY` as a secret, or drop it and let the grok sections skip.
 
 1. **Console setup** — service account (added as a member of the target workspace), issuer, rule, per the sections above.
 2. **Set the repository variables** (`gh variable set`, above). Setting `ANTHROPIC_FEDERATION_RULE_ID` is what switches the workflow onto the WIF path; until then it uses the key exactly as today.
-3. **Apply the workflow patch**, which is staged behind the existing key path:
-   ```sh
-   git apply 0002-wif-integration.patch
-   ```
-   It needs a `workflow`-scoped token to push (`gh auth refresh -h github.com -s workflow`), and `.github/workflows/` is `:ro` inside a sandy session — so commit it from the host.
+3. **Apply the workflow patch**, which is staged behind the existing key path. `.github/workflows/` is `:ro` inside a sandy session, so commit it from the host; it needs a `workflow`-scoped token to push (`gh auth refresh -h github.com -s workflow`).
 4. **Re-enable the workflow if it is disabled** — a disabled workflow cannot be dispatched either:
    ```sh
    gh workflow list --repo rappdw/sandy --all      # look for disabled_manually
@@ -184,22 +182,19 @@ So: keep `XAI_API_KEY` as a secret, or drop it and let the grok sections skip.
    ```sh
    gh workflow run Integration --repo rappdw/sandy -f only=7 -f skip=19,20,21
    ```
-   Confirm the log reads `auth: workload identity federation (rule …)` **and** that §7 did not skip. A skip means the credential never arrived.
-5. **Build the per-section loop** (below), run the full suite, and only then delete `ANTHROPIC_API_KEY` from secrets.
+   Confirm the log reads `auth: workload identity federation (rule …)`, the suite's own banner reads `Claude: ✓ (auth-token)`, and that §7 did not skip. A skip means the credential never arrived; `(auth-token)` rather than `(wif)` confirms the *new* eager-exchange path is what actually supplied it, not the raw WIF pair.
+5. **Run the full suite**, confirm the timing table shows every section completing, and only then delete `ANTHROPIC_API_KEY` from secrets.
 
-### Token lifetimes — the usable window is 300s, not 598s
+### Token lifetimes — the shipped fix: eager, per-section exchange
 
-**Three lifetimes, and confusing them cost this document three revisions.**
+**Two lifetimes, one JWT-bound and one much longer, and the fix is to stop letting the run live on the short one.**
 
 ```
-JWT lifetime_seconds : 300    the GitHub assertion's validity  <-- THE ONE THAT BINDS
-expires_in           : 598    the access token, IF you exchange immediately
-rule "Token lifetime": 600    configured; not capped by the JWT as the form implies
+JWT lifetime_seconds : 300    the GitHub assertion's own validity
+expires_in           : 598    the Anthropic access token, IF exchanged promptly
 ```
 
-The rule form says *"Token lifetime … Upper-bounded by JWT expiry"*. Measured, a 300s JWT yields a 598s access token, so that wording does not describe what happens. But **598s is not the budget**, because nothing in a real run exchanges immediately.
-
-**Claude Code performs the exchange lazily — inside the container, when it first needs credentials.** By then the workflow's JWT may already be dead. Proved by a real run:
+**What was tried and measured to fail.** Claude Code exchanges the WIF identity token *lazily, inside the container, when it first needs credentials* — so forwarding the raw identity token (as the workflow originally did) binds the whole run to the JWT's 300s, not the access token's 598s. A real lean run proved this:
 
 ```
 minted at 03:53:03Z   JWT lifetime 300s   → expires 03:58:03Z
@@ -207,28 +202,35 @@ minted at 03:53:03Z   JWT lifetime 300s   → expires 03:58:03Z
   API Error: Token exchange failed with status 401
 ```
 
-Note the error: *token exchange* failed, not *access token expired*. The agent was still trying to exchange, 4 minutes after the assertion died.
+That run: **57 of 58 passed, 1152s total.** Note the error is *token exchange failed*, not *access token expired* — the container was still trying to trade a dead JWT for a live token, four minutes after the JWT died.
 
-**So budget against the JWT's 300 seconds.** Every section that ran inside that window passed; the one that runs ~9 minutes in did not.
+**Per-section re-minting of the JWT alone does not rescue this either.** Two individual sections outlast the 300s JWT budget on their own, independent of anything cumulative — measured on CI, not the (faster) maintainer host:
 
-### What that means for the suite
+```
+1:3s  2:0s  4:45s  5:0s  6:45s  7:191s  8-11:0s  12:33s
+13:380s   <-- exceeds 300s on its own
+14:370s   <-- exceeds 300s on its own
+15:2s 16:0s 17:5s 18:0s 22:1s 23:21s 24:19s
+```
 
-That lean run: **57 of 58 passed, 8 skipped, 1152s total.** The single failure was this expiry, not a defect.
+(§19/§20/§21 — the acceptance harnesses — are skipped by default, ~46% more runtime; §20 alone ran ~432s on the maintainer host, see the residual risk below.)
 
-| | duration | fits 300s from mint? |
-|---|---|---|
-| the first few sections | inside the window | yes |
-| proxy end-to-end (§13) | starts ~9 min in | **no** |
-| lean run total | ~1152s | **no** |
-| full run | ~27 min | **no** |
+**The fix that works: exchange eagerly, host-side, and stop passing raw federation material into the sandbox at all.** `test/ci-wif-access-token.sh` mints a fresh JWT and immediately exchanges it for an access token, once, in the workflow shell — not lazily inside a container. That access token is forwarded as `ANTHROPIC_AUTH_TOKEN` (see item 3 above), and `run-integration-tests.sh`'s `section()` hook re-runs the same script whenever the token in hand is ≥60s old, refreshing it before the next section starts (`SANDY_INTEG_CRED_REFRESH_CMD`). So the budget per section becomes the **598s access token**, not the 300s JWT, and every section starts with a token no more than ~60s stale:
 
-**Per-section re-minting is therefore required, not optional** — and it must mint immediately before each section, since a token minted at job start is dead within five minutes.
+```
+worst individual lean section (§13)     380s
+token age ceiling at section start       60s
+remaining budget at section start      ≥538s
+margin over the worst section          ≥158s
+```
 
-The earlier claim that "every section fits inside one token" was computed against 598s and is withdrawn. Against 300s, §20 (~432s) does not fit and needs splitting after all.
+**§13 and §14 both fit comfortably now** — the combination (eager exchange for the longer budget, per-section refresh so no section starts on a stale token) is what makes the whole lean run work, where either half alone was proven insufficient above.
 
 A third option is deliberately rejected: re-minting from *inside* the container would require forwarding `ACTIONS_ID_TOKEN_REQUEST_TOKEN` into the sandbox and allowlisting GitHub's token endpoint through the egress proxy. That puts a GitHub credential inside the box to avoid an Anthropic one — strictly worse than the problem it solves.
 
-**`ANTHROPIC_API_KEY` is a bring-up crutch, not the destination.** It exists so the nightly keeps working while steps 1–3 above are being proven, and it goes away at step 5.
+**`ANTHROPIC_API_KEY` is a bring-up crutch, not the destination.** It exists so the nightly keeps working while steps 1–4 above are being proven, and it goes away at step 5.
+
+**Residual risk, stated rather than hidden:** the numbers above prove the **lean** (default, scheduled) run. §20 runs `--rebuild` and was ~432s on the maintainer host; its CI duration is unmeasured. If the span from its section-start refresh to its last `claude` API call exceeds ~598s on CI, it can still 401 — the follow-up there is a refresh *inside* the acceptance harness between phases, not a change to this mechanism. §19 and §21 (~300s combined on the maintainer host) are expected to fit individually but are likewise unmeasured on CI. Whether the rule's `Token lifetime` field can be raised above 600 also remains untested — this document has been wrong about that field's semantics before, so it is not depended on here.
 
 ---
 
@@ -266,7 +268,7 @@ gh variable list --repo rappdw/sandy    # identifiers — safe to read
 gh secret   list --repo rappdw/sandy    # names only; values are never retrievable
 ```
 
-The suite prints its credential banner near the top of the run. Under WIF, expect `Claude: ✓ (wif)` with **no** `ANTHROPIC_API_KEY` secret configured — that is the whole point.
+The suite prints its credential banner near the top of the run. Under the shipped design, expect `Claude: ✓ (auth-token)` with **no** `ANTHROPIC_API_KEY` secret configured — that is the whole point. (`Claude: ✓ (wif)` also exists, and still means "recognised" — it fires only if an operator forwards the raw WIF pair directly rather than going through `test/ci-wif-access-token.sh`; the Integration workflow itself no longer does that.)
 
 > ### A WIF run can go green having tested nothing
 >
@@ -280,14 +282,14 @@ The suite prints its credential banner near the top of the run. Under WIF, expec
 >
 > The workflow authenticated correctly, but the **suite's own credential detection did not know WIF exists** — it looked for `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, or `~/.claude/.credentials.json`, and WIF supplies none of them. Every claude section skipped, and because a skip is a *legitimate* outcome, nothing failed.
 >
-> Fixed in `run-integration-tests.sh` (#196), which now treats `ANTHROPIC_FEDERATION_RULE_ID` **plus** `ANTHROPIC_IDENTITY_TOKEN` as credentials — both, since a rule alone is configuration with nothing to exchange.
+> Fixed in `run-integration-tests.sh` (#196), which now treats `ANTHROPIC_FEDERATION_RULE_ID` **plus** `ANTHROPIC_IDENTITY_TOKEN` as credentials — both, since a rule alone is configuration with nothing to exchange. A second fix layered on top of that once the eager-exchange design shipped: `ANTHROPIC_AUTH_TOKEN` is *also* treated as a Claude credential, since that (not the raw identity token) is what the workflow actually forwards now.
 >
 > **The operational lesson outlives the fix:** on this suite, green does not mean tested. Always confirm the banner shows the auth method you expect *and* that the sections you care about actually ran. A skipped section and a passing section look identical in the exit code.
 
 ### Verification checklist for a WIF run
 
 1. `auth: workload identity federation (rule …)` — the workflow took the WIF branch rather than falling back
-2. `Claude: ✓ (wif)` in the banner — the *suite* recognised the credential
+2. `Claude: ✓ (auth-token)` in the banner — the *suite* recognised the eagerly-exchanged credential
 3. The section you targeted **ran**, rather than reporting `⊘ … (skipped)`
 4. `All N tests passed` with **N > 0**
 

--- a/test/ci-wif-access-token.sh
+++ b/test/ci-wif-access-token.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test/ci-wif-access-token.sh — mint a GitHub OIDC JWT and immediately
+# exchange it for a short-lived Anthropic access token (Workload Identity
+# Federation, #190). Prints ONLY the access token on stdout; every diagnostic
+# (decoded JWT claims, exchange expires_in) goes to stderr, so a caller doing
+#     _tok="$(bash test/ci-wif-access-token.sh)"
+# gets a clean value with nothing else mixed in.
+#
+# Why exchange eagerly, here, instead of letting the client do it lazily
+# in-container: the GitHub JWT is only good for ~300s (measured), but the
+# Anthropic access token this script hands back is good for ~598s -- see
+# docs/CI-KEYLESS-AUTH.md "Token lifetimes -- measured, and not what the form
+# implies". Exchanging once, at a known moment, is what makes that longer
+# clock start where the caller expects it to.
+#
+# Required env:
+#   ACTIONS_ID_TOKEN_REQUEST_URL, ACTIONS_ID_TOKEN_REQUEST_TOKEN
+#       -- populated by GitHub Actions when the job has `permissions:
+#          id-token: write`. Not set outside Actions.
+#   ANTHROPIC_FEDERATION_RULE_ID, ANTHROPIC_ORGANIZATION_ID,
+#   ANTHROPIC_SERVICE_ACCOUNT_ID
+#       -- the federation rule's identifiers (repository variables upstream;
+#          identifiers, not secrets -- a repo-scoped rule means a leaked ID
+#          grants nothing).
+# Optional env:
+#   ANTHROPIC_WORKSPACE_ID -- only needed when the rule spans multiple
+#       workspaces; omitted from the exchange payload entirely when unset,
+#       rather than sent as an empty string.
+#
+# A diagnostic must never fail this script -- every diagnostic block below is
+# wrapped so a jq/base64 hiccup while decoding claims cannot turn a working
+# mint+exchange into a false failure.
+
+_die() {
+    printf '[ci-wif-access-token] ERROR: %s\n' "$1" >&2
+    exit 1
+}
+
+[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] \
+    || _die "ACTIONS_ID_TOKEN_REQUEST_URL is not set (job needs permissions: id-token: write)"
+[ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ] \
+    || _die "ACTIONS_ID_TOKEN_REQUEST_TOKEN is not set (job needs permissions: id-token: write)"
+[ -n "${ANTHROPIC_FEDERATION_RULE_ID:-}" ]   || _die "ANTHROPIC_FEDERATION_RULE_ID is not set"
+[ -n "${ANTHROPIC_ORGANIZATION_ID:-}" ]      || _die "ANTHROPIC_ORGANIZATION_ID is not set"
+[ -n "${ANTHROPIC_SERVICE_ACCOUNT_ID:-}" ]   || _die "ANTHROPIC_SERVICE_ACCOUNT_ID is not set"
+
+# Anthropic's default audience; the console rule leaves "Expected audience"
+# blank, which means exactly this value is required.
+_aud="https://api.anthropic.com"
+
+# --- Step 1: mint the GitHub OIDC JWT ---------------------------------------
+# --fail-with-body: curl exits 0 on an HTTP error without it, which would
+# report a green mint on a failed request. The writeout goes to stderr
+# (%{stderr}) so stdout stays pure JSON for jq.
+_jwt="$(curl -sS --fail-with-body -w '%{stderr}HTTP %{http_code}\n' \
+          -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${_aud}" | jq -r '.value')" \
+    || _die "OIDC token request failed"
+[ -n "$_jwt" ] && [ "$_jwt" != "null" ] || _die "OIDC token request returned no value"
+
+# --- Diagnostic: decode + report the JWT's own claims -----------------------
+# When an exchange is rejected, the API says only "Authentication failed";
+# the decoded sub is what gets diffed against the federation rule's subject
+# pattern to see why. `|| true` throughout -- never fail the mint over a
+# diagnostic.
+{
+    _pay="$(printf '%s' "$_jwt" | cut -d. -f2)"
+    _pay="$_pay$(printf '%*s' $(( (4 - ${#_pay} % 4) % 4 )) '' | tr ' ' '=')"
+    _pay="$(printf '%s' "$_pay" | tr '_-' '/+')"
+    # GNU (Linux/CI, the actual execution environment for this script) uses
+    # `base64 -d`; BSD (macOS, in case a maintainer runs this by hand) uses
+    # `-D`. Try GNU first, fall back to BSD.
+    _claims="$( { printf '%s' "$_pay" | base64 -d 2>/dev/null \
+                    || printf '%s' "$_pay" | base64 -D 2>/dev/null; } \
+                | jq -c '{sub, aud, lifetime_seconds: (.exp - .iat)}' 2>/dev/null || echo '{}')"
+    printf '[ci-wif-access-token] minted at %s; claims: %s\n' \
+        "$(date -u +%H:%M:%SZ)" "$_claims" >&2
+} || true
+
+# --- Step 2: exchange the JWT for an Anthropic access token -----------------
+# Built with jq -n rather than string interpolation into a heredoc, so the
+# JWT and IDs never need to be shell/JSON-escaped by hand -- and so
+# workspace_id can be OMITTED (not sent as "") when the rule is single-workspace.
+_payload="$(jq -n \
+    --arg grant_type "urn:ietf:params:oauth:grant-type:jwt-bearer" \
+    --arg assertion "$_jwt" \
+    --arg rule "$ANTHROPIC_FEDERATION_RULE_ID" \
+    --arg org "$ANTHROPIC_ORGANIZATION_ID" \
+    --arg svc "$ANTHROPIC_SERVICE_ACCOUNT_ID" \
+    --arg ws "${ANTHROPIC_WORKSPACE_ID:-}" \
+    '{grant_type: $grant_type, assertion: $assertion,
+      federation_rule_id: $rule, organization_id: $org, service_account_id: $svc}
+     + (if $ws != "" then {workspace_id: $ws} else {} end)')"
+
+_resp="$(curl -sS --fail-with-body -w '%{stderr}HTTP %{http_code}\n' \
+    https://api.anthropic.com/v1/oauth/token \
+    -H "content-type: application/json" \
+    --data "$_payload")" \
+    || _die "token exchange failed"
+
+_access_token="$(printf '%s' "$_resp" | jq -r '.access_token // empty' 2>/dev/null || true)"
+[ -n "$_access_token" ] || _die "exchange response had no access_token"
+
+# --- Diagnostic: report the ACCESS TOKEN's lifetime (not the JWT's) ---------
+# This is the number the caller's refresh budget is actually built on.
+{
+    _expires_in="$(printf '%s' "$_resp" | jq -r '.expires_in // "unknown"' 2>/dev/null || echo unknown)"
+    printf '[ci-wif-access-token] exchange ok; expires_in=%ss\n' "$_expires_in" >&2
+} || true
+
+# stdout: the access token, and nothing else.
+printf '%s' "$_access_token"

--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -154,6 +154,15 @@ done
 
 # --- Helpers ---
 
+# --- BEGIN SANDY_INTEG_SECTION_HOOK ---
+# Sentinel pair (mirrors the AUTOGEN sentinel convention used elsewhere in
+# this repo) so run-tests.sh's own suite-hook section can extract this exact,
+# real block and drive it directly, rather than maintaining a hand-copied
+# duplicate that could silently drift from the shipped logic. Deliberately
+# not spelling out the sed invocation here: it would repeat this pair's own
+# marker text inline and confuse a naive range-match into stopping early, at
+# this very comment. Keep this block self-contained so the extraction stays
+# valid as a standalone script.
 info()  { printf "\033[0;36m%s\033[0m\n" "$*"; }
 pass()  { PASS=$((PASS + 1)); printf "  \033[0;32m✓ %s\033[0m\n" "$*"; }
 fail()  { FAIL=$((FAIL + 1)); ERRORS+=("$*"); printf "  \033[0;31m✗ %s\033[0m\n" "$*"; }
@@ -174,6 +183,41 @@ _CUR_SECTION_TITLE=""
 _CUR_SECTION_START=0
 _CUR_SECTION_STATE="run"
 _SECTION_ON=true
+
+# --- Eager per-section credential refresh (SANDY_INTEG_CRED_REFRESH_CMD) ---
+# Lazy in-container WIF exchange binds the whole run to the GitHub JWT's
+# measured ~300s lifetime, and individual sections (§13, §14) already exceed
+# that on their own -- see docs/CI-KEYLESS-AUTH.md. The fix run eagerly here:
+# at the start of every RUN (not deselected) section, if the last refresh is
+# at least 60s old, re-mint+re-exchange and export a fresh ANTHROPIC_AUTH_TOKEN
+# so every section starts with a token close to the full ~598s access-token
+# budget rather than one that has been aging across prior sections.
+# -9999 as the initial "last refresh" so the very first eligible section
+# always refreshes (age is trivially >= 60).
+_CRED_LAST_REFRESH=-9999
+_cred_refresh_if_due() {
+    [ -n "${SANDY_INTEG_CRED_REFRESH_CMD:-}" ] || return 0
+    [ "$_SECTION_ON" = true ] || return 0
+    local _age
+    _age=$(( SECONDS - _CRED_LAST_REFRESH ))
+    [ "$_age" -ge 60 ] || return 0
+    # RC-guarded, never `|| true` before the rc read: a refresh failure must
+    # warn and keep the previous token, not silently vanish or abort the suite.
+    local _rc=0 _tok=""
+    _tok="$(bash -c "$SANDY_INTEG_CRED_REFRESH_CMD")" || _rc=$?
+    if [ "$_rc" -eq 0 ] && [ -n "$_tok" ]; then
+        export ANTHROPIC_AUTH_TOKEN="$_tok"
+        _CRED_LAST_REFRESH=$SECONDS
+        # Mask on the runner's own log processor -- only meaningful (and only
+        # emitted) under GITHUB_ACTIONS, never in a plain terminal run.
+        if [ -n "${GITHUB_ACTIONS:-}" ]; then
+            printf '::add-mask::%s\n' "$_tok"
+        fi
+    else
+        printf "  \033[0;33m! credential refresh failed for section %s (rc=%d) -- keeping previous token\033[0m\n" \
+            "$_CUR_SECTION_ID" "$_rc"
+    fi
+}
 
 # True when "$1" appears as a comma-separated token of "$2" (exact-token match,
 # so ONLY=1 does not select 12/12b/13...).
@@ -232,7 +276,9 @@ section() {
         _CUR_SECTION_STATE="deselected"
         printf "  \033[0;33mo section %s deselected (SANDY_INTEG_ONLY/SANDY_INTEG_SKIP)\033[0m\n" "$_CUR_SECTION_ID"
     fi
+    _cred_refresh_if_due
 }
+# --- END SANDY_INTEG_SECTION_HOOK ---
 
 _print_timing_table() {
     [ "$_SEC_COUNT" -gt 0 ] || return 0
@@ -587,11 +633,20 @@ done
 #
 # The identity token is required as well as the rule id: the rule alone is just
 # configuration, and an exchange cannot happen without an assertion to present.
+# This branch is kept for an operator passing raw WIF vars straight through
+# (lazy in-container exchange) -- it is no longer what the Integration workflow
+# itself does (see ANTHROPIC_AUTH_TOKEN below), but it is still a valid way to
+# supply Claude credentials to this suite.
 HAS_CLAUDE_WIF=false
 if [ -n "${ANTHROPIC_FEDERATION_RULE_ID:-}" ] && [ -n "${ANTHROPIC_IDENTITY_TOKEN:-}" ]; then
     HAS_CLAUDE_WIF=true
 fi
+# ANTHROPIC_AUTH_TOKEN: an already-exchanged Anthropic access token (bearer),
+# eagerly minted host-side (test/ci-wif-access-token.sh) rather than exchanged
+# lazily in-container from a WIF identity token. This is what the Integration
+# workflow's WIF path forwards -- see docs/CI-KEYLESS-AUTH.md "Token lifetimes".
 if [ -n "${ANTHROPIC_API_KEY:-}" ] || [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] \
+        || [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ] \
         || [ -f "$HOME/.claude/.credentials.json" ] || [ "$HAS_CLAUDE_WIF" = true ]; then
     HAS_CLAUDE=true
 fi
@@ -629,7 +684,7 @@ _auth_detail() {
 
 echo "  Codex:    $(_label $HAS_CODEX)  $(_auth_detail "api-key=$HAS_OPENAI_API_KEY" "oauth=$HAS_CODEX_OAUTH")"
 echo "  Gemini:   $(_label $HAS_GEMINI)  $(_auth_detail "api-key=$HAS_GEMINI_API_KEY" "oauth=$HAS_GEMINI_OAUTH" "adc=$HAS_GEMINI_ADC")"
-echo "  Claude:   $(_label $HAS_CLAUDE)  $(_auth_detail "wif=$HAS_CLAUDE_WIF" "api-key=$([ -n "${ANTHROPIC_API_KEY:-}" ] && echo true || echo false)" "oauth-token=$([ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && echo true || echo false)" "credentials-file=$([ -f "$HOME/.claude/.credentials.json" ] && echo true || echo false)")"
+echo "  Claude:   $(_label $HAS_CLAUDE)  $(_auth_detail "wif=$HAS_CLAUDE_WIF" "auth-token=$([ -n "${ANTHROPIC_AUTH_TOKEN:-}" ] && echo true || echo false)" "api-key=$([ -n "${ANTHROPIC_API_KEY:-}" ] && echo true || echo false)" "oauth-token=$([ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && echo true || echo false)" "credentials-file=$([ -f "$HOME/.claude/.credentials.json" ] && echo true || echo false)")"
 echo "  OpenCode: $(_label $HAS_OPENCODE)  $(_auth_detail "anthropic-key=$([ -n "${ANTHROPIC_API_KEY:-}" ] && echo true || echo false)" "openai-key=$HAS_OPENAI_API_KEY" "gemini-key=$HAS_GEMINI_API_KEY" "oauth=$HAS_OPENCODE_OAUTH")"
 echo "  Grok:     $(_label $HAS_GROK)  $(_auth_detail "api-key=$HAS_XAI_API_KEY")"
 echo ""

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -9514,6 +9514,286 @@ rm -rf "$_S102_DOWNBIN" "$_S102_BIN" "$_S102_HOME" "$_S102_WS" "$_S102_STATE"
 rm -f "$_S102_OUT"
 unset _S102_STATE
 
+echo "§103: eager per-section WIF credential refresh (test/ci-wif-access-token.sh + the section() hook, #200)"
+# ============================================================
+# Purpose: the Integration workflow exchanges a federated Anthropic access
+# token EAGERLY, host-side (test/ci-wif-access-token.sh), instead of letting
+# Claude Code exchange the raw identity token lazily in-container -- the
+# lazy path bound the whole run to the GitHub JWT's measured ~300s lifetime,
+# and per-section re-minting of the JWT alone was ALSO measured insufficient
+# (two sections individually exceed 300s on their own). The suite's own
+# section() hook (test/run-integration-tests.sh) re-runs the same exchange
+# script before any section whose current token is >=60s old
+# (SANDY_INTEG_CRED_REFRESH_CMD), so no section ever starts on a stale
+# token. See docs/CI-KEYLESS-AUTH.md "Token lifetimes" for the full
+# measurement writeup.
+#
+# This section covers everything reachable WITHOUT Docker or network:
+#   (a) test/ci-wif-access-token.sh's own mint+exchange behavior, behind a
+#       PATH-stubbed curl -- stdout purity (the property the workflow's and
+#       the suite hook's own `$(...)` capture depend on), diagnostics
+#       landing on stderr, and both failure shapes (a failed exchange, and
+#       missing required env).
+#   (b) the suite hook's OWN, REAL code -- extracted verbatim from
+#       test/run-integration-tests.sh via the SANDY_INTEG_SECTION_HOOK
+#       sentinel pair, NOT a hand-copied duplicate that could silently
+#       drift from the shipped logic (the "guard tests assert the
+#       property" lesson) -- driven under a set -euo pipefail + ERR trap
+#       harness matching how the real suite runs it (the "section harness
+#       must match CI" lesson): a successful refresh exports the new
+#       token; the 60s age gate skips a too-recent refresh; a FAILING
+#       refresh warns and keeps the previous token WITHOUT aborting the
+#       harness; the ::add-mask:: line is emitted only under
+#       GITHUB_ACTIONS; a deselected section never refreshes.
+#   (c) a structural assertion that HAS_CLAUDE credential detection names
+#       ANTHROPIC_AUTH_TOKEN (the carrier the workflow actually forwards).
+#
+# Docker-runtime end-to-end proof (the real workflow, a real exchange, a
+# real claude call under the refreshed token) is out of scope here by
+# construction -- the mandatory bring-up proof is a scoped `-f only=7`
+# dispatch, documented in docs/CI-KEYLESS-AUTH.md's Bring-up order.
+
+_S103_REPO="$(dirname "$_SBX_SCRIPT")"
+_S103_SCRIPT="$_S103_REPO/test/ci-wif-access-token.sh"
+_S103_INTEG="$_S103_REPO/test/run-integration-tests.sh"
+_S103_BIN="$(mktemp -d)"
+
+check "§103(pre) test/ci-wif-access-token.sh exists and is executable" \
+    test -x "$_S103_SCRIPT"
+
+# --- (a) test/ci-wif-access-token.sh functional behavior ---
+
+# Fake curl: distinguishes the OIDC-mint call (URL contains the s103mint
+# marker this fixture puts in ACTIONS_ID_TOKEN_REQUEST_URL) from the
+# token-exchange call (the real script's hardcoded oauth/token URL).
+# _S103_MODE selects the exchange call's outcome; success is the default so
+# scenarios that only care about the mint side don't have to set it.
+cat > "$_S103_BIN/curl" <<'S103CURL'
+#!/usr/bin/env bash
+_url=""
+for _a in "$@"; do
+    case "$_a" in http*) _url="$_a" ;; esac
+done
+case "$_url" in
+    *s103mint*)
+        printf '{"value":"%s"}\n' "${_S103_FAKE_JWT:-}"
+        echo "HTTP 200" >&2
+        exit 0
+        ;;
+    *oauth/token*)
+        if [ "${_S103_MODE:-success}" = "exchange_fail" ]; then
+            # Mirrors --fail-with-body: print the error body, exit non-zero.
+            printf '{"type":"error","error":{"type":"authentication_error","message":"Authentication failed"}}\n'
+            echo "HTTP 401" >&2
+            exit 22
+        fi
+        printf '{"access_token":"%s","token_type":"Bearer","expires_in":598}\n' \
+            "${_S103_FAKE_TOKEN:-fake-access-token}"
+        echo "HTTP 200" >&2
+        exit 0
+        ;;
+    *)
+        echo "§103 fake curl: unexpected url: $_url" >&2
+        exit 1
+        ;;
+esac
+S103CURL
+chmod +x "$_S103_BIN/curl"
+
+# A minimal, valid-shaped fake JWT (header.payload.sig) so the script's own
+# claims-decoding diagnostic has something real to parse. Base64url built
+# from plain `base64` (encode is flag-compatible between GNU and BSD; only
+# decode differs) with padding/newlines stripped -- portable to the
+# maintainer's macOS as well as CI.
+_S103_JWT_PAYLOAD="$(printf '{"sub":"repo:rappdw/sandy:ref:refs/heads/main","aud":"https://api.anthropic.com","iat":1000,"exp":1300}' \
+    | base64 | tr -d '=\n' | tr '/+' '_-')"
+_S103_FAKE_JWT="fakehdr.${_S103_JWT_PAYLOAD}.fakesig"
+
+# (a1) success: stdout is EXACTLY the access token, diagnostics on stderr.
+_S103_OUT1="$(mktemp)"; _S103_ERR1="$(mktemp)"
+_s103_rc=0
+PATH="$_S103_BIN:$PATH" \
+    ACTIONS_ID_TOKEN_REQUEST_URL="https://example.invalid/s103mint?x=1" \
+    ACTIONS_ID_TOKEN_REQUEST_TOKEN="reqtok" \
+    ANTHROPIC_FEDERATION_RULE_ID="fdrl_test" \
+    ANTHROPIC_ORGANIZATION_ID="org_test" \
+    ANTHROPIC_SERVICE_ACCOUNT_ID="svac_test" \
+    _S103_FAKE_JWT="$_S103_FAKE_JWT" \
+    _S103_FAKE_TOKEN="fake-access-token-xyz" \
+    _S103_MODE="success" \
+    bash "$_S103_SCRIPT" >"$_S103_OUT1" 2>"$_S103_ERR1" && _s103_rc=0 || _s103_rc=$?
+check "§103(a1) success: exits 0" test "$_s103_rc" -eq 0
+check "§103(a1) success: stdout is EXACTLY the access token, nothing else (stdout purity -- what a \$(...) capture depends on) (mutation: printing a diagnostic to stdout instead of stderr breaks this)" \
+    bash -c '[ "$(cat "$1")" = "fake-access-token-xyz" ]' -- "$_S103_OUT1"
+check "§103(a1) success: diagnostics (expires_in) landed on stderr" \
+    bash -c 'grep -q "expires_in=598s" "$1"' -- "$_S103_ERR1"
+
+# (a2) failed exchange: --fail-with-body's shape (error body + non-zero) is
+# surfaced as a clean non-zero exit with NOTHING on stdout -- a caller must
+# never mistake an error body, or a fragment of one, for a real token.
+_S103_OUT2="$(mktemp)"; _S103_ERR2="$(mktemp)"
+_s103_rc=0
+PATH="$_S103_BIN:$PATH" \
+    ACTIONS_ID_TOKEN_REQUEST_URL="https://example.invalid/s103mint?x=1" \
+    ACTIONS_ID_TOKEN_REQUEST_TOKEN="reqtok" \
+    ANTHROPIC_FEDERATION_RULE_ID="fdrl_test" \
+    ANTHROPIC_ORGANIZATION_ID="org_test" \
+    ANTHROPIC_SERVICE_ACCOUNT_ID="svac_test" \
+    _S103_FAKE_JWT="$_S103_FAKE_JWT" \
+    _S103_MODE="exchange_fail" \
+    bash "$_S103_SCRIPT" >"$_S103_OUT2" 2>"$_S103_ERR2" && _s103_rc=0 || _s103_rc=$?
+check "§103(a2) failed exchange: exits non-zero" test "$_s103_rc" -ne 0
+check "§103(a2) failed exchange: stdout is empty (no partial/garbage token printed)" \
+    bash -c '[ ! -s "$1" ]' -- "$_S103_OUT2"
+
+# (a3) missing required env: fails fast, before ever invoking curl.
+_S103_OUT3="$(mktemp)"; _S103_ERR3="$(mktemp)"
+_s103_rc=0
+PATH="$_S103_BIN:$PATH" bash "$_S103_SCRIPT" >"$_S103_OUT3" 2>"$_S103_ERR3" && _s103_rc=0 || _s103_rc=$?
+check "§103(a3) missing required env: exits 1" test "$_s103_rc" -eq 1
+check "§103(a3) missing required env: stdout is empty" \
+    bash -c '[ ! -s "$1" ]' -- "$_S103_OUT3"
+
+check "§103(a4) both curl invocations use --fail-with-body (mutation: a bare curl exits 0 on an HTTP error, so dropping this would report success on a failed exchange -- (a2)'s stubbed curl exits non-zero unconditionally, so it can't catch this mutation; this static check is what does)" \
+    bash -c 'test "$(grep -c "curl -sS --fail-with-body" "$1")" -eq 2' -- "$_S103_SCRIPT"
+
+rm -f "$_S103_OUT1" "$_S103_ERR1" "$_S103_OUT2" "$_S103_ERR2" "$_S103_OUT3" "$_S103_ERR3"
+rm -rf "$_S103_BIN"
+
+# --- (b) the suite's section() refresh hook: REAL code, extracted verbatim ---
+
+_S103_HOOKSRC="$(mktemp)"
+sed -n '/BEGIN SANDY_INTEG_SECTION_HOOK/,/END SANDY_INTEG_SECTION_HOOK/p' \
+    "$_S103_INTEG" > "$_S103_HOOKSRC"
+check "§103(b0) extracted the real section() hook block from run-integration-tests.sh (mutation: renaming/removing the sentinel pair silently empties this extraction)" \
+    bash -c 'grep -q "_cred_refresh_if_due()" "$1" && grep -q "^section() {" "$1"' -- "$_S103_HOOKSRC"
+
+_S103_DRIVER="$(mktemp)"
+cat > "$_S103_DRIVER" <<'S103DRIVER'
+#!/usr/bin/env bash
+# Replicates the suite's own set -euo pipefail + ERR trap (the "section
+# harness must match CI" lesson) -- without it this harness cannot see an
+# unguarded non-zero exit the way the real suite would.
+set -euo pipefail
+trap 'printf "[err-trap] line %d: %s exited %d\n" "$LINENO" "$BASH_COMMAND" "$?" >&2' ERR
+set -E
+
+# shellcheck source=/dev/null
+. "$1"
+
+# SCEN1: a due refresh (initial -9999 sentinel) exports the new token.
+SANDY_INTEG_CRED_REFRESH_CMD='echo tok-A' section "1. First" >/dev/null
+printf 'SCEN1_TOKEN=%s\n' "${ANTHROPIC_AUTH_TOKEN:-<unset>}"
+
+# SCEN2: within 60s of SCEN1's refresh -- must NOT refresh again.
+unset ANTHROPIC_AUTH_TOKEN
+SANDY_INTEG_CRED_REFRESH_CMD='echo tok-B' section "2. Second" >/dev/null
+printf 'SCEN2_TOKEN=%s\n' "${ANTHROPIC_AUTH_TOKEN:-<unset>}"
+
+# SCEN3: force due, but the refresh command FAILS -- must warn, must NOT
+# abort the harness (proves the RC-guard, not `|| true`), must keep the
+# previous token.
+export ANTHROPIC_AUTH_TOKEN="tok-A"
+_CRED_LAST_REFRESH=-9999
+_scen3_out="$(mktemp)"
+SANDY_INTEG_CRED_REFRESH_CMD='exit 7' section "3. Third" >"$_scen3_out"
+printf 'SCEN3_REACHED_AFTER_FAILED_REFRESH=yes\n'
+printf 'SCEN3_TOKEN=%s\n' "${ANTHROPIC_AUTH_TOKEN:-<unset>}"
+if grep -q "credential refresh failed" "$_scen3_out"; then
+    printf 'SCEN3_WARNED=yes\n'
+else
+    printf 'SCEN3_WARNED=no\n'
+fi
+rm -f "$_scen3_out"
+
+# SCEN4: force due, GITHUB_ACTIONS set -- ::add-mask:: must be emitted.
+_CRED_LAST_REFRESH=-9999
+_scen4_out="$(mktemp)"
+GITHUB_ACTIONS=true SANDY_INTEG_CRED_REFRESH_CMD='echo tok-C' section "4. Fourth" >"$_scen4_out"
+if grep -q '::add-mask::tok-C' "$_scen4_out"; then
+    printf 'SCEN4_MASKED=yes\n'
+else
+    printf 'SCEN4_MASKED=no\n'
+fi
+rm -f "$_scen4_out"
+
+# SCEN5: force due, GITHUB_ACTIONS NOT set -- ::add-mask:: must NOT appear
+# (a plain terminal run must never print a masking directive).
+_CRED_LAST_REFRESH=-9999
+_scen5_out="$(mktemp)"
+unset GITHUB_ACTIONS 2>/dev/null || true
+SANDY_INTEG_CRED_REFRESH_CMD='echo tok-D' section "5. Fifth" >"$_scen5_out"
+if grep -q '::add-mask::' "$_scen5_out"; then
+    printf 'SCEN5_MASKED=yes\n'
+else
+    printf 'SCEN5_MASKED=no\n'
+fi
+rm -f "$_scen5_out"
+
+# SCEN6: a DESELECTED section must never refresh, even when force-due.
+_CRED_LAST_REFRESH=-9999
+export ANTHROPIC_AUTH_TOKEN="tok-D"
+SANDY_INTEG_ONLY=99 SANDY_INTEG_CRED_REFRESH_CMD='echo tok-E' section "6. Sixth" >/dev/null
+printf 'SCEN6_TOKEN=%s\n' "${ANTHROPIC_AUTH_TOKEN:-<unset>}"
+
+# SCEN7/SCEN8: pin the 60s THRESHOLD itself, both directions. The -9999
+# sentinel is due at ANY threshold and SCEN2's real-time gap is under any sane
+# one, so neither notices if the interval is widened. Verified: changing 60 to
+# 9999 passed all 21 original checks -- and would silently run every section
+# after the first on a stale token, which is the exact failure this design
+# exists to prevent. The interval IS the budget, so it gets asserted.
+_CRED_LAST_REFRESH=$(( SECONDS - 61 ))
+export ANTHROPIC_AUTH_TOKEN="tok-STALE"
+SANDY_INTEG_CRED_REFRESH_CMD='echo tok-FRESH' section "7. Seventh" >/dev/null
+printf 'SCEN7_TOKEN=%s\n' "${ANTHROPIC_AUTH_TOKEN:-<unset>}"
+
+_CRED_LAST_REFRESH=$(( SECONDS - 59 ))
+export ANTHROPIC_AUTH_TOKEN="tok-KEEP"
+SANDY_INTEG_CRED_REFRESH_CMD='echo tok-NOPE' section "8. Eighth" >/dev/null
+printf 'SCEN8_TOKEN=%s\n' "${ANTHROPIC_AUTH_TOKEN:-<unset>}"
+
+printf 'ALL_SCENARIOS_COMPLETE=yes\n'
+S103DRIVER
+chmod +x "$_S103_DRIVER"
+
+_S103_DRIVER_OUT="$(mktemp)"
+_s103_rc=0
+bash "$_S103_DRIVER" "$_S103_HOOKSRC" >"$_S103_DRIVER_OUT" 2>&1 && _s103_rc=0 || _s103_rc=$?
+
+check "§103(b1) the driver harness completed all scenarios without the ERR trap firing (mutation: an unguarded \`|| true\` swallowing a real error would let this pass even on broken code -- exit code AND the completion marker are both asserted)" \
+    bash -c 'test "$1" -eq 0 && grep -q "ALL_SCENARIOS_COMPLETE=yes" "$2" && ! grep -q "err-trap" "$2"' \
+    -- "$_s103_rc" "$_S103_DRIVER_OUT"
+check "§103(b2) a due refresh exports the new token (SCEN1)" \
+    bash -c 'grep -q "^SCEN1_TOKEN=tok-A$" "$1"' -- "$_S103_DRIVER_OUT"
+check "§103(b3) a refresh within 60s of the last one does NOT re-run (SCEN2, mutation: dropping the age check makes every section refresh)" \
+    bash -c 'grep -q "^SCEN2_TOKEN=<unset>$" "$1"' -- "$_S103_DRIVER_OUT"
+check "§103(b4) a FAILING refresh command does not abort the harness (SCEN3, mutation: \`|| true\` before the rc read would make this vacuous)" \
+    bash -c 'grep -q "^SCEN3_REACHED_AFTER_FAILED_REFRESH=yes$" "$1"' -- "$_S103_DRIVER_OUT"
+check "§103(b5) a FAILING refresh command warns" \
+    bash -c 'grep -q "^SCEN3_WARNED=yes$" "$1"' -- "$_S103_DRIVER_OUT"
+check "§103(b6) a FAILING refresh command keeps the previous token (mutation: exporting an empty/garbage token on failure)" \
+    bash -c 'grep -q "^SCEN3_TOKEN=tok-A$" "$1"' -- "$_S103_DRIVER_OUT"
+check "§103(b7) ::add-mask:: IS emitted under GITHUB_ACTIONS (SCEN4)" \
+    bash -c 'grep -q "^SCEN4_MASKED=yes$" "$1"' -- "$_S103_DRIVER_OUT"
+check "§103(b8) ::add-mask:: is NOT emitted without GITHUB_ACTIONS (SCEN5, mutation: emitting it unconditionally would leak the marker into a plain terminal run)" \
+    bash -c 'grep -q "^SCEN5_MASKED=no$" "$1"' -- "$_S103_DRIVER_OUT"
+check "§103(b9) a deselected section never refreshes, even when force-due (SCEN6)" \
+    bash -c 'grep -q "^SCEN6_TOKEN=tok-D$" "$1"' -- "$_S103_DRIVER_OUT"
+
+check "§103(b10) age 61s IS due — the section gets a fresh token (pins the 60s threshold; widening the interval fails only this)" \
+    grep -qx 'SCEN7_TOKEN=tok-FRESH' "$_S103_DRIVER_OUT"
+check "§103(b11) age 59s is NOT due — the previous token is kept (pins the other side of the same threshold)" \
+    grep -qx 'SCEN8_TOKEN=tok-KEEP' "$_S103_DRIVER_OUT"
+
+rm -f "$_S103_HOOKSRC" "$_S103_DRIVER" "$_S103_DRIVER_OUT"
+
+# --- (c) structural: HAS_CLAUDE credential detection names ANTHROPIC_AUTH_TOKEN ---
+
+check "§103(c) run-integration-tests.sh's Claude credential detection includes ANTHROPIC_AUTH_TOKEN (mutation: forgetting this leaves the eager-exchange design forwarding a token the suite never looks for -- every claude section would silently skip, the exact 'green run that tested nothing' failure this whole mechanism exists to avoid)" \
+    bash -c 'grep -q "ANTHROPIC_AUTH_TOKEN" "$1"' -- "$_S103_INTEG"
+check "§103(c) the banner surfaces auth-token as its own detail (not folded into api-key) (mutation: silently reusing the api-key slot would make bring-up's \`(auth-token)\` check meaningless)" \
+    bash -c 'grep -q "auth-token=" "$1"' -- "$_S103_INTEG"
+
 # ============================================================
 # Summary
 # ============================================================


### PR DESCRIPTION
The suite failed under WIF because **Claude Code exchanges the JWT lazily, inside the container**, whenever it first needs credentials — so the binding budget was the JWT's measured **300s**, and §13 alone takes **380s**.

## Neither obvious fix works alone

| approach | why not |
|---|---|
| `ANTHROPIC_AUTH_TOKEN` as carrier | gives 598s instead of 300s — but the lean run is **1152s**, so §13 (starting ~800s in) still calls on a dead token |
| per-section JWT re-minting | keeps the 300s budget, and **§13 (380s) / §14 (370s) each exceed it alone** |

**The combination is the mechanism.**

`test/ci-wif-access-token.sh` mints a GitHub OIDC JWT and exchanges it **eagerly, host-side**, printing *only* the access token on stdout — every diagnostic goes to stderr, so a `$(...)` capture can't be corrupted. The suite's `section()` gains a refresh hook: when `SANDY_INTEG_CRED_REFRESH_CMD` is set and the last refresh is ≥60s old, it re-exchanges and exports a fresh `ANTHROPIC_AUTH_TOKEN`.

Every section therefore starts with a token **≤60s old — ≥538s remaining against a 380s worst case**.

## Verified, not assumed

Container delivery is `SANDY_EXTRA_ENV=ANTHROPIC_AUTH_TOKEN`. `ANTHROPIC_AUTH_TOKEN` appears in **neither** `SANDY_PRIVILEGED_KEYS` nor `SANDY_PASSIVE_KEYS` and has no `_sandy_key_metadata` row — so `_load_sandy_extra_env` forwards it rather than rejecting it as already-recognized. Checked in the source; the design depends on it.

No federation config or identity token enters the sandbox at all now. The WIF branch still unsets `ANTHROPIC_API_KEY`, which outranks `AUTH_TOKEN` even when empty.

Staging, activity gate, Sunday baseline, concurrency, and pre-build-outside-the-window all unchanged.

## §103 — and the mutation that survived review

23 checks. **Two were added after a mutation survived the original 21:** widening the refresh interval from 60 to 9999 passed everything — which would silently run every section after the first on a stale token, the exact failure this design exists to prevent.

The interval **is** the budget, so `§103(b10)/(b11)` now pin it from both sides:

| mutation | fails |
|---|---|
| interval 60 → 9999 | only `(b10)` — age 61s must refresh |
| interval 60 → 1 | only `(b11)` — age 59s must not |
| diagnostics to stdout | `(a1)`/`(a2)` — stdout purity |
| unguarded refresh aborting the suite | 7 checks, incl. the ERR-trap completion marker |

§91 15/15 · §92 28/28 · §99 50/50 · §100 27/27 · §101 18/18 · §102 30/30 · §103 23/23. `lint-bash32` clean (18 files — the new script is picked up automatically), all three regen `--check` clean.

## Still unsolved

This covers the **lean set**. The full run adds §19/20/21, and **§20 (~432s on the maintainer host) has not been measured in CI** — if it exceeds ~538s it needs splitting.

Related: #106, #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)