### PR TITLE
ci(proxy): scan the Go the proxy actually ships with

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,9 +52,23 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Track the SAME Go the shipped proxy is built with. The image uses
+      # `FROM golang:1.26-trixie` -- a floating tag resolving to the latest
+      # 1.26.x -- but `go-version-file: proxy/go.mod` reads the `go 1.26.0`
+      # directive LITERALLY and installs 1.26.0 exactly. That divergence made
+      # govulncheck scan a toolchain that never ships: it reported 14 reachable
+      # stdlib vulnerabilities fixed across 1.26.1-1.26.6 which the shipped
+      # binary does not have, while never validating the binary that does ship.
+      # A scan of the wrong artifact is worse than no scan -- it reads as
+      # coverage. `1.26` here mirrors the image tag, so the advisory findings
+      # describe the artifact users actually run.
+      #
+      # The go.mod directive stays `go 1.26.0`: it is a MINIMUM (the lowest
+      # toolchain allowed to build this module), not a pin, and raising it would
+      # exclude contributors on an older 1.26.x for no gain.
       - uses: actions/setup-go@v7
         with:
-          go-version-file: proxy/go.mod
+          go-version: '1.26'
           cache-dependency-path: proxy/go.sum
 
       - name: gofmt


### PR DESCRIPTION
`govulncheck` reports **14 reachable stdlib vulnerabilities** on every proxy run (visible as the 10 error annotations on a green job). They are fixed across `go1.26.1`–`go1.26.6`, and two of them parse untrusted wire bytes:

- **GO-2026-5039** — `net/textproto.ReadMIMEHeader`, reachable from `connectListener.handle`
- **GO-2026-6090** — `crypto/tls`, post-handshake message flooding

### The shipped binary does not have them

| | Go version | Mechanism |
|---|---|---|
| Shipped proxy | latest 1.26.x | `FROM golang:1.26-trixie` — floating tag |
| CI govulncheck | **exactly 1.26.0** | `go-version-file: proxy/go.mod` reads `go 1.26.0` *literally* |

`CLAUDE.md`'s monthly freshness epoch + `--pull` exists precisely to keep the image's stdlib current, and it works. CI was the half that drifted.

### Why this matters more than the noise

The scan described a toolchain that **never ships**, while never validating the one that does. That's worse than not scanning — 14 unactionable findings train the reader to ignore the step, and a genuine finding against the real image would have been invisible behind them.

### The change

Point `setup-go` at the same floating tag the image uses. The `go.mod` directive stays `go 1.26.0` — it's a **minimum**, not a pin; raising it would exclude contributors on an older 1.26.x for no gain.

The step stays **advisory** (`continue-on-error`), per the documented posture: stdlib patch latency is remediated by the monthly image refresh, not by blocking unrelated proxy PRs. What changes is that its output now describes the artifact users actually run.