### PR TITLE
fix(ci): make a refused WIF exchange diagnosable in one round trip (#106)

### DIFF
--- a/docs/CI-KEYLESS-AUTH.md
+++ b/docs/CI-KEYLESS-AUTH.md
@@ -257,6 +257,19 @@ ref               refs/heads/main
 repository        rappdw/sandy
 ```
 
+### Telling a malformed request apart from a rejected identity
+
+Before reaching for the console, note that `/v1/oauth/token` **validates request shape before it validates identity**, so the status code alone partitions the problem:
+
+| You get | Means |
+|---|---|
+| `400` + a specific message (`Unsupported grant_type: ...`, `federation_rule_id is not a well-formed fdrl_ tagged ID`) | the *request* is wrong — fix it locally, no console needed |
+| `401` `Authentication failed` | the request was well-formed and reached claim verification, which **refused it** — the console log is the only source of why |
+
+Verified directly: a syntactically valid request carrying the literal string `not.a.jwt` as its assertion returns output byte-identical to a real-but-rejected token. So a 401 body is worth capturing but will never explain itself — do not spend round trips reading it.
+
+Two dimensions of the exchange are genuinely ambiguous for a console-created rule, and neither is documented: whether `workspace_id` must be **sent or omitted** for a single-workspace rule, and whether a blank *Expected audience* means Anthropic's default audience or GitHub's. Guessing costs one CI round trip each, so `test/ci-wif-access-token.sh` walks that small matrix itself on rejection, re-minting per attempt, and reports which combination the rule accepts — then uses it, loudly, so the canonical shape gets corrected rather than left wrong.
+
 This is why claim conditions start blank: `sub` alone already carries repo **and** ref, so a `workflow` condition adds little and breaks any workflow not named in it. Add conditions only after the exchange is proven, and only ones you can state a threat for.
 
 ---

--- a/test/ci-wif-access-token.sh
+++ b/test/ci-wif-access-token.sh
@@ -15,6 +15,22 @@ set -euo pipefail
 # implies". Exchanging once, at a known moment, is what makes that longer
 # clock start where the caller expects it to.
 #
+# WHY THERE IS A FALLBACK MATRIX BELOW. /v1/oauth/token answers every
+# authentication failure with an opaque 401 "Authentication failed" -- verified
+# directly: a syntactically valid request carrying the string "not.a.jwt" as its
+# assertion returns byte-identical output to a real-but-rejected token. The
+# endpoint DOES validate shape first (a bad grant_type or a malformed fdrl_ ID
+# returns 400 with a specific message), so a 401 proves the payload reached
+# claim verification and was refused there -- but says nothing about why.
+# Two dimensions of the request are genuinely ambiguous against a rule created
+# through the console, and neither is knowable without an attempt:
+#   * whether workspace_id must be SENT or OMITTED for a single-workspace rule
+#   * whether a blank "Expected audience" means Anthropic's default audience or
+#     GitHub's default (the repo owner URL)
+# Guessing costs a CI round trip per guess. So on rejection this script walks
+# the small matrix, reports which combination the rule accepts, and uses it --
+# loudly, so the canonical shape gets corrected rather than left wrong.
+#
 # Required env:
 #   ACTIONS_ID_TOKEN_REQUEST_URL, ACTIONS_ID_TOKEN_REQUEST_TOKEN
 #       -- populated by GitHub Actions when the job has `permissions:
@@ -25,16 +41,19 @@ set -euo pipefail
 #          identifiers, not secrets -- a repo-scoped rule means a leaked ID
 #          grants nothing).
 # Optional env:
-#   ANTHROPIC_WORKSPACE_ID -- only needed when the rule spans multiple
-#       workspaces; omitted from the exchange payload entirely when unset,
-#       rather than sent as an empty string.
+#   ANTHROPIC_WORKSPACE_ID -- sent when set, unless a fallback variant omits it.
 #
 # A diagnostic must never fail this script -- every diagnostic block below is
 # wrapped so a jq/base64 hiccup while decoding claims cannot turn a working
 # mint+exchange into a false failure.
 
+_log() { printf '[ci-wif-access-token] %s\n' "$*" >&2; }
 _die() {
-    printf '[ci-wif-access-token] ERROR: %s\n' "$1" >&2
+    _log "ERROR: $1"
+    # The response body is the only thing that could ever explain a failure, so
+    # it must never be discarded -- the first version of this script threw it
+    # away and left a 401 with nothing to go on.
+    [ -n "${_RESP:-}" ] && _log "last response: $(printf '%s' "$_RESP" | head -c 400)"
     exit 1
 }
 
@@ -46,69 +65,128 @@ _die() {
 [ -n "${ANTHROPIC_ORGANIZATION_ID:-}" ]      || _die "ANTHROPIC_ORGANIZATION_ID is not set"
 [ -n "${ANTHROPIC_SERVICE_ACCOUNT_ID:-}" ]   || _die "ANTHROPIC_SERVICE_ACCOUNT_ID is not set"
 
-# Anthropic's default audience; the console rule leaves "Expected audience"
-# blank, which means exactly this value is required.
-_aud="https://api.anthropic.com"
+_ANTHROPIC_AUD="https://api.anthropic.com"
 
-# --- Step 1: mint the GitHub OIDC JWT ---------------------------------------
+# --- mint a GitHub OIDC JWT -------------------------------------------------
+# $1: audience to request, or the empty string to take GitHub's default.
 # --fail-with-body: curl exits 0 on an HTTP error without it, which would
-# report a green mint on a failed request. The writeout goes to stderr
-# (%{stderr}) so stdout stays pure JSON for jq.
-_jwt="$(curl -sS --fail-with-body -w '%{stderr}HTTP %{http_code}\n' \
-          -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${_aud}" | jq -r '.value')" \
-    || _die "OIDC token request failed"
-[ -n "$_jwt" ] && [ "$_jwt" != "null" ] || _die "OIDC token request returned no value"
+# report a green mint on a failed request.
+_mint_jwt() {
+    local _aud="$1" _url="$ACTIONS_ID_TOKEN_REQUEST_URL" _out=""
+    [ -n "$_aud" ] && _url="${_url}&audience=${_aud}"
+    _out="$(curl -sS --fail-with-body \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "$_url" | jq -r '.value')" || return 1
+    [ -n "$_out" ] && [ "$_out" != "null" ] || return 1
+    printf '%s' "$_out"
+}
 
-# --- Diagnostic: decode + report the JWT's own claims -----------------------
-# When an exchange is rejected, the API says only "Authentication failed";
-# the decoded sub is what gets diffed against the federation rule's subject
-# pattern to see why. `|| true` throughout -- never fail the mint over a
-# diagnostic.
-{
-    _pay="$(printf '%s' "$_jwt" | cut -d. -f2)"
+# --- decode a JWT payload for diagnostics -----------------------------------
+# GNU (Linux/CI, the actual execution environment) uses `base64 -d`; BSD
+# (macOS, for a maintainer running this by hand) uses `-D`. Try GNU, fall back.
+_jwt_claims() {
+    local _pay
+    _pay="$(printf '%s' "$1" | cut -d. -f2)"
     _pay="$_pay$(printf '%*s' $(( (4 - ${#_pay} % 4) % 4 )) '' | tr ' ' '=')"
     _pay="$(printf '%s' "$_pay" | tr '_-' '/+')"
-    # GNU (Linux/CI, the actual execution environment for this script) uses
-    # `base64 -d`; BSD (macOS, in case a maintainer runs this by hand) uses
-    # `-D`. Try GNU first, fall back to BSD.
-    _claims="$( { printf '%s' "$_pay" | base64 -d 2>/dev/null \
-                    || printf '%s' "$_pay" | base64 -D 2>/dev/null; } \
-                | jq -c '{sub, aud, lifetime_seconds: (.exp - .iat)}' 2>/dev/null || echo '{}')"
-    printf '[ci-wif-access-token] minted at %s; claims: %s\n' \
-        "$(date -u +%H:%M:%SZ)" "$_claims" >&2
-} || true
+    { printf '%s' "$_pay" | base64 -d 2>/dev/null \
+        || printf '%s' "$_pay" | base64 -D 2>/dev/null; } \
+      | jq -c '{sub, aud, lifetime_seconds: (.exp - .iat)}' 2>/dev/null || printf '{}'
+}
 
-# --- Step 2: exchange the JWT for an Anthropic access token -----------------
-# Built with jq -n rather than string interpolation into a heredoc, so the
-# JWT and IDs never need to be shell/JSON-escaped by hand -- and so
-# workspace_id can be OMITTED (not sent as "") when the rule is single-workspace.
-_payload="$(jq -n \
-    --arg grant_type "urn:ietf:params:oauth:grant-type:jwt-bearer" \
-    --arg assertion "$_jwt" \
-    --arg rule "$ANTHROPIC_FEDERATION_RULE_ID" \
-    --arg org "$ANTHROPIC_ORGANIZATION_ID" \
-    --arg svc "$ANTHROPIC_SERVICE_ACCOUNT_ID" \
-    --arg ws "${ANTHROPIC_WORKSPACE_ID:-}" \
-    '{grant_type: $grant_type, assertion: $assertion,
-      federation_rule_id: $rule, organization_id: $org, service_account_id: $svc}
-     + (if $ws != "" then {workspace_id: $ws} else {} end)')"
+# --- exchange a JWT for an access token -------------------------------------
+# $1 JWT, $2 include workspace_id (1|0). Sets _RESP; returns curl status.
+# Built with jq -n rather than string interpolation, so the JWT and IDs never
+# need hand-escaping -- and so workspace_id can be genuinely OMITTED rather
+# than sent as an empty string.
+_exchange() {
+    local _jwt="$1" _with_ws="$2" _payload=""
+    local _ws=""
+    [ "$_with_ws" = "1" ] && _ws="${ANTHROPIC_WORKSPACE_ID:-}"
+    _payload="$(jq -n \
+        --arg grant_type "urn:ietf:params:oauth:grant-type:jwt-bearer" \
+        --arg assertion "$_jwt" \
+        --arg rule "$ANTHROPIC_FEDERATION_RULE_ID" \
+        --arg org "$ANTHROPIC_ORGANIZATION_ID" \
+        --arg svc "$ANTHROPIC_SERVICE_ACCOUNT_ID" \
+        --arg ws "$_ws" \
+        '{grant_type: $grant_type, assertion: $assertion,
+          federation_rule_id: $rule, organization_id: $org,
+          service_account_id: $svc}
+         + (if $ws != "" then {workspace_id: $ws} else {} end)')"
+    _RESP="$(curl -sS --fail-with-body https://api.anthropic.com/v1/oauth/token \
+        -H "content-type: application/json" --data "$_payload")"
+}
 
-_resp="$(curl -sS --fail-with-body -w '%{stderr}HTTP %{http_code}\n' \
-    https://api.anthropic.com/v1/oauth/token \
-    -H "content-type: application/json" \
-    --data "$_payload")" \
-    || _die "token exchange failed"
+# --- token extraction --------------------------------------------------------
+_token_from_resp() { printf '%s' "${_RESP:-}" | jq -r '.access_token // empty' 2>/dev/null || true; }
 
-_access_token="$(printf '%s' "$_resp" | jq -r '.access_token // empty' 2>/dev/null || true)"
-[ -n "$_access_token" ] || _die "exchange response had no access_token"
+# --- attempt: mint for an audience, exchange with/without workspace_id -------
+# $1 audience ("" = GitHub default), $2 include workspace_id, $3 label.
+# Echoes the access token on success; returns nonzero on any failure.
+_attempt() {
+    local _aud="$1" _with_ws="$2" _label="$3" _jwt="" _tok="" _rc=0
+    _jwt="$(_mint_jwt "$_aud")" || { _log "  $_label: JWT mint failed"; return 1; }
+    _RESP=""
+    _exchange "$_jwt" "$_with_ws" || _rc=$?
+    if [ "$_rc" -ne 0 ]; then
+        _log "  $_label: rejected -- $(printf '%s' "${_RESP:-}" | jq -rc '.error.message // "no body"' 2>/dev/null || printf 'no body')"
+        return 1
+    fi
+    _tok="$(_token_from_resp)"
+    [ -n "$_tok" ] || { _log "  $_label: 200 but no access_token in response"; return 1; }
+    printf '%s' "$_tok"
+}
 
-# --- Diagnostic: report the ACCESS TOKEN's lifetime (not the JWT's) ---------
-# This is the number the caller's refresh budget is actually built on.
-{
-    _expires_in="$(printf '%s' "$_resp" | jq -r '.expires_in // "unknown"' 2>/dev/null || echo unknown)"
-    printf '[ci-wif-access-token] exchange ok; expires_in=%ss\n' "$_expires_in" >&2
-} || true
+# --- canonical attempt -------------------------------------------------------
+_jwt="$(_mint_jwt "$_ANTHROPIC_AUD")" || _die "OIDC token request failed"
+_log "minted at $(date -u +%H:%M:%SZ); claims: $(_jwt_claims "$_jwt")"
+
+_RESP=""
+_rc=0
+_exchange "$_jwt" "1" || _rc=$?
+_access_token=""
+[ "$_rc" -eq 0 ] && _access_token="$(_token_from_resp)"
+
+# --- fallback matrix ---------------------------------------------------------
+# Only reached when the canonical shape is refused. Each entry re-mints, so a
+# single-use assertion cannot produce a false negative on a later variant.
+if [ -z "$_access_token" ]; then
+    _log "canonical exchange refused (workspace_id sent, audience $_ANTHROPIC_AUD)."
+    _log "walking the fallback matrix to identify what this rule accepts:"
+    _WORKED=""
+    # Newline-delimited rather than an array: an empty array expansion under
+    # `set -u` is a documented bash-3.2 trap in this repo.
+    while IFS='|' read -r _v_aud _v_ws _v_label; do
+        [ -z "$_v_label" ] && continue
+        _t="$(_attempt "$_v_aud" "$_v_ws" "$_v_label")" || continue
+        _access_token="$_t"; _WORKED="$_v_label"; break
+    done <<VARIANTS
+$_ANTHROPIC_AUD|0|anthropic-audience, workspace_id OMITTED
+|1|github-default-audience, workspace_id sent
+|0|github-default-audience, workspace_id OMITTED
+VARIANTS
+    if [ -n "$_access_token" ]; then
+        _log ""
+        _log "!! The canonical exchange shape in this script is WRONG for this rule."
+        _log "!! Accepted instead: $_WORKED"
+        _log "!! Proceeding with that, but fix the canonical shape so the matrix"
+        _log "!! stops being load-bearing (docs/CI-KEYLESS-AUTH.md)."
+        _log ""
+    fi
+fi
+
+if [ -z "$_access_token" ]; then
+    _log "every variant was refused. The 401 body is opaque by design, so the"
+    _log "next diagnostic step is the Anthropic console audit log: find this"
+    _log "attempt and read its failure reason (e.g. match_claim_value_mismatch),"
+    _log "then compare it against the sub printed above."
+    _die "token exchange failed"
+fi
+
+# Report the ACCESS TOKEN lifetime (not the JWT's) -- this is the number the
+# caller's refresh budget is actually built on.
+_log "exchange ok; expires_in=$(printf '%s' "$_RESP" | jq -r '.expires_in // "unknown"' 2>/dev/null || printf 'unknown')s"
 
 # stdout: the access token, and nothing else.
 printf '%s' "$_access_token"


### PR DESCRIPTION
The eager host-side exchange from #201 has **never succeeded** in CI — every run 401s. The same JWT (identical `sub`/`aud`) *was* accepted when Claude Code exchanged it in-container, so the token is fine and the exchange request is what differs.

### Why it was undiagnosable

- `_die` threw away the response body — the one thing that could explain a failure.
- The body would not have helped. Verified live: a well-formed request carrying the literal string `not.a.jwt` as its assertion returns output **byte-identical** to a real-but-rejected token.

### What partitions the problem

`/v1/oauth/token` validates **shape before identity**:

| Response | Means |
|---|---|
| `400` + specific message | the request is wrong — fix locally |
| `401 Authentication failed` | well-formed, reached claim verification, **refused there** |

So our 401 proves the payload is structurally correct. That is now the documented first diagnostic step.

### The fallback matrix

Two dimensions are genuinely ambiguous for a console-created rule, neither documented: whether `workspace_id` must be **sent or omitted** for a single-workspace rule, and whether a blank *Expected audience* means Anthropic's default or GitHub's. Guessing costs a CI round trip **each**.

On rejection the script now walks that matrix itself — re-minting per attempt so a single-use assertion can't cause a false negative — reports which combination the rule accepts, and proceeds with it **loudly**, so the canonical shape gets fixed rather than left quietly wrong. If everything is refused it fails with a pointer to the console audit log.

### Verification

Stdout purity holds on every path (the caller captures with `$(...)`), proven against a stubbed endpoint:

| Case | rc | stdout |
|---|---|---|
| canonical success | 0 | `TOK-canonical` |
| fallback recovery | 0 | `TOK-nows` + `!! Accepted instead: ...` on stderr |
| all variants refused | 1 | *(empty)* + audit-log pointer |

`bash -n`, `shellcheck -S warning`, and `test/lint-bash32.sh` all clean.