### PR TITLE
fix(claude): suppress the auto-mode opt-in prompt at the policy layer

### DIFF
--- a/sandy
+++ b/sandy
@@ -10992,6 +10992,43 @@ printf '{\n  "schema": 1,\n  "sandy_version": "%s",\n  "egress_mode": "%s",\n  "
     "$_sandy_perm_mode_json" \
     > "$_sandy_session_file"
 RUN_FLAGS+=(-v "$_sandy_session_file":/etc/sandy-session.json:ro)
+
+# --- Auto-mode opt-in prompt suppression, at the POLICY layer (#129 follow-up)
+# Claude Code 2.1.x offers "Make auto mode your default permission mode?" on
+# launch. In a sandbox where sandy already pins bypassPermissions that is pure
+# friction, and sandy has long seeded `skipAutoPermissionPrompt` into the
+# sandbox settings.json to suppress it. On a NEW sandbox that no longer works,
+# and reading the shipped binary (2.1.250) says exactly why.
+#
+# A one-shot migration deletes the key from USER settings whenever the mode is
+# not "auto" -- which is precisely sandy's configuration:
+#
+#   if (p?.skipAutoPermissionPrompt && p?.permissions?.defaultMode !== "auto")
+#       await qt("userSettings", { skipAutoPermissionPrompt: void 0 }, ...)
+#
+# It is guarded by a one-time flag, so an EXISTING sandbox that already ran it
+# keeps sandy's re-seeded value and stays quiet -- which is why this only ever
+# reproduced on fresh workspaces. The display gate reads three sources:
+#
+#   !["policySettings","userSettings","flagSettings"]
+#       .some(o => _e(o)?.skipAutoPermissionPrompt === true)
+#
+# The migration only ever rewrites userSettings, so the POLICY layer survives
+# it. On Linux that is /etc/claude-code (hardcoded -- the env override function
+# returns undefined in this build, so there is no path knob to use instead).
+#
+# Mounted :ro, so this is also a value the agent cannot edit -- unlike the
+# settings.json seed, which is rw inside the container by design.
+if _sandy_agent_has claude && [ "${SANDY_SKIP_PERMISSIONS:-true}" = "true" ]; then
+    _sandy_policy_dir="$SANDBOX_DIR/claude-policy"
+    mkdir -p "$_sandy_policy_dir"
+    printf '{\n  "skipAutoPermissionPrompt": true\n}\n' > "$_sandy_policy_dir/managed-settings.json"
+    # Mount the DIRECTORY, not the file: /etc/claude-code does not exist in the
+    # image, and a directory mountpoint is the least surprising thing to ask
+    # docker to create under a --read-only rootfs.
+    RUN_FLAGS+=(-v "$_sandy_policy_dir":/etc/claude-code:ro)
+    [ "${SANDY_VERBOSE:-0}" != "0" ] && info "Policy settings /etc/claude-code/managed-settings.json (auto-mode prompt suppressed)"
+fi
 [ "${SANDY_VERBOSE:-0}" != "0" ] && info "Session marker /etc/sandy-session.json nonce=${_sandy_session_nonce} egress=${_sandy_egress_mode}"
 if _sandy_agent_has claude; then
     # Channels env vars: for single-agent 'claude' these drive the in-container plugin path;

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -10651,6 +10651,41 @@ check "§110(9) claudeAiMcpEverConnected is stripped from the .claude.json seed 
     grep -q 'delete d.claudeAiMcpEverConnected' "$_S110"
 unset _S110 _S110_T
 
+echo ""
+echo "§111: the auto-mode opt-in prompt is suppressed at the POLICY layer"
+# WHY THE POLICY LAYER AND NOT settings.json. Sandy has long seeded
+# skipAutoPermissionPrompt into the sandbox settings.json, but Claude Code
+# 2.1.x ships a one-shot migration that DELETES that key from USER settings
+# whenever permissions.defaultMode != "auto" -- precisely sandy's config:
+#
+#   if (p?.skipAutoPermissionPrompt && p?.permissions?.defaultMode !== "auto")
+#       await qt("userSettings", { skipAutoPermissionPrompt: void 0 }, ...)
+#
+# It is guarded by a one-time flag, so an EXISTING sandbox that already ran it
+# keeps sandy's re-seeded value -- which is why the prompt only ever reproduced
+# on FRESH workspaces. The display gate reads three sources:
+#
+#   !["policySettings","userSettings","flagSettings"]
+#       .some(o => _e(o)?.skipAutoPermissionPrompt === true)
+#
+# The migration touches only userSettings, so the policy layer survives it.
+_S111="$SANDY_SCRIPT"
+check "§111(1) sandy writes a managed-settings.json (mutation: relying on the settings.json seed alone lets the migration delete it on every new sandbox)" \
+    grep -q 'managed-settings.json' "$_S111"
+check "§111(2) it carries skipAutoPermissionPrompt: true" \
+    bash -c 'grep -A2 "claude-policy/managed-settings.json" "$1" | grep -q skipAutoPermissionPrompt || grep -q "skipAutoPermissionPrompt.*true.*managed\|managed-settings.json\"" "$1"' -- "$_S111"
+# /etc/claude-code is the hardcoded Linux policy dir -- the env override
+# function returns undefined in this build, so there is no path knob.
+check "§111(3) mounted at /etc/claude-code, the policy dir Claude Code actually reads" \
+    grep -q ':/etc/claude-code:ro' "$_S111"
+# :ro matters: the settings.json seed is rw inside the container by design, so
+# an agent could edit it. A policy file the agent can rewrite is not a policy.
+check "§111(4) the policy mount is READ-ONLY (mutation: dropping :ro lets the agent rewrite its own permission policy)" \
+    bash -c 'grep -q "_sandy_policy_dir\":/etc/claude-code:ro" "$1"' -- "$_S111"
+check "§111(5) it is gated on claude AND skip-permissions (mutation: writing it unconditionally would suppress the prompt even when the user deliberately turned skip off)" \
+    bash -c 'grep -B2 "_sandy_policy_dir=" "$1" | grep -q "_sandy_agent_has claude.*SANDY_SKIP_PERMISSIONS"' -- "$_S111"
+unset _S111
+
 _run_provenance   # timestamp + commit + tree state, so a result you scroll back
                   # to after a context switch says which build produced it.
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
New sandy workspaces still show **"Make auto mode your default permission mode?"** — the prompt sandy has seeded `skipAutoPermissionPrompt` to suppress since 2.1.x. Existing workspaces are quiet.

Reading the shipped binary (2.1.250) explains both halves.

### Why it happens, and why only on new sandboxes

A one-shot migration deletes the key from **user** settings whenever the mode is not `"auto"` — precisely sandy’s configuration:

```js
if (p?.skipAutoPermissionPrompt && p?.permissions?.defaultMode !== "auto")
    await qt("userSettings", { skipAutoPermissionPrompt: void 0 }, ...)
```

It is guarded by a one-time flag (`hasResetAutoModeOptInForDefaultOffer`), so a sandbox that already ran it keeps sandy’s re-seeded value. A **fresh** sandbox starts with that flag unset: sandy seeds the key, the migration fires once and deletes it, prompt appears. Confirmed against this container, where the flag is `true` and no prompt shows.

### The fix

The display gate reads **three** sources:

```js
!["policySettings","userSettings","flagSettings"]
    .some(o => _e(o)?.skipAutoPermissionPrompt === true)
```

The migration only ever rewrites `userSettings`, so the **policy layer survives it**. On Linux that path is hardcoded to `/etc/claude-code` — the resolver’s env-override hook is `function eyn(){return}`, undefined in this build, so there is no path knob.

Sandy now writes `$SANDBOX_DIR/claude-policy/managed-settings.json` and mounts the **directory** at `/etc/claude-code:ro`. A directory mountpoint is the least surprising thing to ask docker to create under a `--read-only` rootfs, and needs no image change.

**`:ro` is deliberate.** The settings.json seed is rw inside the container by design, so an agent can edit it — *a policy file the agent can rewrite is not a policy.*

Gated on claude **and** `SANDY_SKIP_PERMISSIONS=true`, so turning skip off still surfaces the offer, which is the documented behavior.

### §111 — mutation-tested, baseline 5/5

| Mutation | Result |
|---|---|
| remove the policy mount | (3)(4) fail — **back to the reported bug** |
| drop `:ro` | (3)(4) fail |
| ungate it | (5) fails |

### Worth a live check

I could not run a container. The proof this works is a fresh sandbox showing **no** prompt on first launch — worth confirming before relying on it.