### PR TITLE
fix: never mount $SANDY_HOME via a symlink; reap stranded proxies (#209, #222)

### DIFF
--- a/sandy
+++ b/sandy
@@ -1700,6 +1700,56 @@ ${_sbname}"
 # candidate that raced back to life between plan and reap is simply not
 # caught by the NEXT list either, so nothing is force-removed out from under
 # a legitimately-revived resource).
+# _sandy_reap_stranded_proxies (#222) — remove proxy sidecars whose paired
+# agent container does not exist, at launch.
+#
+# WHY THIS EXISTS. The proxy runs with `--restart on-failure:5` so a mid-session
+# proxy death cannot strand the agent on a routeless --internal sidecar. That
+# policy cannot tell "I crashed" from "the host rebooted": a reboot SIGKILLs the
+# container, docker reads the non-zero exit as a failure, and revives it on the
+# next daemon start. A FOREGROUND agent (--rm, no restart policy) does not come
+# back, so the pair splits and the proxy is stranded -- the inverse of the
+# stranded-AGENT failure cleanup()'s atomic teardown exists to prevent. Reported
+# from a real host: three such proxies after one reboot, each holding a network
+# and a 256m memory cap, with nothing to reap them until that same workspace
+# happened to be relaunched.
+#
+# THE PREDICATE IS DELIBERATELY NARROWER THAN --gc'S. This runs AUTOMATICALLY on
+# every launch, where --gc is explicitly invoked and confirmed, so a false
+# positive here would tear the route out from under a LIVE session -- strictly
+# worse than the leak being fixed. So it does not reason about liveness at all:
+# a proxy is stranded only when its paired agent container DOES NOT EXIST. That
+# is unambiguous, needs no has-session probe or lock file, and is exactly the
+# reboot case (the foreground agent was --rm, so nothing remains). Any live or
+# merely-stopped session still has its agent container, so it is never touched.
+#
+# Classification is by IMAGE, never by name prefix: a workspace whose basename
+# is `proxy` produces an AGENT container literally named sandy-proxy-<hash>,
+# which was a real pre-1.3.0 --gc regression. Only containers whose image is
+# sandy-proxy are considered, so that agent is never mistaken for a sidecar.
+_sandy_reap_stranded_proxies() {
+    command -v docker >/dev/null 2>&1 || return 0
+    local _rows _name _img _sb
+    _rows="$(docker ps -a --filter 'name=^/sandy-proxy-' \
+        --format '{{.Names}}|{{.Image}}' 2>/dev/null)" || return 0
+    [ -n "$_rows" ] || return 0
+    while IFS='|' read -r _name _img; do
+        [ -n "$_name" ] || continue
+        # Image gate: this is what tells a sidecar from an agent whose workspace
+        # happens to be named `proxy`.
+        [ "${_img%%:*}" = "sandy-proxy" ] || continue
+        _sb="${_name#sandy-proxy-}"
+        [ -n "$_sb" ] || continue
+        # Paired agent present in ANY state (running or stopped)? Then leave it.
+        if docker ps -a --filter "name=^/sandy-${_sb}$" --format '{{.Names}}' 2>/dev/null | grep -qx "sandy-${_sb}"; then
+            continue
+        fi
+        warn "Removing stranded egress proxy $_name (its agent container is gone)."
+        docker rm -f "$_name" >/dev/null 2>&1 || true
+    done <<< "$_rows"
+    return 0
+}
+
 _sandy_gc_reap_containers() {
     local _cname
     # "reap" mode: retries the mid-startup has-session probe (5x/sleep-1)
@@ -6829,6 +6879,11 @@ fi
 # fall through instead of exiting). Does NOT change bare-sandy session
 # semantics — it only removes leftovers nothing live owns.
 command -v docker >/dev/null 2>&1 && _sandy_reap_orphan_networks || true
+# #222: same moment, same rationale as the eager network reap above -- clean up
+# leaked resources before allocating new ones. A reboot can resurrect a proxy
+# whose foreground agent is gone for good; nothing else reaps it until that
+# workspace is relaunched, so they accumulate silently.
+_sandy_reap_stranded_proxies || true
 
 # Safe key-value config parser (no arbitrary code execution).
 #
@@ -7550,6 +7605,27 @@ _sandy_resolve_symlinks() {
             if [[ "$target" != "$HOME"/* ]]; then
                 continue
             fi
+            # #209: NEVER mount sandy's own state into a sandbox it manages.
+            # $SANDY_HOME defaults to $HOME/.sandy, so it passes the $HOME test
+            # above and would be bind-mounted READ-WRITE like any other target
+            # (the symlink mounts carry no :ro). That hands the agent
+            # .handoff-enabled -- the operator-side enrollment marker placed at
+            # the sandbox TOP LEVEL precisely so the agent cannot create it for
+            # itself -- plus agent-args.<agent>, which would let it write its own
+            # launch flags, plus the approved-symlinks list that gates this very
+            # check, plus every OTHER sandbox if the link targets ~/.sandy.
+            #
+            # Refused rather than routed through approval: there is no legitimate
+            # use for mounting sandy's state into a sandbox, so an extra prompt
+            # would only train the user to say yes. Warned rather than skipped
+            # silently, so an operator who genuinely pointed a symlink there
+            # learns why it did not appear.
+            case "$target" in
+                "$SANDY_HOME"|"$SANDY_HOME"/*)
+                    warn "Ignoring symlink into sandy's own state: ${link#$WORK_DIR/} -> $target"
+                    warn "  Mounting \$SANDY_HOME into a sandbox would expose operator state the agent must not reach."
+                    continue ;;
+            esac
             link_rel="${link#$WORK_DIR/}"
             DANGEROUS_SYMLINKS+=("$link_rel -> $target")
             SYMLINK_HOST_PATHS+=("$target")

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -10493,6 +10493,91 @@ check "§108(11) ...and fails closed with actionable guidance when there is no t
 rm -rf "$_S108_T"
 unset _S108 _S108_ABS _S108_SBX _S108_EXIT _S108_BUILD _S108_T _S108_OUT
 
+echo ""
+echo "§109: symlinks never mount \$SANDY_HOME; stranded proxies are reaped (#209, #222)"
+_S109="$SANDY_SCRIPT"
+
+# --- #209: a workspace symlink must not mount sandy's own state -------------
+# $SANDY_HOME defaults to $HOME/.sandy, so it passes the existing $HOME test and
+# would be bind-mounted READ-WRITE like any other target (the symlink mounts
+# carry no :ro). That hands the agent .handoff-enabled and agent-args.<agent> --
+# the two files placed at the sandbox TOP LEVEL precisely so it cannot reach
+# them -- plus the approved-symlinks list that gates this very check.
+check "§109(1) the symlink scan refuses targets under \$SANDY_HOME (mutation: dropping the case arm re-opens agent write access to operator state)" \
+    bash -c 'awk "/^_sandy_resolve_symlinks\(\) \{/,/^\}\$/" "$1" | grep -q "SANDY_HOME\"|\"\\\$SANDY_HOME\"/\\*"' -- "$_S109"
+check "§109(2) ...and warns rather than skipping silently (an operator who pointed a symlink there must learn why it vanished)" \
+    bash -c 'awk "/^_sandy_resolve_symlinks\(\) \{/,/^\}\$/" "$1" | grep -q "sandy own state\|sandy.s own state"' -- "$_S109"
+
+# Behavioral: real script, stubbed docker, three symlinks. The third is the
+# regression guard -- an ORDINARY escape must still be offered for approval, so
+# the exclusion cannot be over-broad.
+_S109_T="$(mktemp -d)"
+mkdir -p "$_S109_T/bin" "$_S109_T/home/sandboxes" "$_S109_T/ws" "$_S109_T/legit"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$_S109_T/bin/docker"; chmod +x "$_S109_T/bin/docker"
+ln -s "$_S109_T/home"                 "$_S109_T/ws/sandy-state"
+ln -s "$_S109_T/home/sandboxes/other" "$_S109_T/ws/other-sandbox"
+ln -s "$_S109_T/legit"                "$_S109_T/ws/legit-escape"
+_S109_ABS="$(cd "$(dirname "$_S109")" && pwd -P)/$(basename "$_S109")"
+_S109_OUT="$( cd "$_S109_T/ws" && PATH="$_S109_T/bin:$PATH" SANDY_HOME="$_S109_T/home" \
+    HOME="$_S109_T" SANDY_APPROVE_ONLY=1 timeout 60 bash "$_S109_ABS" </dev/null 2>&1 || true )"
+# Assert the REFUSAL line, not merely that the link name appears: an unexcluded
+# symlink also prints its name, in the "Symlinks that point outside" approval
+# list. Grepping the name alone passes either way -- a vacuous check that
+# mutation testing caught.
+check "§109(3) a symlink to \$SANDY_HOME itself is REFUSED (mutation: dropping the exclusion offers it for approval instead, which the name alone cannot distinguish)" \
+    bash -c 'printf "%s" "$1" | grep -q "Ignoring symlink into.*sandy-state"' -- "$_S109_OUT"
+check "§109(4) a symlink INTO a sandbox dir is REFUSED" \
+    bash -c 'printf "%s" "$1" | grep -q "Ignoring symlink into.*other-sandbox"' -- "$_S109_OUT"
+check "§109(5) an ORDINARY escaping symlink is STILL offered for approval (mutation: an over-broad exclusion would silently stop surfacing real escapes)" \
+    bash -c 'printf "%s" "$1" | grep -q "legit-escape"' -- "$_S109_OUT"
+rm -rf "$_S109_T"
+
+# --- #222: stranded proxies ---------------------------------------------------
+check "§109(6) sandy reaps stranded proxies at launch" \
+    grep -q '^_sandy_reap_stranded_proxies() {' "$_S109"
+check "§109(7) ...and does so on the launch path, beside the eager network reap (mutation: defining it but never calling it leaves the leak)" \
+    bash -c '[ "$(grep -c "^_sandy_reap_stranded_proxies || true" "$1")" -ge 1 ]' -- "$_S109"
+# The predicate is deliberately NARROWER than --gc's because this runs
+# automatically: it must not reason about liveness, only about existence.
+check "§109(8) the predicate is agent-container-ABSENCE, not liveness (mutation: reusing --gc's liveness lister here would tear the route out from under a live session on any false positive)" \
+    bash -c 'awk "/^_sandy_reap_stranded_proxies\(\) \{/,/^\}\$/" "$1" | grep -q "docker ps -a --filter \"name=\^/sandy-"' -- "$_S109"
+check "§109(9) classification is by IMAGE, never name prefix (mutation: a workspace named \`proxy\` yields an AGENT container called sandy-proxy-<hash>; a name test reaps it — the pre-1.3.0 regression)" \
+    bash -c 'awk "/^_sandy_reap_stranded_proxies\(\) \{/,/^\}\$/" "$1" | grep -q "sandy-proxy\" \]"' -- "$_S109"
+
+# Behavioral: a fleet with one paired proxy, one stranded, and one agent whose
+# name looks like a proxy.
+_S109_T2="$(mktemp -d)"; mkdir -p "$_S109_T2/bin"
+cat > "$_S109_T2/bin/docker" <<'DOCKERSTUB'
+#!/usr/bin/env bash
+LOG="${DOCKER_LOG:-/dev/null}"
+if [ "$1" = ps ]; then
+  filt=""; for a in "$@"; do case "$a" in name=^/*) filt="$a";; esac; done
+  case "$filt" in
+    'name=^/sandy-proxy-')
+        printf 'sandy-proxy-alive-1111|sandy-proxy\n'
+        printf 'sandy-proxy-dead-2222|sandy-proxy\n'
+        printf 'sandy-proxy-proxy-3333|sandy-claude-code\n'
+        exit 0 ;;
+    'name=^/sandy-alive-1111$') echo 'sandy-alive-1111'; exit 0 ;;
+    *) exit 0 ;;
+  esac
+fi
+[ "$1" = rm ] && { echo "REAPED: ${*: -1}" >> "$LOG"; exit 0; }
+exit 0
+DOCKERSTUB
+chmod +x "$_S109_T2/bin/docker"
+_S109_FN="$(awk '/^_sandy_reap_stranded_proxies\(\) \{/,/^\}$/' "$_S109")"
+PATH="$_S109_T2/bin:$PATH" DOCKER_LOG="$_S109_T2/log" bash -c "warn(){ :; }; $_S109_FN; _sandy_reap_stranded_proxies" >/dev/null 2>&1 || true
+_S109_LOG="$(cat "$_S109_T2/log" 2>/dev/null || true)"
+check "§109(10) the stranded proxy IS reaped" \
+    bash -c 'printf "%s" "$1" | grep -q "sandy-proxy-dead-2222"' -- "$_S109_LOG"
+check "§109(11) a proxy whose agent EXISTS is left alone (mutation: reaping it strands a live session on a routeless sidecar)" \
+    bash -c '! printf "%s" "$1" | grep -q "proxy-alive-1111"' -- "$_S109_LOG"
+check "§109(12) an AGENT named sandy-proxy-* is NOT reaped (the \`proxy\` basename trap)" \
+    bash -c '! printf "%s" "$1" | grep -q "proxy-proxy-3333"' -- "$_S109_LOG"
+rm -rf "$_S109_T2"
+unset _S109 _S109_ABS _S109_T _S109_T2 _S109_OUT _S109_FN _S109_LOG
+
 _run_provenance   # timestamp + commit + tree state, so a result you scroll back
                   # to after a context switch says which build produced it.
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #209. Closes #222.

## #209 — a workspace symlink could mount sandy’s own state **read-write**

The symlink target loop mounts any target under `$HOME`, and `SANDY_HOME` defaults to `$HOME/.sandy` — so it passed that test and was bind-mounted **rw** like any other target (symlink mounts carry no `:ro`). That handed the agent:

| | |
|---|---|
| `.handoff-enabled` | the enrollment marker placed at the sandbox **top level** precisely so the agent cannot create it |
| `agent-args.<agent>` | per-agent launch flags — *an agent that can write these can grant itself anything a flag allows* |
| `.sandy-approved-symlinks.list` | the list gating this very check |
| every **other** sandbox | when the link targets `~/.sandy` rather than one directory |

Gated behind the dangerous-symlink approval, so an agent could not create the link *and then use it*. But it needed an operator to approve such a symlink once — and the prompt shows a link and a target, not *"this grants the agent write access to its own launch flags"*. The consent was not informed.

**Refused, not routed through approval:** there is no legitimate reason to mount sandy’s state into a sandbox it manages, so an extra prompt would only train the user to say yes. **Warned, not silent**, so an operator who genuinely pointed a symlink there learns why it vanished. Ordinary escaping symlinks still surface for approval — guarded, because an over-broad exclusion would silently stop surfacing real escapes.

## #222 — proxies survived a reboot and stranded

`--restart on-failure:5` cannot tell *"I crashed"* from *"the host rebooted"*. A reboot SIGKILLs the container, docker reads the non-zero exit as failure and revives it; a **foreground** agent (`--rm`) does not come back. Three such proxies appeared on a real host after one reboot.

Reaped at launch, beside the eager network reap — same moment, same rationale.

### The predicate is deliberately narrower than `--gc`’s, and my first draft got this wrong

Reusing `--gc`’s dead-owner lister *looked* right (DEC-4b: don’t duplicate a lister) but is the wrong trade: **`--gc` is explicitly invoked and confirmed, while this runs automatically on every launch** — one false positive tears the route out from under a **live** session, strictly worse than the leak. Driving that lister under a stub showed it reporting a live pair as dead-owner: exactly that failure.

So it reasons about **existence, not liveness** — a proxy is stranded only when its paired agent container does not exist at all. Unambiguous, no has-session probe, and precisely the reboot case.

Classification is by **image**, never name prefix: a workspace named `proxy` produces an *agent* container called `sandy-proxy-<hash>` — the real pre-1.3.0 `--gc` regression.

## §109 — mutation-tested, baseline 12/12 `completed=true`

| Mutation | Result |
|---|---|
| drop the `$SANDY_HOME` exclusion | (1)(3)(4) fail |
| make the exclusion over-broad | (1) fails |
| never call the proxy reaper | (7) fails |
| drop the image gate | (9)(12) fail |

**(3) and (4) were vacuous in my first draft** — they grepped for the symlink’s *name*, which appears whether it is refused **or** offered for approval, so they passed under the very mutation that removes the fix. They now assert the refusal line. Caught only by mutation testing.