### PR TITLE
test(integration): recognize provider billing exhaustion as SKIP, not FAIL

### DIFF
--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -637,6 +637,17 @@ done
 # (lazy in-container exchange) -- it is no longer what the Integration workflow
 # itself does (see ANTHROPIC_AUTH_TOKEN below), but it is still a valid way to
 # supply Claude credentials to this suite.
+# Provider-side API errors that mean "sandy did its job — the agent launched
+# and REACHED the API — but the provider refused for account reasons". Sections
+# SKIP on these rather than FAIL. One variable, because the same regex was
+# previously pasted at every site and drifted as one: a real host ran dry of
+# OpenAI credits and the resulting "You have no credits remaining" stream error
+# matched nothing, failing two codex sections as if sandy were broken.
+# Deliberately tight: billing/quota/rate/auth phrasings only — never a bare
+# "billing" or "error", which would mask genuine sandy faults that merely
+# mention them.
+_API_ERR_RE='HTTP error: [45][0-9][0-9]|[45][0-9][0-9] (Unauthorized|Forbidden|Too Many Requests)|rate.?limit|insufficient.?quota|no credits remaining|exceeded your current quota'
+
 HAS_CLAUDE_WIF=false
 if [ -n "${ANTHROPIC_FEDERATION_RULE_ID:-}" ] && [ -n "${ANTHROPIC_IDENTITY_TOKEN:-}" ]; then
     HAS_CLAUDE_WIF=true
@@ -972,8 +983,8 @@ if [ "$HAS_OPENAI_API_KEY" = true ]; then
     if [ -n "$_out" ] && echo "$_out" | grep -vi "reply with exactly one word" | grep -qi "pineapple"; then
         pass "codex headless responds without errors"
     elif [ -n "$_out" ] \
-         && echo "$_out" | grep -qiE 'HTTP error: [45][0-9][0-9]|[45][0-9][0-9] (Unauthorized|Forbidden|Too Many Requests)|rate.?limit|insufficient.?quota'; then
-        skip "codex headless responds without errors — codex API error, not a sandy fault ($(echo "$_out" | grep -oiE 'HTTP error: [45][0-9][0-9]|[45][0-9][0-9] (Unauthorized|Forbidden|Too Many Requests)|rate.?limit|insufficient.?quota' | head -1))"
+         && echo "$_out" | grep -qiE "$_API_ERR_RE"; then
+        skip "codex headless responds without errors — codex API error, not a sandy fault ($(echo "$_out" | grep -oiE "$_API_ERR_RE" | head -1))"
     else
         fail "codex headless responds without errors"
         if [ -z "$_out" ]; then
@@ -1308,8 +1319,8 @@ if [ "$HAS_CLAUDE" = true ] && [ "$HAS_OPENAI_API_KEY" = true ]; then
     if [ -n "$_out" ] && echo "$_out" | grep -vi "reply one word" | grep -qi "first"; then
         pass "codex session works in switch test"
     elif [ -n "$_out" ] \
-         && echo "$_out" | grep -qiE 'HTTP error: [45][0-9][0-9]|[45][0-9][0-9] (Unauthorized|Forbidden|Too Many Requests)|rate.?limit|insufficient.?quota'; then
-        skip "codex session works in switch test — codex API error, not a sandy fault ($(echo "$_out" | grep -oiE 'HTTP error: [45][0-9][0-9]|[45][0-9][0-9] (Unauthorized|Forbidden|Too Many Requests)|rate.?limit|insufficient.?quota' | head -1))"
+         && echo "$_out" | grep -qiE "$_API_ERR_RE"; then
+        skip "codex session works in switch test — codex API error, not a sandy fault ($(echo "$_out" | grep -oiE "$_API_ERR_RE" | head -1))"
     else
         fail "codex session works in switch test"
         if [ -z "$_out" ]; then
@@ -1872,7 +1883,7 @@ if [ -n "$_combo" ]; then
     if [ -n "$_out" ] && echo "$_out" | grep -vi "reply one word" | grep -qi "alpha"; then
         pass "combo $_combo → headless routes to $_routed, which responds"
     elif [ -n "$_out" ] \
-         && echo "$_out" | grep -qiE 'status: *[45][0-9][0-9]|critical error|503|500|RESOURCE_EXHAUSTED|quota|UNAVAILABLE|rate.?limit|HTTP error: [45][0-9][0-9]|[45][0-9][0-9] (Unauthorized|Forbidden|Too Many Requests)|insufficient.?quota'; then
+         && echo "$_out" | grep -qiE "status: *[45][0-9][0-9]|critical error|503|500|RESOURCE_EXHAUSTED|quota|UNAVAILABLE|$_API_ERR_RE"; then
         skip "combo $_combo → routed $_routed reached API but it errored, not a sandy fault ($(echo "$_out" | grep -oiE 'status: *[0-9]+|critical error|RESOURCE_EXHAUSTED|quota|HTTP error: [45][0-9][0-9]|[45][0-9][0-9] [A-Za-z]+' | head -1))"
     else
         fail "combo $_combo → headless routes to $_routed, which responds"

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -10778,6 +10778,36 @@ check "§112(15) cred_mode covers the full lattice (oauth-token / access-token-o
     bash -c 'for m in oauth-token access-token-only full api-key none; do grep -q "CRED_MODE=\"$m\"" "$1" || exit 1; done' -- "$_S112"
 unset _S112 _S112_FN _S112_CREDS _S112_OUT _s112_rc
 
+echo ""
+echo "§113: the API-error skip recognizer knows real provider failures, and only those"
+# WHY. Integration sections SKIP when the agent reached the API and the PROVIDER
+# refused (billing, quota, rate, auth) — that is sandy doing its job — and FAIL
+# otherwise. The recognizer was pasted at every site and drifted as one: a real
+# host ran out of OpenAI credits and the "You have no credits remaining" stream
+# error matched nothing, failing two codex sections as if sandy were broken.
+# Now one variable; this drives it against REAL captured strings both ways.
+# `|| true`: a no-match grep exits 1 and an unguarded assignment under the
+# suite ERR trap aborts the WHOLE RUN as "pass=N fail=0" — the dead-run shape.
+# Safe here because this captures stdout and nothing reads $?; §113(0) is the
+# check that judges the empty result.
+_S113_RE="$(grep -m1 '^_API_ERR_RE=' "$(dirname "$0")/run-integration-tests.sh" | cut -d= -f2- | sed "s/^'//;s/'\$//" || true)"
+check "§113(0) extracted a non-empty recognizer (mutation: a rename empties this, and an empty ERE matches EVERYTHING — every check below would pass vacuously)" \
+    test -n "$_S113_RE"
+_s113() { printf '%s' "$1" | grep -qiE "$_S113_RE"; }
+check "§113(1) SKIPS the no-credits stream error (the reported false-FAIL, verbatim)" \
+    _s113 'ERROR: stream disconnected before completion: You have no credits remaining. Add credits to continue using the API at https://platform.openai.com/settings/organization/billing/.'
+check "§113(2) SKIPS the exceeded-quota phrasing" \
+    _s113 'You exceeded your current quota, please check your plan and billing details'
+check "§113(3) SKIPS an HTTP 401" _s113 'HTTP error: 401'
+check "§113(4) SKIPS a rate limit" _s113 'Rate limit reached for gpt-5.5'
+check "§113(5) still FAILS a usage banner (mutation: an over-broad recognizer masks the agent-args class of sandy fault that produced exactly this output once)" \
+    bash -c '! printf "%s" "$1" | grep -qiE "$2"' -- 'Usage: codex exec [OPTIONS] [PROMPT]' "$_S113_RE"
+check "§113(6) still FAILS a mount fault" \
+    bash -c '! printf "%s" "$1" | grep -qiE "$2"' -- 'Error: EROFS read-only file system /home/claude/.codex' "$_S113_RE"
+check "§113(7) exactly ONE literal copy of the regex exists (the definition; mutation: re-pasting it at a call site restores the drift this section exists to end)" \
+    bash -c '[ "$(grep -c "Unauthorized|Forbidden|Too Many Requests" "$1")" -eq 1 ]' -- "$(dirname "$0")/run-integration-tests.sh"
+unset _S113_RE
+
 _run_provenance   # timestamp + commit + tree state, so a result you scroll back
                   # to after a context switch says which build produced it.
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
A real host ran the suite with an out-of-credits OpenAI account. Codex launched, authenticated, reached the API — **sandy did its job end to end** — and the API answered:

```
stream disconnected before completion: You have no credits remaining.
```

The suite is *designed* to SKIP on provider-side API errors and FAIL only on sandy-shaped problems — but its recognizer knew `401/403/429/rate-limit/insufficient-quota` phrasings and not this one, so two codex sections failed as if sandy were broken.

(Diagnosis initially chased a codex version regression — 0.149.1 → 0.151.0 shipped in the window and floating-latest pulled it — but the failure tail ruled that out. Coincidence; the account was simply dry.)

### The structural fix

The regex was pasted verbatim at **four sites plus embedded in a fifth** — which is *why* this class recurs: every new provider phrasing needs N edits and gets fewer. Hoisted to one `_API_ERR_RE`, all five sites repointed, two OpenAI billing phrasings added.

**Deliberately tight** — never a bare `billing` or `error`, which would mask genuine sandy faults that merely mention them. The usage-banner output from the agent-args incident is pinned as a must-still-FAIL case.

### §113 — recognizer driven both ways against real captured strings

| Mutation | Result |
|---|---|
| drop the no-credits alternative | (1) fails — *the reported gap returns* |
| over-broaden to bare `error` | (5)(6)(7) fail — *masking faults* |
| rename the variable | (0)(5)(6) fail — **suite completes** |

That third one initially **aborted the whole suite** (`pass=0, completed=false`): the extraction was an unguarded assignment whose no-match grep exits 1 under the ERR trap — the dead-run class again. Guarded; a rename now fails cleanly.

### Effect on the reporting host

Until credits are added: **90 passed + 2 skipped** *("codex API error, not a sandy fault")* — the honest verdict.