### PR TITLE
fix(build): never attempt a build when its resources are unreachable (#218)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,7 +413,13 @@ Add entries to `SKILL_PACK_NAMES`, `SKILL_PACK_REPOS`, `SKILL_PACK_VERSIONS`, an
 
 ## Auto-update
 
-On each launch, sandy checks for newer Claude Code versions by comparing the installed version against the latest release. If an update is available, the image is rebuilt with `--no-cache`. Inside the container, `DISABLE_AUTOUPDATER=1` prevents Claude Code from attempting self-updates against the read-only filesystem.
+On each launch, sandy checks for newer Claude Code versions by comparing the installed version against the latest release. If an update is available, the image is rebuilt with `--no-cache`.
+
+**No image is built when the resources a build needs are unreachable (#218).** The version check and the build pull from *different* endpoints, and **partial reachability is the normal failure mode** — captive portals and in-flight wifi routinely allow one CDN while blocking another, so a successful update check proves nothing about whether a rebuild can succeed. Observed on in-flight wifi: the check reached `storage.googleapis.com`, flipped `NEEDS_BUILD=true`, and the forced `--no-cache` rebuild died at `apt-get update` with exit 100 — aborting the launch under `set -e` on exactly the network where the already-built local image was most wanted, and re-dying on every retry.
+
+So **every** build site — base, proxy, agent, both skill-pack layers, and the per-project `.sandy/Dockerfile` — passes through `_sandy_build_allowed`, which probes the actual build dependencies (`deb.debian.org`, `registry.npmjs.org`) rather than general connectivity. If they are unreachable: an existing image is kept and the refresh deferred; if there is **no** existing image, sandy fails **immediately** with an accurate message instead of after a multi-minute apt timeout that names the wrong cause. The probe is lazy and memoized, so a launch that needs no build pays nothing.
+
+The agent build additionally tolerates a build that fails *despite* the probe passing (the probe runs host-side while `docker build` runs in Docker's VM, and networks drop mid-build): with a usable image present it warns and continues, since the hash file is only written on success so the rebuild retries next launch. Hash-change and missing-image builds keep failing hard — there is nothing known-good to fall back to. A deferred refresh is reported at session end, so the auto-patch CVE posture below does not erode silently. Guarded by `run-tests.sh §107`. Inside the container, `DISABLE_AUTOUPDATER=1` prevents Claude Code from attempting self-updates against the read-only filesystem.
 
 ### Wrapped-agent security / CVE watch (sandbox-escape eval Issue E)
 

--- a/sandy
+++ b/sandy
@@ -7559,17 +7559,78 @@ _sandy_prune_old_image() {
 _BASE_BUILD_Q=()
 [ "${SANDY_DAEMON_SUPERVISOR:-0}" = "1" ] && _BASE_BUILD_Q=(-q)
 
+# --- Build-resource reachability gate (#218) --------------------------------
+# A rebuild pulls from Debian mirrors, npm, and Docker Hub. Those are DIFFERENT
+# endpoints from the tiny HTTPS version check that decides an agent update is
+# available, and PARTIAL REACHABILITY IS THE NORMAL FAILURE MODE -- captive
+# portals and in-flight wifi routinely allow one CDN while blocking another. So
+# "the update check succeeded" proves nothing about whether a build can succeed.
+#
+# Observed on in-flight wifi: the version check reached storage.googleapis.com,
+# saw a newer Claude Code, flipped NEEDS_BUILD=true, and the forced --no-cache
+# rebuild died at `apt-get update` with exit 100 -- aborting the launch under
+# set -e on exactly the network where the already-built local image was most
+# wanted. Every retry re-detected the update and re-died, locking the user out.
+#
+# THE RULE: a build is only ATTEMPTED when the resources it needs are reachable.
+# If they are not, use the existing image. If there is no existing image, fail
+# IMMEDIATELY with an accurate message rather than after a multi-minute apt
+# timeout that names the wrong cause.
+#
+# Probed LAZILY and memoized, so a launch that needs no build pays nothing --
+# which is the overwhelmingly common case.
+_SANDY_BUILD_NET=""            # "" unprobed | "ok" reachable | "no" not
+_SANDY_BUILD_NET_WHY=""        # which endpoint failed, for the message
+_SANDY_BUILD_DEFERRED=false    # any build skipped this launch?
+_sandy_build_net_ok() {
+    if [ -z "$_SANDY_BUILD_NET" ]; then
+        _SANDY_BUILD_NET="ok"
+        # Probe the BUILD dependencies, never general connectivity: the whole
+        # lesson of the incident is that a reachable version-check endpoint
+        # coexisted with unreachable mirrors. -I so nothing is downloaded.
+        for _bn_url in "https://deb.debian.org/debian/" "https://registry.npmjs.org/"; do
+            curl -fsS -I --max-time 5 "$_bn_url" >/dev/null 2>&1 && continue
+            _SANDY_BUILD_NET="no"; _SANDY_BUILD_NET_WHY="$_bn_url"; break
+        done
+        unset _bn_url
+    fi
+    [ "$_SANDY_BUILD_NET" = "ok" ]
+}
+
+# Decide whether a build may proceed. $1 = image name, $2 = human label.
+#   returns 0  -> go ahead and build
+#   returns 1  -> SKIP the build; a usable image exists and the caller keeps it
+#   exits 1    -> unreachable AND no image to fall back to
+# Callers MUST wrap their build in `if _sandy_build_allowed ...; then`, so that
+# the hash file write and the predecessor prune stay with the build they belong
+# to -- writing a hash for a build that never ran is exactly the declared-vs-
+# actual drift this repo keeps paying for.
+_sandy_build_allowed() {
+    _sandy_build_net_ok && return 0
+    if docker image inspect "$1" >/dev/null 2>&1; then
+        warn "Build resources unreachable ($_SANDY_BUILD_NET_WHY) — skipping the $2 rebuild."
+        warn "  Continuing on the existing image; it refreshes on the next launch from a healthy network."
+        _SANDY_BUILD_DEFERRED=true
+        return 1
+    fi
+    error "Build resources unreachable ($_SANDY_BUILD_NET_WHY), and no $2 exists to fall back to."
+    error "  sandy cannot build $1 without network access. Reconnect and retry."
+    exit 1
+}
+
 # Phase 1: Base image (language runtimes — rebuilds rarely)
 BASE_HASH="$(cat "$SANDY_HOME/Dockerfile.base" | sha256 | cut -d' ' -f1)"
 BASE_HASH_FILE="$SANDY_HOME/.base_build_hash"
 BASE_REBUILT=false
 if [ ! -f "$BASE_HASH_FILE" ] || [ "$(cat "$BASE_HASH_FILE")" != "$BASE_HASH" ] || ! docker image inspect "$BASE_IMAGE_NAME" &>/dev/null; then
-    info "Building base image (language runtimes) — this may take several minutes on first run..."
-    _old_base_id="$(docker image inspect -f '{{.Id}}' "$BASE_IMAGE_NAME" 2>/dev/null || true)"
-    docker build ${_BASE_BUILD_Q[@]+"${_BASE_BUILD_Q[@]}"} --no-cache --pull --label sandy.managed=1 -t "$BASE_IMAGE_NAME" -f "$SANDY_HOME/Dockerfile.base" "$SANDY_HOME"
-    echo "$BASE_HASH" > "$BASE_HASH_FILE"
-    BASE_REBUILT=true
-    _sandy_prune_old_image "$_old_base_id" "$BASE_IMAGE_NAME"
+    if _sandy_build_allowed "$BASE_IMAGE_NAME" "base image"; then
+        info "Building base image (language runtimes) — this may take several minutes on first run..."
+        _old_base_id="$(docker image inspect -f '{{.Id}}' "$BASE_IMAGE_NAME" 2>/dev/null || true)"
+        docker build ${_BASE_BUILD_Q[@]+"${_BASE_BUILD_Q[@]}"} --no-cache --pull --label sandy.managed=1 -t "$BASE_IMAGE_NAME" -f "$SANDY_HOME/Dockerfile.base" "$SANDY_HOME"
+        echo "$BASE_HASH" > "$BASE_HASH_FILE"
+        BASE_REBUILT=true
+        _sandy_prune_old_image "$_old_base_id" "$BASE_IMAGE_NAME"
+    fi
 else
     info "Base image up to date."
 fi
@@ -7591,6 +7652,7 @@ if [ "$_SANDY_PROXY_ON" = true ]; then
     PROXY_HASH="$(sha256 < "$SANDY_HOME/Dockerfile.proxy" | cut -d' ' -f1)"
     PROXY_HASH_FILE="$SANDY_HOME/.build_hash_proxy"
     if [ ! -f "$PROXY_HASH_FILE" ] || [ "$(cat "$PROXY_HASH_FILE")" != "$PROXY_HASH" ] || ! docker image inspect "$PROXY_IMAGE_NAME" &>/dev/null; then
+        if _sandy_build_allowed "$PROXY_IMAGE_NAME" "egress proxy image"; then
         info "Building egress proxy image (sandy-proxy, ref=$(_sandy_proxy_ref))..."
         _old_proxy_id="$(docker image inspect -f '{{.Id}}' "$PROXY_IMAGE_NAME" 2>/dev/null || true)"
         # --pull: re-resolve golang:1.26-trixie to the current digest on every
@@ -7600,6 +7662,7 @@ if [ "$_SANDY_PROXY_ON" = true ]; then
         docker build -q --no-cache --pull --label sandy.managed=1 -t "$PROXY_IMAGE_NAME" -f "$SANDY_HOME/Dockerfile.proxy" "$SANDY_HOME"
         echo "$PROXY_HASH" > "$PROXY_HASH_FILE"
         _sandy_prune_old_image "$_old_proxy_id" "$PROXY_IMAGE_NAME"
+        fi
     else
         info "Egress proxy image up to date."
     fi
@@ -7671,11 +7734,30 @@ if [ "$NEEDS_BUILD" = false ]; then
 fi
 
 if [ "$NEEDS_BUILD" = true ]; then
-    info "Building sandbox image (may take a few minutes)..."
-    _old_agent_id="$(docker image inspect -f '{{.Id}}' "$IMAGE_NAME" 2>/dev/null || true)"
-    docker build -q --no-cache --label sandy.managed=1 -t "$IMAGE_NAME" -f "$DOCKERFILE_PATH" "$SANDY_HOME"
-    echo "$BUILD_HASH" > "$HASH_FILE"
-    _sandy_prune_old_image "$_old_agent_id" "$IMAGE_NAME"
+    if _sandy_build_allowed "$IMAGE_NAME" "agent image"; then
+        info "Building sandbox image (may take a few minutes)..."
+        _old_agent_id="$(docker image inspect -f '{{.Id}}' "$IMAGE_NAME" 2>/dev/null || true)"
+        # Layer 2 (#218): the probe above runs on the HOST while `docker build`
+        # runs inside Docker's VM, so a host-reachable mirror can still be
+        # unreachable from the builder, and a network can drop mid-build. When
+        # that happens AND a usable image already exists, a failed OPTIONAL
+        # refresh must not take down a launch that would have succeeded ten
+        # minutes earlier. Nothing is lost by continuing: the hash file is only
+        # written and the predecessor only pruned after a SUCCESSFUL build.
+        _agent_build_rc=0
+        docker build -q --no-cache --label sandy.managed=1 -t "$IMAGE_NAME" -f "$DOCKERFILE_PATH" "$SANDY_HOME" || _agent_build_rc=$?
+        if [ "$_agent_build_rc" -eq 0 ]; then
+            echo "$BUILD_HASH" > "$HASH_FILE"
+            _sandy_prune_old_image "$_old_agent_id" "$IMAGE_NAME"
+        elif [ -n "$_old_agent_id" ]; then
+            warn "Agent image rebuild failed (docker build exit $_agent_build_rc) — continuing on the existing image."
+            warn "  The hash file is unchanged, so the rebuild is retried on the next launch."
+            _SANDY_BUILD_DEFERRED=true
+        else
+            error "Agent image build failed (docker build exit $_agent_build_rc) and no previous image exists."
+            exit 1
+        fi
+    fi
 else
     info "Sandbox image up to date."
 fi
@@ -8027,10 +8109,12 @@ if [ -n "${SANDY_SKILL_PACKS:-}" ]; then
         fi
 
         if [ "$SKILLS_BASE_NEEDS_BUILD" = true ]; then
+            if _sandy_build_allowed "$SKILLS_BASE_IMAGE" "skill-pack base image"; then
             info "Building skill pack base image (Playwright + Chromium)..."
             docker build --label sandy.managed=1 -t "$SKILLS_BASE_IMAGE" \
                 -f "$SANDY_HOME/Dockerfile.skills-base" "$SANDY_HOME"
             echo "$SKILLS_BASE_HASH" > "$SKILLS_BASE_HASH_FILE"
+            fi
         else
             info "Skill pack base image up to date."
         fi
@@ -8057,11 +8141,13 @@ if [ -n "${SANDY_SKILL_PACKS:-}" ]; then
     fi
 
     if [ "$SKILLS_NEEDS_BUILD" = true ]; then
+        if _sandy_build_allowed "$SKILLS_IMAGE_NAME" "skill-pack image"; then
         info "Building skill pack image (${SANDY_SKILL_PACKS})..."
         docker build --no-cache --label sandy.managed=1 -t "$SKILLS_IMAGE_NAME" \
             -f "$SANDY_HOME/Dockerfile.skills" "$SANDY_HOME"
         echo "$SKILLS_BUILD_HASH" > "$SKILLS_HASH_FILE"
         SKILLS_REBUILT=true
+        fi
     else
         info "Skill pack image up to date."
     fi
@@ -9137,6 +9223,10 @@ if [ -f "$PROJECT_DOCKERFILE" ] && _sandy_project_dockerfile_approved "$PROJECT_
         PROJECT_NEEDS_BUILD=true
     fi
     if [ "$PROJECT_NEEDS_BUILD" = true ]; then
+        # The per-project Dockerfile is arbitrary user RUN commands, so it needs
+        # the network at least as much as sandy's own images do -- and it is the
+        # LAST build, so an unreachable mirror here wastes everything above it.
+        if _sandy_build_allowed "$PROJECT_IMAGE_NAME" "project image"; then
         info "Building project image from .sandy/Dockerfile..."
         docker build -q --no-cache \
             --label sandy.managed=1 \
@@ -9144,6 +9234,7 @@ if [ -f "$PROJECT_DOCKERFILE" ] && _sandy_project_dockerfile_approved "$PROJECT_
             -t "$PROJECT_IMAGE_NAME" \
             -f "$PROJECT_DOCKERFILE" "$WORK_DIR/.sandy"
         echo "$PROJECT_HASH" > "$PROJECT_HASH_FILE"
+        fi
     else
         info "Project image up to date."
     fi
@@ -9419,6 +9510,16 @@ cleanup() {
             printf "${YELLOW}[sandy]${NC} See github.com/rappdw/sandy/issues/151 — sandy re-pins the mode on the next launch.\n" >&2
         fi
         rm -f "$SANDBOX_DIR/.claude-perm-mode-at-launch"
+    fi
+    # #218: if a build was skipped or fell back this launch, say so at session
+    # end. Sandy auto-patches wrapped agents by rebuilding on a detected update
+    # (CLAUDE.md "Wrapped-agent security"), so a DEFERRED update quietly erodes
+    # that posture. Surfacing it keeps the deferral a known state rather than an
+    # invisible one -- it clears itself on the first launch from a healthy
+    # network, and this line is how the user knows it has not yet.
+    if [ "${_SANDY_BUILD_DEFERRED:-false}" = "true" ]; then
+        printf "${YELLOW}[sandy]${NC} An image refresh was deferred this session (build resources were unreachable).\n" >&2
+        printf "${YELLOW}[sandy]${NC} You ran on the existing image. It rebuilds on the next launch from a healthy network.\n" >&2
     fi
     # HF-incident Issue 4: session-end egress summary. When allowed-egress logging
     # is on, roll up proxy.log into "what hosts did the agent actually reach" — the

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -10343,6 +10343,86 @@ unset _S106_PS_HOME _S106_PS_BIN _S106_PS_ERR_FULL _S106_PS_OUT_FULL _S106_PS_ER
 unset _S106_RMS_HOME _S106_RMS_OUT
 unset _S106_RSB_WS _S106_RSB_HOME _S106_RSB_HASH _S106_RSB_BASE _S106_RSB_SB _S106_RSB_OUT
 
+echo ""
+echo "§107: build-resource reachability gate — never attempt a doomed build (#218)"
+# WHY. On degraded networks (in-flight wifi, captive portals) the tiny HTTPS
+# agent-version check succeeds while the Debian mirrors are unreachable. That
+# flipped NEEDS_BUILD=true, the forced --no-cache rebuild died at `apt-get
+# update` with exit 100, and the launch ABORTED under set -e -- on exactly the
+# network where the already-built local image was most wanted. Every retry
+# re-detected the update and re-died. PARTIAL REACHABILITY IS THE NORMAL
+# FAILURE MODE, so "the update check worked" proves nothing about a build.
+_S107_SANDY="$SANDY_SCRIPT"
+check "§107(pre) sandy defines the reachability gate" \
+    grep -q '_sandy_build_allowed()' "$_S107_SANDY"
+
+# --- the decision matrix, driven against the REAL extracted helpers ----------
+# Extracted rather than reimplemented: a copy would keep passing while the real
+# gate broke, which is the vacuous-guard failure this repo keeps rediscovering.
+_S107_H="$(mktemp)"
+sed -n '/^# --- Build-resource reachability gate/,/^}$/p' "$_S107_SANDY" > "$_S107_H"
+awk '/^_sandy_build_allowed\(\) \{/,/^}$/' "$_S107_SANDY" >> "$_S107_H"
+check "§107(0) extracted BOTH helpers from sandy (mutation: a rename empties this and must fail HERE, not silently pass the matrix below)" \
+    bash -c '[ "$(grep -c "^_sandy_build_" "$1")" -eq 2 ]' -- "$_S107_H"
+
+_S107_BIN="$(mktemp -d)"
+# $1 = net reachable (ok|no), $2 = image present (yes|no) -> prints "rc=N deferred=X"
+_s107_decide() {
+    printf '#!/usr/bin/env bash\n[ "%s" = ok ] && exit 0 || exit 7\n' "$1" > "$_S107_BIN/curl"
+    printf '#!/usr/bin/env bash\n[ "$1" = image ] && { [ "%s" = yes ] && exit 0 || exit 1; }\nexit 0\n' "$2" > "$_S107_BIN/docker"
+    chmod +x "$_S107_BIN/curl" "$_S107_BIN/docker"
+    PATH="$_S107_BIN:$PATH" bash -c '
+        set -euo pipefail
+        warn(){ :; }; error(){ :; }; YELLOW=""; NC=""
+        . "$1"
+        RC=0
+        _sandy_build_allowed "sandy-base" "base image" || RC=$?
+        printf "rc=%s deferred=%s" "$RC" "${_SANDY_BUILD_DEFERRED:-false}"
+    ' -- "$_S107_H" 2>/dev/null || printf 'rc=EXIT'
+}
+check "§107(1) reachable + image present -> build PROCEEDS" \
+    test "$(_s107_decide ok yes)" = "rc=0 deferred=false"
+check "§107(2) reachable + NO image -> build PROCEEDS (a first build must not be blocked)" \
+    test "$(_s107_decide ok no)" = "rc=0 deferred=false"
+check "§107(3) UNREACHABLE + image present -> SKIP and keep running (mutation: dropping the docker-image-inspect branch turns this into a hard exit and re-creates the lockout)" \
+    test "$(_s107_decide no yes)" = "rc=1 deferred=true"
+check "§107(4) UNREACHABLE + NO image -> hard exit (mutation: returning 1 here would let the caller build anyway and die at apt with the wrong cause)" \
+    test "$(_s107_decide no no)" = "rc=EXIT"
+rm -rf "$_S107_BIN" "$_S107_H"
+
+# --- every build site is gated ----------------------------------------------
+# The point of #218 is that NO image is built when resources are unreachable,
+# including the per-project .sandy/Dockerfile. A gate on five of six sites still
+# lets a launch die at the ungated one.
+check "§107(5) every docker build site is gated (6 gate calls for 6 build sites; mutation: adding an ungated build makes these counts diverge)" \
+    bash -c '[ "$(grep -c "_sandy_build_allowed \"" "$1")" -eq 6 ]' -- "$_S107_SANDY"
+for _s107_img in BASE_IMAGE_NAME PROXY_IMAGE_NAME IMAGE_NAME SKILLS_BASE_IMAGE SKILLS_IMAGE_NAME PROJECT_IMAGE_NAME; do
+    check "§107(5) gated: \$$_s107_img" \
+        grep -q "_sandy_build_allowed \"\$$_s107_img\"" "$_S107_SANDY"
+done
+unset _s107_img
+
+# --- the probe must be LAZY -------------------------------------------------
+# A launch needing no build must pay zero latency. Structurally: the probe is
+# reachable ONLY through the gate, and every gate call sits inside a
+# needs-build branch.
+check "§107(6) the probe is reachable only via the gate (mutation: calling _sandy_build_net_ok at top level costs every launch a 5s probe)" \
+    bash -c '[ "$(grep -c "_sandy_build_net_ok" "$1")" -eq 2 ]' -- "$_S107_SANDY"
+
+# --- Layer 2: a failed OPTIONAL refresh must not abort the launch -----------
+check "§107(7) the agent build captures its exit rather than dying under set -e (mutation: a bare docker build aborts the launch, which is the reported bug)" \
+    grep -q '|| _agent_build_rc=\$?' "$_S107_SANDY"
+check "§107(8) ...and falls back to the existing image when one exists" \
+    bash -c 'grep -A6 "_agent_build_rc=\\\$?" "$1" | grep -q "elif \[ -n \"\\\$_old_agent_id\" \]"' -- "$_S107_SANDY"
+check "§107(9) the hash file is written ONLY on a successful build (mutation: writing it unconditionally marks a failed build as current and suppresses the retry forever)" \
+    bash -c 'grep -A4 "if \[ \"\\\$_agent_build_rc\" -eq 0 \]" "$1" | grep -q "echo \"\\\$BUILD_HASH\" > \"\\\$HASH_FILE\""' -- "$_S107_SANDY"
+
+# --- the deferral must be surfaced ------------------------------------------
+# Sandy auto-patches wrapped agents by rebuilding on a detected update, so a
+# silent deferral erodes that posture invisibly.
+check "§107(10) a deferred refresh is reported at session end (mutation: dropping it makes the deferral invisible and the CVE posture silently stale)" \
+    bash -c 'grep -q "_SANDY_BUILD_DEFERRED:-false" "$1" && grep -q "image refresh was deferred" "$1"' -- "$_S107_SANDY"
+
 _run_provenance   # timestamp + commit + tree state, so a result you scroll back
                   # to after a context switch says which build produced it.
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #218.

On degraded networks — observed on in-flight wifi — sandy locked the user out of a working sandbox entirely:

1. Every hash matched, so nothing **needed** rebuilding.
2. The agent update check reached `storage.googleapis.com`, saw a newer Claude Code, flipped `NEEDS_BUILD=true`.
3. The forced `--no-cache` rebuild re-ran `apt-get` from scratch and died with **exit 100** — the Debian mirrors were unreachable even though the tiny HTTPS version check had succeeded.
4. `docker build` failed under `set -e` and the whole launch aborted.

Every retry re-detected the update and re-died, on exactly the network where the already-built local image was most wanted.

### The key point

**Partial reachability is the normal failure mode**, not an edge case — captive portals and in-flight wifi routinely allow one CDN while blocking another. *"The update check succeeded" proves nothing about whether a build can succeed*, and any fix probing **general** connectivity would have missed this exactly.

### The rule, applied to every build site

> A build is only attempted when the resources it needs are reachable. If they are not, use the existing image; if there is no existing image, fail **immediately** with an accurate message rather than after a multi-minute apt timeout that names the wrong cause.

All **six** are gated — base, proxy, agent, both skill-pack layers, and the per-project `.sandy/Dockerfile`. Gating five of six still lets a launch die at the sixth, and the project Dockerfile is the *last* build, so an unreachable mirror there wastes every build above it.

| | |
|---|---|
| Probes | `deb.debian.org`, `registry.npmjs.org` — the actual build dependencies, never general connectivity |
| Cost when no build is needed | **zero** — lazy and memoized; structurally enforced, since the probe is reachable only via the gate and every gate sits inside a needs-build branch |
| Unreachable + image exists | skip, warn, keep running |
| Unreachable + no image | immediate, accurate hard failure |

### Layer 2

The agent build also tolerates a failure the probe **cannot** predict: it runs host-side while `docker build` runs inside Docker’s VM, so a host-reachable mirror can still be unreachable from the builder, and networks drop mid-build. With a usable image present it warns and continues — nothing is lost, because the hash file is written and the predecessor pruned only after a **successful** build, so the rebuild retries next launch.

Hash-change and missing-image builds keep failing hard: there is nothing known-good to fall back to, and launching a stale image against a changed Dockerfile would be declared-vs-actual drift.

A deferred refresh is **reported at session end**, so the auto-patch CVE posture does not erode invisibly.

### §107, mutation-tested — baseline 18/18, `completed=true`

| Mutation | Result |
|---|---|
| gate ignores an existing image | (3) fails — *re-creates the lockout* |
| ungate the project build | (5) fails ×2 |
| bare `docker build`, exit not captured | (7)(8) fail — *the reported abort* |
| drop the session-end notice | (10) fails |

The decision matrix is driven against helpers **extracted from `sandy`**, not a reimplementation, and (0) asserts the extraction is non-empty so a rename fails loudly rather than silently passing everything after it.

### Not included

**#219** (`SANDY_OFFLINE` / `--no-update-check`) — that is the explicit user override; this is the automatic resilience. Both are wanted.