### PR TITLE
chore: bump to 1.8.1

### DIFF
--- a/sandy
+++ b/sandy
@@ -17,7 +17,7 @@ set -euo pipefail
 #   sandy --agent claude,gemini   Override agent selection for this run
 # =============================================================================
 
-SANDY_VERSION="1.8.1-dev"
+SANDY_VERSION="1.8.1"
 SANDY_COMMIT=""  # baked in by install.sh; empty = detect from git at runtime
 
 # Schema contract version for --print-schema / --print-state / --validate-config.


### PR DESCRIPTION
Fixes only since 1.8.0 — no new flags, no new config keys, `schema_version` stays `1`, forward-compat floor stays `1.0.0`. `X.Y.(Z+1)` is correct under the 1.x discipline.

| | |
|---|---|
| #218 | never attempt a build whose resources are unreachable |
| #221 | `--start` resolves first-encounter approvals pre-fork; failure codes |
| #209 | a workspace symlink could mount `$SANDY_HOME` read-write |
| #213 | `--remove-sandbox` left `<name>.claude.json` behind |
| #215 | `.daemon-start-<pid>.log` accumulated with no reaper |
| #222 | proxy sidecars stranded after a host reboot |

### One judgement call worth recording

#221 gives `--start` distinct exit codes (6/7/8) where every failure previously ended at `1`. That *reads* like a contract change — but `v1.8.0`’s DEC-C table documented `--attach` and `--stop` **only**; `--start`’s codes were never published. So this specifies previously-unspecified behavior rather than breaking a promise, and any consumer testing `rc != 0` is unaffected.

Checked against the `v1.8.0` tag rather than assumed.

Release notes for the tag are staged in `docs/RELEASE-1.8.1.md` (not committed — they go in the GitHub release body).

### Before tagging

The integration suite has **not** been run against these changes. Four of the six touch the launch path — the build gate fires on every launch, `#221` moves the `APPROVE_ONLY` exit, `#209` changes symlink handling, `#222` adds a launch-time reap — which is exactly what §19/§20/§21 cover. Worth a host run first; it was 23 minutes for 1.8.0.