### PR TITLE
chore: bump to 1.8.1-dev after cutting 1.8.0

### DIFF
--- a/sandy
+++ b/sandy
@@ -17,7 +17,7 @@ set -euo pipefail
 #   sandy --agent claude,gemini   Override agent selection for this run
 # =============================================================================
 
-SANDY_VERSION="1.8.0"
+SANDY_VERSION="1.8.1-dev"
 SANDY_COMMIT=""  # baked in by install.sh; empty = detect from git at runtime
 
 # Schema contract version for --print-schema / --print-state / --validate-config.


### PR DESCRIPTION
Post-release bump per the versioning convention in `CLAUDE.md`: immediately after cutting a final release, `main` moves to `X.Y.(Z+1)-dev` so a build from `main` is never mistaken for the released version.

The update check compares only `SANDY_VERSION` and strips everything after the first `-`, so `1.8.1-dev` compares as `1.8.1` — a user on `main` is not nagged toward the 1.8.0 release they are already ahead of.

One line.