### PR TITLE
fix: unescaped quote in the settings seeder broke sandbox creation

### DIFF
--- a/sandy
+++ b/sandy
@@ -8956,16 +8956,23 @@ if _sandy_agent_has claude; then
             // ambient authority crossing the boundary sandy exists to draw.
             //
             // Verified against the installed Claude Code (2.1.250), whose own
-            // schema text reads: "When true in any settings source, claude.ai MCP
-            // cloud connectors are not auto-fetched or connected. ... Any-source-
-            // true wins: a project can opt out, but a project-level false cannot
-            // override a user-level true."
+            // schema text says a true value in ANY settings source stops
+            // claude.ai MCP cloud connectors being auto-fetched or connected,
+            // and that true-anywhere wins: a project can opt out, but a
+            // project-level false cannot override a user-level true.
             //
             // ALWAYS SET, never only-if-absent: this is a managed key like
-            // permissions.defaultMode. And because any-source-true wins, exposing
-            // connectors is not "write false" -- an inherited true from the HOST
-            // settings.json would survive and silently defeat the opt-in. The
-            // key is therefore overwritten outright in both directions.
+            // permissions.defaultMode. And because true-anywhere wins, exposing
+            // connectors is not merely writing false -- an inherited true from
+            // the HOST settings.json would survive and silently defeat the
+            // opt-in. The key is overwritten outright in both directions.
+            //
+            // NO DOUBLE QUOTE CHARACTERS ANYWHERE IN THIS COMMENT. The node
+            // program is passed as a double-quoted shell string, so one of them
+            // here closes that string early and bash executes the remainder of
+            // the program as commands. That shipped once and broke sandbox
+            // creation with: //: is a directory. It is syntactically valid
+            // bash, so bash -n and CI both passed it.
             s.disableClaudeAiConnectors = (process.env.SANDY_CLAUDE_CONNECTORS || '0') !== '1';
             if (skip) {
                 if (!s.permissions || typeof s.permissions !== 'object') s.permissions = {};

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -10670,6 +10670,21 @@ echo "§111: the auto-mode opt-in prompt is suppressed at the POLICY layer"
 #
 # The migration touches only userSettings, so the policy layer survives it.
 _S111="$SANDY_SCRIPT"
+# An unescaped double quote inside the settings.json seeding program CLOSES the
+# shell string it is passed in, and bash then executes the rest of the JS as
+# commands. That shipped in #227 and broke sandbox creation with
+#     sandy: line NNNN: //: is a directory
+# It is syntactically valid bash, so `bash -n` passed, CI passed, and only a
+# real launch found it. This scans the program itself.
+# sed line-range, not awk: the program is delimited by the `node -e "` opener
+# and a line that is exactly the closing quote plus the output path. Strip the
+# escaped quotes (\") first, then anything left is an UNESCAPED one.
+_S111_PROG_BAD="$(sed -n '/SANDY_TOOL_AUDIT=.*node -e "/,/^        " "\$SEED_SETTINGS"/p' "$SANDY_SCRIPT" \
+    | sed '1d;$d' | sed 's/\\"//g' | grep -c '"' || true)"
+check "§111(0) the settings-seeding node program contains no unescaped double quote (mutation: adding one closes the shell string early and bash executes the JS as commands -- bash -n does NOT catch it; this shipped once and broke sandbox creation with: //: is a directory)" \
+    test "${_S111_PROG_BAD:-1}" -eq 0
+unset _S111_PROG_BAD
+
 check "§111(1) sandy writes a managed-settings.json (mutation: relying on the settings.json seed alone lets the migration delete it on every new sandbox)" \
     grep -q 'managed-settings.json' "$_S111"
 check "§111(2) it carries skipAutoPermissionPrompt: true" \


### PR DESCRIPTION
Reported immediately after #227 shipped — creating a new sandbox dies with:

```
sandy: line 8960: //: is a directory
```

The settings.json seeding program is passed to node as a **double-quoted shell string**. My #129 comment block contained a quoted excerpt of Claude Code’s schema text, and that quote character **closed the shell string early** — so bash executed the remainder of the JavaScript as commands, starting with a `//` comment marker, which resolves to the root directory.

**This is my bug and it shipped to `main`.** The comment is reworded to carry no double-quote characters at all.

### Why nothing caught it

The broken form is *perfectly valid bash* — a string ends early and some commands follow. So `bash -n` passed, shellcheck passed, the bash-3.2 linter passed, and CI passed. The failure only appears when the seeding actually **runs**, which happens on sandbox creation — and **no test creates a sandbox**. Every guard in the suite was looking at the wrong thing.

### The guard

§111 gains a check for the invariant itself: the seeding program must contain no unescaped double quote.

| | |
|---|---|
| baseline | 6/6 |
| reintroduce the exact shipped bug | §111(0) **fails**, while `bash -n` still passes |

The comment now also states the constraint inline — the next person adding a line there has no other way to know the string is double-quoted.

### Note

The still-unverified claim from #228 stands: a fresh sandbox showing no auto-mode prompt. That could not be tested before because sandbox creation was broken by this.