### PR TITLE
docs(wif): a blank Expected audience matches nothing, and fix §104(6) (#106)

### DIFF
--- a/docs/CI-KEYLESS-AUTH.md
+++ b/docs/CI-KEYLESS-AUTH.md
@@ -75,7 +75,7 @@ The rule maps verified token claims to API access.
 | Issuer | `github-ci` | the one registered in Step 1 |
 | Subject pattern | `repo:rappdw/sandy:ref:refs/heads/main` | exact — **no trailing `*`** |
 | Additional claim conditions | **blank** initially | see below |
-| Expected audience | **blank** | blank means Anthropic's default `https://api.anthropic.com`, which is what the workflow requests |
+| Expected audience | `https://api.anthropic.com` | **must be set explicitly.** A blank field is an *empty list* that matches nothing — not a default. Leaving it blank rejects every token with `jwt_audience_mismatch`. This value is what the workflow requests |
 | Service account | the one from Step 0 | must be a **member of the target workspace** |
 | Authorization | **Workspaces → Default**, *not* "all workspaces" | least privilege, **and** it avoids needing `ANTHROPIC_WORKSPACE_ID` at all |
 | OAuth scope | `workspace:developer` | the default |
@@ -245,6 +245,7 @@ The entry carries `status.reason` plus the full decoded token claims, which is e
 | `match_claim_value_mismatch` | an **Additional claim condition** on the rule does not match the token | compare the condition against the logged `claims`. A condition pinning `workflow` to one workflow's name fails for *every other* workflow — including a smoke test |
 | subject/pattern mismatch | the `sub` does not match the subject pattern | compare `claims.sub` against the pattern; a push from a non-`main` branch is the usual cause |
 | `workspace_id_required` | the rule spans multiple workspaces | set `ANTHROPIC_WORKSPACE_ID` |
+| `jwt_audience_mismatch` | the token's `aud` is not in the rule's **Expected audience** list | set *Expected audience* on the rule. A blank field matches nothing — the audit entry shows `actor.audience: []`. Use `https://api.anthropic.com`, which is what the workflow requests |
 
 Claims worth knowing are distinct, because pinning the wrong one is the common mistake:
 
@@ -268,7 +269,9 @@ Before reaching for the console, note that `/v1/oauth/token` **validates request
 
 Verified directly: a syntactically valid request carrying the literal string `not.a.jwt` as its assertion returns output byte-identical to a real-but-rejected token. So a 401 body is worth capturing but will never explain itself — do not spend round trips reading it.
 
-Two dimensions of the exchange are genuinely ambiguous for a console-created rule, and neither is documented: whether `workspace_id` must be **sent or omitted** for a single-workspace rule, and whether a blank *Expected audience* means Anthropic's default audience or GitHub's. Guessing costs one CI round trip each, so `test/ci-wif-access-token.sh` walks that small matrix itself on rejection, re-minting per attempt, and reports which combination the rule accepts — then uses it, loudly, so the canonical shape gets corrected rather than left wrong.
+One dimension of the exchange stays ambiguous for a console-created rule: whether `workspace_id` must be **sent or omitted** for a single-workspace rule. Guessing costs a CI round trip, so `test/ci-wif-access-token.sh` walks a small matrix itself on rejection, re-minting per attempt, and reports which combination the rule accepts — then uses it, loudly, so the canonical shape gets corrected rather than left wrong.
+
+The matrix also varies the audience, but that dimension can only ever succeed once the rule's *Expected audience* is set: a blank field matches nothing, so **no** requested audience works. If every variant is refused with `jwt_audience_mismatch`, do not keep varying the request — fix the rule.
 
 This is why claim conditions start blank: `sub` alone already carries repo **and** ref, so a `workflow` condition adds little and breaks any workflow not named in it. Add conditions only after the exchange is proven, and only ones you can state a threat for.
 

--- a/test/ci-wif-access-token.sh
+++ b/test/ci-wif-access-token.sh
@@ -65,6 +65,12 @@ _die() {
 [ -n "${ANTHROPIC_ORGANIZATION_ID:-}" ]      || _die "ANTHROPIC_ORGANIZATION_ID is not set"
 [ -n "${ANTHROPIC_SERVICE_ACCOUNT_ID:-}" ]   || _die "ANTHROPIC_SERVICE_ACCOUNT_ID is not set"
 
+# The audience requested from GitHub. It must MATCH the federation rule's
+# "Expected audience" field, and that field has to be set EXPLICITLY: a blank
+# field is an empty expected-audience list which matches nothing, not a default.
+# Confirmed by an audit entry reading `jwt_audience_mismatch` with
+# `actor.audience: []` while the rule was blank -- every token was refused
+# regardless of the aud it carried.
 _ANTHROPIC_AUD="https://api.anthropic.com"
 
 # --- mint a GitHub OIDC JWT -------------------------------------------------

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -9859,8 +9859,15 @@ check "§104(4) unset + absent -> passes (default must be opt-in, never opt-out)
 # variable -- (1)-(4) above prove the LOGIC, this proves it is WIRED IN.
 check "§104(5) the suite contains the SANDY_INTEG_REQUIRE_CLAUDE guard" \
     grep -q 'SANDY_INTEG_REQUIRE_CLAUDE' "$_S104_SUITE"
+# NO PIPE HERE, deliberately. Written as `check "..." grep -A12 ... | grep -q`,
+# the pipe binds to the whole `check` invocation: check would run only the first
+# grep (so the verdict came from "the pattern exists", never "the guard exits"),
+# and check's own result line was swallowed by grep -q, which is why it printed
+# nothing at all. It was also a latent GREPM -- `grep | grep -q` under pipefail
+# dies on EPIPE. The extracted block already holds the real text, so match it
+# directly instead of re-reading the file through a pipeline.
 check "§104(6) the guard exits rather than only warning (mutation: downgrading exit 1 to a printf leaves the false green in place)" \
-    grep -A12 'SANDY_INTEG_REQUIRE_CLAUDE:-0' "$_S104_SUITE" | grep -q 'exit 1'
+    bash -c 'case "$1" in *"exit 1"*) exit 0 ;; *) exit 1 ;; esac' _ "$_S104_BLOCK"
 
 # And the workflow must SET it on the WIF path, or the guard never fires where
 # the false green actually happened.


### PR DESCRIPTION
### The cause, from the audit log

```json
"reason": "jwt_audience_mismatch",
"actor": { "audience": [] }
```

The runbook told operators to leave the rule's **Expected audience** blank, claiming blank meant "Anthropic's default." It does not — **blank is an empty list, which matches nothing**, so every token is refused regardless of its `aud`. That instruction configured the rule into a state where no request could succeed.

Corrected in three places:

| Site | Fix |
|---|---|
| Setup table | specifies `https://api.anthropic.com` explicitly, and says why blank fails |
| Diagnosis table | new `jwt_audience_mismatch` row, with the `actor.audience: []` tell |
| Script comment | old claim replaced with the audit evidence |

Also corrected: the claim that audience was one of two *"genuinely ambiguous"* dimensions worth probing. It wasn't. With a blank rule **no** requested audience can succeed — the matrix was varying the request while the rule was the empty side of the comparison. The runbook now says to stop varying and fix the rule.

### §104(6) was invisible *and* testing the wrong thing

```sh
check "..." grep -A12 PATTERN "$FILE" | grep -q 'exit 1'
```

The pipe binds to the whole `check` invocation, so `check` ran **only the first grep** — its verdict came from *"the pattern exists"*, never *"the guard exits"* — and its own ✓/✗ line was swallowed by `grep -q`. That's why §104(6) printed **nothing** in CI while every sibling reported. It was also a latent `GREPM` (`grep | grep -q` under `pipefail` dies on `EPIPE`).

Now matches the already-extracted guard text with no pipeline. Mutation-tested:

| State | §104(6) |
|---|---|
| baseline | **pass** |
| `exit 1` → `printf` warning | **fail** ← the mutation it exists to catch |