### PR TITLE
test(integration): refuse to report a green run that tested nothing (#106)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -193,6 +193,14 @@ jobs:
           # CI runners are slower than the maintainer host; the default 300s
           # per-test timeout is tuned for the latter.
           SANDY_INTEG_TIMEOUT: '600'
+          # Declare that a claude credential is EXPECTED whenever WIF is
+          # configured, so the suite fails instead of skipping ~22 sections and
+          # reporting success. Run 32681634083 did exactly that: it announced
+          # "auth: workload identity federation", ended up with Claude "none
+          # configured", and went green having tested nothing. Actions cannot
+          # omit an env entry conditionally, so this evaluates to '0' (opt-out,
+          # the safe default) when WIF is not configured.
+          SANDY_INTEG_REQUIRE_CLAUDE: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID != '' && '1' || '0' }}
         run: |
           set -euo pipefail
           if [ -n "${ANTHROPIC_FEDERATION_RULE_ID:-}" ]; then

--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -689,6 +689,29 @@ echo "  OpenCode: $(_label $HAS_OPENCODE)  $(_auth_detail "anthropic-key=$([ -n 
 echo "  Grok:     $(_label $HAS_GROK)  $(_auth_detail "api-key=$HAS_XAI_API_KEY")"
 echo ""
 
+# --- fail closed when a credential was INTENDED but did not arrive ----------
+# The #196 class of false green, seen again in run 32681634083: the Integration
+# workflow announced "auth: workload identity federation", the exchange silently
+# produced nothing, Claude came up "none configured", every claude section
+# skipped cleanly, and the run went GREEN having tested nothing.
+#
+# Skipping is the right behavior when no credential was intended -- that is what
+# keeps this suite useful on a repo with no secrets. It is a FALSE GREEN when one
+# was. The two cases are indistinguishable from inside the suite, so the operator
+# declares the intent: SANDY_INTEG_REQUIRE_CLAUDE=1 means "a claude credential is
+# expected", which turns a silent skip into a hard failure that names the cause.
+#
+# Checked AFTER the banner prints, so the log shows the full credential table
+# first -- the table is the diagnosis, the error is just the verdict.
+# >>> SANDY_REQUIRE_CLAUDE_GUARD (extracted verbatim by run-tests.sh §104)
+if [ "${SANDY_INTEG_REQUIRE_CLAUDE:-0}" = "1" ] && [ "$HAS_CLAUDE" != true ]; then
+    printf "\033[0;31mSANDY_INTEG_REQUIRE_CLAUDE=1, but no claude credential is configured.\033[0m\n"
+    printf "This run would have skipped every claude section and reported success.\n"
+    printf "Refusing to report a green run that tested nothing (see the table above).\n"
+    exit 1
+fi
+# <<< SANDY_REQUIRE_CLAUDE_GUARD
+
 _all_true=true
 for _v in $HAS_CODEX $HAS_GEMINI $HAS_CLAUDE $HAS_OPENCODE $HAS_GROK; do
     [ "$_v" = true ] || _all_true=false

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -9808,6 +9808,68 @@ else
         printf "  \033[0;31m- %s\033[0m\n" "$e"
     done
 fi
+echo ""
+echo "§104: fail closed when a claude credential was intended but absent (#106)"
+# WHY THIS EXISTS. Integration run 32681634083 went GREEN having tested nothing:
+# the workflow announced "auth: workload identity federation", the exchange
+# produced no usable credential, Claude came up "none configured", and all ~22
+# claude sections skipped cleanly. A suite that skips when a credential is
+# genuinely absent is correct -- that is what makes it useful on a repo with no
+# secrets -- so the two cases can only be told apart by operator intent.
+# SANDY_INTEG_REQUIRE_CLAUDE=1 declares that intent.
+#
+# This section asserts the PROPERTY (a required-but-absent credential fails the
+# run), not the mere presence of the variable name -- a grep for the string would
+# still pass if the comparison were inverted or the exit dropped.
+_S104_SUITE="$(dirname "$0")/run-integration-tests.sh"
+check "§104(pre) run-integration-tests.sh exists" test -f "$_S104_SUITE"
+
+# Extract the guard and exercise it in isolation, against the four combinations
+# of (intent declared?) x (credential present?). Running the real suite is not an
+# option here -- it launches containers -- so the guard block is lifted verbatim
+# and driven directly, which keeps this coupled to the real source text.
+# Extract the guard VERBATIM from the suite and drive it. Reimplementing the
+# logic here would test a copy -- a disabled guard in the real file would leave
+# these checks green, which is precisely the vacuous-guard failure this repo has
+# hit before. The sentinel pair is asserted below so a rename cannot silently
+# empty the extraction.
+_S104_BLOCK="$(awk '/^# >>> SANDY_REQUIRE_CLAUDE_GUARD/{f=1;next} /^# <<< SANDY_REQUIRE_CLAUDE_GUARD/{f=0} f' "$_S104_SUITE")"
+check "§104(0) extracted the real guard from the suite (mutation: renaming or removing the sentinel pair empties this extraction and must fail here, not silently pass everything after it)" \
+    test -n "$_S104_BLOCK"
+
+_s104_guard() {
+    # $1 = SANDY_INTEG_REQUIRE_CLAUDE, $2 = HAS_CLAUDE. Runs the SUITE's own text.
+    env SANDY_INTEG_REQUIRE_CLAUDE="$1" HAS_CLAUDE="$2" bash -c "
+        $_S104_BLOCK
+        exit 0"
+}
+_s104_rc=0; _s104_guard 1 false || _s104_rc=$?
+check "§104(1) required + absent  -> FAILS (the false-green case; mutation: inverting the test or dropping the exit makes this pass)" \
+    test "$_s104_rc" -eq 1
+_s104_rc=0; _s104_guard 1 true || _s104_rc=$?
+check "§104(2) required + present -> passes" test "$_s104_rc" -eq 0
+_s104_rc=0; _s104_guard 0 false || _s104_rc=$?
+check "§104(3) not required + absent -> passes (a credential-less repo must still run and skip)" \
+    test "$_s104_rc" -eq 0
+_s104_rc=0; _s104_guard "" false || _s104_rc=$?
+check "§104(4) unset + absent -> passes (default must be opt-in, never opt-out)" \
+    test "$_s104_rc" -eq 0
+
+# The guard must actually be present in the suite, and gated on the documented
+# variable -- (1)-(4) above prove the LOGIC, this proves it is WIRED IN.
+check "§104(5) the suite contains the SANDY_INTEG_REQUIRE_CLAUDE guard" \
+    grep -q 'SANDY_INTEG_REQUIRE_CLAUDE' "$_S104_SUITE"
+check "§104(6) the guard exits rather than only warning (mutation: downgrading exit 1 to a printf leaves the false green in place)" \
+    grep -A12 'SANDY_INTEG_REQUIRE_CLAUDE:-0' "$_S104_SUITE" | grep -q 'exit 1'
+
+# And the workflow must SET it on the WIF path, or the guard never fires where
+# the false green actually happened.
+_S104_WF="$(dirname "$0")/../.github/workflows/integration.yml"
+if [ -f "$_S104_WF" ]; then
+    check "§104(7) the Integration workflow sets SANDY_INTEG_REQUIRE_CLAUDE (mutation: the guard is inert in CI without this)" \
+        grep -q 'SANDY_INTEG_REQUIRE_CLAUDE' "$_S104_WF"
+fi
+
 _run_provenance   # timestamp + commit + tree state, so a result you scroll back
                   # to after a context switch says which build produced it.
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
### The finding

Integration run `32681634083` is recorded as the one **successful** WIF run. It was not:

```
auth: workload identity federation (rule fdrl_...)
Claude:   ✗  none configured
```

The exchange produced no usable credential, every claude section skipped cleanly, and the run went **green having tested nothing**.

This matters beyond the one run: it means **no Integration run has ever authenticated via WIF**, on either the eager or the lazy path. WIF looked closer to working than it is.

### The fix

Skipping is *correct* when a credential is genuinely absent — that's what keeps this suite useful on a repo with no secrets — so the suite cannot distinguish the two cases on its own. The operator declares intent:

- `SANDY_INTEG_REQUIRE_CLAUDE=1` → a claude credential is **expected**; its absence is a hard failure naming the cause.
- The Integration workflow sets it whenever WIF is configured; **opt-out by default** everywhere else.

### §104, and the vacuous first draft

The first version of §104 reimplemented the guard inline — so disabling the real guard in the suite left **every check green**. That's the failure mode this repo keeps rediscovering, caught here only by mutation-testing it.

It now extracts the guard **verbatim** between sentinels and drives that text, and asserts the sentinel pair so a rename fails loudly instead of silently emptying the extraction.

| State | Result |
|---|---|
| baseline | **8/8 pass** |
| guard body disabled (`if false`) | **§104(1) fails** |
| sentinel renamed | **§104(0) and §104(1) fail** |