### PR TITLE
fix(claude): suppress the auto-mode default offer — proven live (hasSeenAutoDefaultNudge)

### DIFF
--- a/sandy
+++ b/sandy
@@ -9976,6 +9976,12 @@ if _sandy_agent_has claude && [ ! -f "$CLAUDE_JSON" ]; then
     # Seed from host's ~/.claude.json (contains onboarding, theme, OAuth, etc.)
     if [ -f "$HOME/.claude.json" ]; then
         # Seed from host, stripping project entries (host paths are meaningless in the container)
+        # NO APOSTROPHES INSIDE THIS PROGRAM -- it is passed as a SINGLE-quoted
+        # shell string, so one closes the string early and bash executes the
+        # rest of the JavaScript as commands. The settings seeder below hit the
+        # mirror image of this (a double quote in a double-quoted program) and
+        # it shipped, breaking sandbox creation. Neither form is caught by
+        # bash -n: both leave syntactically valid bash behind.
         node -e '
             const fs = require("fs");
             let d;
@@ -9990,6 +9996,24 @@ if _sandy_agent_has claude && [ ! -f "$CLAUDE_JSON" ]; then
             // settings.json key is the real gate, this is just not handing over a
             // list of what is on the other side of it.
             delete d.claudeAiMcpEverConnected;
+            // Suppress the "Make auto mode your default permission mode?" offer
+            // on a fresh sandbox. Reading the shipped binary (2.1.250), that
+            // dialog is an announcement registered as id "auto-mode-default"
+            // and gated by:
+            //     function DEe(e){ let o=oe(); return ... && e==="auto"
+            //         && o.hasCompletedOnboarding===true
+            //         && !o.hasSeenAutoDefaultNotice }
+            // called as DEe("auto"), so the only reachable lever here is the
+            // last clause. NOTE this is NOT skipAutoPermissionPrompt, which
+            // gates a DIFFERENT notice (U5t, the auto-mode entry warning) --
+            // sandy seeds that one too, and it never suppressed this dialog.
+            //
+            // Only fresh sandboxes show it: an existing one has the flag set
+            // because someone answered the offer once, and that answer persists
+            // in this same file. Seeding it makes the first launch behave like
+            // every launch after it, in a sandbox where sandy has already
+            // pinned the permission mode and the offer is pure friction.
+            if (d.hasSeenAutoDefaultNotice !== true) d.hasSeenAutoDefaultNotice = true;
             fs.writeFileSync(process.argv[2], JSON.stringify(d, null, 2) + "\n");
         ' "$HOME/.claude.json" "$CLAUDE_JSON" 2>/dev/null \
             || {

--- a/sandy
+++ b/sandy
@@ -9996,23 +9996,21 @@ if _sandy_agent_has claude && [ ! -f "$CLAUDE_JSON" ]; then
             // settings.json key is the real gate, this is just not handing over a
             // list of what is on the other side of it.
             delete d.claudeAiMcpEverConnected;
-            // Suppress the "Make auto mode your default permission mode?" offer
-            // on a fresh sandbox. Reading the shipped binary (2.1.250), that
-            // dialog is an announcement registered as id "auto-mode-default"
-            // and gated by:
-            //     function DEe(e){ let o=oe(); return ... && e==="auto"
-            //         && o.hasCompletedOnboarding===true
-            //         && !o.hasSeenAutoDefaultNotice }
-            // called as DEe("auto"), so the only reachable lever here is the
-            // last clause. NOTE this is NOT skipAutoPermissionPrompt, which
-            // gates a DIFFERENT notice (U5t, the auto-mode entry warning) --
-            // sandy seeds that one too, and it never suppressed this dialog.
-            //
-            // Only fresh sandboxes show it: an existing one has the flag set
-            // because someone answered the offer once, and that answer persists
-            // in this same file. Seeding it makes the first launch behave like
-            // every launch after it, in a sandbox where sandy has already
-            // pinned the permission mode and the offer is pure friction.
+            // Suppress the auto-mode default offer on a fresh sandbox. PROVEN
+            // LIVE against 2.1.250 in a container A/B: the dialog is the
+            // auto-default NUDGE, which fires when user settings pin a non-auto
+            // defaultMode -- sandy always pins bypassPermissions -- and
+            // hasSeenAutoDefaultNudge is unset. It queues behind the first
+            // response, defaults to YES, and one stray Enter flips the pin to
+            // auto mode. With the flag set true the dialog does not appear and
+            // the pin survives. hasSeenAutoDefaultNotice is the announcement-
+            // surface sibling of the same offer; both are set. The every-launch
+            // json_merge later in the launch path sets these too -- this seed
+            // exists so even the very first read of a fresh file has them.
+            // NO APOSTROPHES OR DOUBLE QUOTES IN THIS COMMENT (single-quoted
+            // shell program; either character ends it early and bash executes
+            // the rest -- one of each has already shipped as an outage).
+            if (d.hasSeenAutoDefaultNudge !== true) d.hasSeenAutoDefaultNudge = true;
             if (d.hasSeenAutoDefaultNotice !== true) d.hasSeenAutoDefaultNotice = true;
             fs.writeFileSync(process.argv[2], JSON.stringify(d, null, 2) + "\n");
         ' "$HOME/.claude.json" "$CLAUDE_JSON" 2>/dev/null \
@@ -10033,7 +10031,17 @@ if _sandy_agent_has claude && [ ! -f "$CLAUDE_JSON" ]; then
 fi
 # Ensure sandy-specific overrides are set (both new and existing sandboxes)
 if _sandy_agent_has claude; then
-    json_merge "$CLAUDE_JSON" '{"tipsDisabled":true,"installMethod":"native"}'
+    # hasSeenAutoDefaultNudge (proven live, 2.1.250): Claude Code offers
+    # {open}Make auto mode your default permission mode?{close} whenever user
+    # settings pin a non-auto defaultMode -- which sandy ALWAYS does
+    # (bypassPermissions) -- and this flag is unset. The offer queues behind the
+    # first response, defaults to YES, and one stray Enter flips the pin to
+    # auto. Reproduced in a live container A/B: flag absent = dialog shown and
+    # an accidental keystroke accepted it; flag true = no dialog, pin intact.
+    # Set EVERY launch, so existing sandboxes and stale sibling .claude.json
+    # files heal too. hasSeenAutoDefaultNotice is its announcement-surface
+    # sibling in the same binary; seeded alongside for the same reason.
+    json_merge "$CLAUDE_JSON" '{"tipsDisabled":true,"installMethod":"native","hasSeenAutoDefaultNudge":true,"hasSeenAutoDefaultNotice":true}'
     # Pre-trust the workspace so Claude Code doesn't show the trust dialog.
     # Sandy provides whole-session isolation — the trust prompt is redundant.
     node -e '

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -10686,8 +10686,16 @@ _S111_PROG_BAD="$(sed -n '/SANDY_TOOL_AUDIT=.*node -e "/,/^        " "\$SEED_SET
 # the settings seeder. That constraint is stated in the code itself; a reliable
 # extraction of just that program proved fiddly enough to be worth less than
 # the comment, so this checks the behaviour instead.
-check "§111(-1b) it seeds hasSeenAutoDefaultNotice (mutation: without it every FRESH sandbox shows the auto-mode offer on first launch)" \
-    grep -q 'hasSeenAutoDefaultNotice = true' "$SANDY_SCRIPT"
+# PROVEN LIVE (2.1.250, in-container A/B): the offer is the auto-default NUDGE,
+# firing when user settings pin a non-auto defaultMode (sandy always pins
+# bypassPermissions) and hasSeenAutoDefaultNudge is unset. Flag absent = dialog
+# shown, and a stray Enter ACCEPTED it, flipping the pin to auto; flag true =
+# no dialog, pin intact. hasSeenAutoDefaultNotice is its announcement-surface
+# sibling; both are seeded.
+check "§111(-1b) the create-time seed sets hasSeenAutoDefaultNudge (mutation: without it every FRESH sandbox shows the offer, which defaults to YES and un-pins bypassPermissions on a stray Enter)" \
+    grep -q 'hasSeenAutoDefaultNudge !== true' "$SANDY_SCRIPT"
+check "§111(-1c) ...and the EVERY-LAUNCH json_merge sets it too (mutation: the create-time seed alone never heals an existing sandbox or a stale sibling .claude.json left by a pre-#213 removal)" \
+    bash -c 'grep "json_merge .\$CLAUDE_JSON." "$1" | grep -q hasSeenAutoDefaultNudge' -- "$SANDY_SCRIPT"
 unset _S111_CJ_BAD
 
 check "§111(0) the settings-seeding node program contains no unescaped double quote (mutation: adding one closes the shell string early and bash executes the JS as commands -- bash -n does NOT catch it; this shipped once and broke sandbox creation with: //: is a directory)" \

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -10681,6 +10681,15 @@ _S111="$SANDY_SCRIPT"
 # escaped quotes (\") first, then anything left is an UNESCAPED one.
 _S111_PROG_BAD="$(sed -n '/SANDY_TOOL_AUDIT=.*node -e "/,/^        " "\$SEED_SETTINGS"/p' "$SANDY_SCRIPT" \
     | sed '1d;$d' | sed 's/\\"//g' | grep -c '"' || true)"
+# The .claude.json seeder is a SINGLE-quoted shell program, so an apostrophe
+# there closes it early -- the mirror of the unescaped double quote that broke
+# the settings seeder. That constraint is stated in the code itself; a reliable
+# extraction of just that program proved fiddly enough to be worth less than
+# the comment, so this checks the behaviour instead.
+check "§111(-1b) it seeds hasSeenAutoDefaultNotice (mutation: without it every FRESH sandbox shows the auto-mode offer on first launch)" \
+    grep -q 'hasSeenAutoDefaultNotice = true' "$SANDY_SCRIPT"
+unset _S111_CJ_BAD
+
 check "§111(0) the settings-seeding node program contains no unescaped double quote (mutation: adding one closes the shell string early and bash executes the JS as commands -- bash -n does NOT catch it; this shipped once and broke sandbox creation with: //: is a directory)" \
     test "${_S111_PROG_BAD:-1}" -eq 0
 unset _S111_PROG_BAD


### PR DESCRIPTION
Fourth attempt at this dialog, and the first **verified by running Claude Code rather than reading it**.

### The rig

A pty harness inside a sandy container launches the real binary (2.1.250) against a simulated fresh-sandbox state — host-shaped `.claude.json` with sandy’s strips applied, sandy-seeded `settings.json`, real credentials — sends one message, and watches the actual screen.

| state | result |
|---|---|
| flag absent (fresh sim) | **dialog shown** — and the scripted keystroke *accepted* it: `defaultMode` flipped `bypassPermissions → auto` |
| `hasSeenAutoDefaultNudge: true` | no dialog, full turn, pin intact |
| exact shipped state | no dialog, full turn, pin intact |

That first row is why this matters beyond friction: **the dialog defaults to YES**, so one stray Enter un-pins `bypassPermissions` in a real session too.

### The real mechanism (decompiled *after* the rig isolated it)

```js
if (r && !o.hasCompletedOnboarding || o.hasSeenAutoDefaultNudge
      || !A("tengu_maple_pier", !1)) return null;
let e = userSettings.permissions.defaultMode;
if (e && e !== "auto" && !t && _9(u)) return e;   // fires because sandy pins non-auto
```

The offer is the auto-default **nudge**: it fires *precisely because* sandy pins a non-auto `defaultMode`, queues behind the first response (matching the field report), and is suppressed by `hasSeenAutoDefaultNudge` alone.

### Why three previous attempts missed

| attempt | actually gates |
|---|---|
| `skipAutoPermissionPrompt` (long-seeded; #228 policy layer) | the auto-mode **entry warning** — different notice |
| `hasSeenAutoDefaultNotice` (this PR’s first commit) | the **announcement-surface sibling** of the offer — kept, same offer on another surface |

### Seeded at both sites

Create-time seed **and** — load-bearing — the **every-launch** `json_merge`, so existing sandboxes heal, and so does a stale sibling `.claude.json` left by a pre-#213 `rm -rf <sandbox-dir>` (which skips the create-time seed because the file still exists — likely why the earlier fix appeared not to work even where its flag was right).

§111 baseline 8/8 `completed=true`; dropping the merge-literal flag fails (-1c), dropping the create-time seed fails (-1b).