### PR TITLE
docs(wif): the audit actor block is blank on failure; document the event_name trap

### DIFF
--- a/docs/CI-KEYLESS-AUTH.md
+++ b/docs/CI-KEYLESS-AUTH.md
@@ -245,7 +245,23 @@ The entry carries `status.reason` plus the full decoded token claims, which is e
 | `match_claim_value_mismatch` | an **Additional claim condition** on the rule does not match the token | compare the condition against the logged `claims`. A condition pinning `workflow` to one workflow's name fails for *every other* workflow — including a smoke test |
 | subject/pattern mismatch | the `sub` does not match the subject pattern | compare `claims.sub` against the pattern; a push from a non-`main` branch is the usual cause |
 | `workspace_id_required` | the rule spans multiple workspaces | set `ANTHROPIC_WORKSPACE_ID` |
-| `jwt_audience_mismatch` | the token's `aud` is not in the rule's **Expected audience** list | set *Expected audience* on the rule. A blank field matches nothing — the audit entry shows `actor.audience: []`. Use `https://api.anthropic.com`, which is what the workflow requests |
+| `jwt_audience_mismatch` | the token's `aud` does not match the rule's **Expected audience** | set *Expected audience* explicitly to `https://api.anthropic.com`, which is what the workflow requests. A blank field matches nothing |
+
+### `actor` is empty on failure — do not read it as configuration
+
+A failed entry carries an unpopulated actor:
+
+```json
+"actor": { "audience": [], "issuer": "", "subject": "", ... }
+```
+
+`issuer` and `subject` are blank there too. That block is a **blank template on failure**, not a readout of the rule's configured values — so `actor.audience: []` is *not* evidence that the rule's audience list is empty, and an empty `subject` is not evidence the token had none. Only `status.reason` is diagnostic. (This document previously claimed the opposite; it was an over-read of a single entry.)
+
+### The `event_name` trap
+
+A required claim of `event_name = push` rejects **every** run of a workflow triggered by `schedule` or `workflow_dispatch` — which is exactly how a keyed integration workflow is triggered, since it deliberately has no `push`/`pull_request` trigger. The rule then refuses every run forever, and the reason it reports may name a *different* failing condition, so the `event_name` mismatch is easy to miss while chasing something else.
+
+This is the concrete form of the general warning below: pin `event_name` only if you can name a trigger it is meant to exclude, and check it against the workflow's actual `on:` block first.
 
 Claims worth knowing are distinct, because pinning the wrong one is the common mistake:
 

--- a/docs/CI-KEYLESS-AUTH.md
+++ b/docs/CI-KEYLESS-AUTH.md
@@ -257,11 +257,11 @@ A failed entry carries an unpopulated actor:
 
 `issuer` and `subject` are blank there too. That block is a **blank template on failure**, not a readout of the rule's configured values — so `actor.audience: []` is *not* evidence that the rule's audience list is empty, and an empty `subject` is not evidence the token had none. Only `status.reason` is diagnostic. (This document previously claimed the opposite; it was an over-read of a single entry.)
 
-### The `event_name` trap
+### Claim conditions and trigger events
 
-A required claim of `event_name = push` rejects **every** run of a workflow triggered by `schedule` or `workflow_dispatch` — which is exactly how a keyed integration workflow is triggered, since it deliberately has no `push`/`pull_request` trigger. The rule then refuses every run forever, and the reason it reports may name a *different* failing condition, so the `event_name` mismatch is easy to miss while chasing something else.
+A required claim of `event_name = push` sits on a rule whose workflow is triggered only by `schedule` and `workflow_dispatch` — a keyed integration workflow deliberately has no `push`/`pull_request` trigger, so no run it ever makes carries `event_name: push`.
 
-This is the concrete form of the general warning below: pin `event_name` only if you can name a trigger it is meant to exclude, and check it against the workflow's actual `on:` block first.
+Whether such a condition hard-refuses every run was **not** established here. Two rule changes (setting *Expected audience*, removing this claim) were made before the first successful exchange, so neither can be credited on this evidence. What is established is the general rule below: pin a claim only if you can name a trigger it is meant to exclude, and check it against the workflow's actual `on:` block first — a condition that cannot match any trigger the workflow uses is at best inert and at worst a permanent refusal, and the reported `status.reason` may name a *different* failing condition while it is in place.
 
 Claims worth knowing are distinct, because pinning the wrong one is the common mistake:
 

--- a/test/ci-wif-access-token.sh
+++ b/test/ci-wif-access-token.sh
@@ -68,9 +68,11 @@ _die() {
 # The audience requested from GitHub. It must MATCH the federation rule's
 # "Expected audience" field, and that field has to be set EXPLICITLY: a blank
 # field is an empty expected-audience list which matches nothing, not a default.
-# Confirmed by an audit entry reading `jwt_audience_mismatch` with
-# `actor.audience: []` while the rule was blank -- every token was refused
-# regardless of the aud it carried.
+# Confirmed by an audit entry whose status.reason read `jwt_audience_mismatch`
+# while the rule's audience field was blank -- every token was refused
+# regardless of the aud it carried. (Read status.reason ONLY: the entry's
+# `actor` block is an empty template on failure, with issuer and subject blank
+# too, so its `audience: []` says nothing about the rule's configuration.)
 _ANTHROPIC_AUD="https://api.anthropic.com"
 
 # --- mint a GitHub OIDC JWT -------------------------------------------------


### PR DESCRIPTION
Two corrections to the diagnosis guidance, both from reading a real rule config.

### 1. An over-read of mine, published in #205

A **failed** audit entry carries:

```json
"actor": { "audience": [], "issuer": "", "subject": "", ... }
```

I cited `actor.audience: []` as evidence that the rule's audience list was empty. It is not evidence of anything — `issuer` and `subject` are blank in the same entry, so the actor block is simply an **unpopulated template on failure**. Only `status.reason` is diagnostic.

The conclusion it supported happened to be correct (the audience field *was* blank), but the reasoning was wrong — and a wrong diagnostic rule in a runbook outlives the incident that produced it.

### 2. The `event_name` trap

A required claim of `event_name = push` rejects **every** run of a workflow triggered by `schedule` or `workflow_dispatch` — which is exactly how a keyed integration workflow is triggered, since it deliberately has no `push`/`pull_request` trigger.

The rule then refuses every run forever, and the reason it reports may name a *different* failing condition, so the mismatch is easy to miss while chasing something else. Now has its own section, as the concrete form of the existing general warning about claim conditions.