### PR TITLE
chore: bump to 1.9.0

### DIFF
--- a/sandy
+++ b/sandy
@@ -17,7 +17,7 @@ set -euo pipefail
 #   sandy --agent claude,gemini   Override agent selection for this run
 # =============================================================================
 
-SANDY_VERSION="1.8.2-dev"
+SANDY_VERSION="1.9.0"
 SANDY_COMMIT=""  # baked in by install.sh; empty = detect from git at runtime
 
 # Schema contract version for --print-schema / --print-state / --validate-config.


### PR DESCRIPTION
Minor, not patch: two new config keys since 1.8.1 (`SANDY_CLAUDE_CONNECTORS`, `SANDY_SUSPICIOUS`) — the additive class the 1.x discipline routes to `X.(Y+1).0`. Their metadata rows already declared `since=1.9.0`, so this bump closes a declared-vs-actual gap the moment it tags.

`schema_version` stays `1`; forward-compat floor stays `1.0.0`. Integration suite green on the reporting host (two remaining skips are provider billing, recognized as such by #232).

Notes staged in `docs/RELEASE-1.9.0.md` (for the release body, not committed). One line in `sandy`.