### PR TITLE
chore: bump to 1.10.0

### DIFF
--- a/sandy
+++ b/sandy
@@ -17,7 +17,7 @@ set -euo pipefail
 #   sandy --agent claude,gemini   Override agent selection for this run
 # =============================================================================
 
-SANDY_VERSION="1.10.0-dev"
+SANDY_VERSION="1.10.0"
 SANDY_COMMIT=""  # baked in by install.sh; empty = detect from git at runtime
 
 # Schema contract version for --print-schema / --print-state / --validate-config.


### PR DESCRIPTION
Cuts **1.10.0**. Version-only change: `SANDY_VERSION="1.10.0-dev"` → `"1.10.0"`.

Additive under the 1.x semver rule — new keys and flags, no retiering, no renames, and no change to the `schema_version: 1` introspection contract.

## What 1.10.0 contains

- **Handoff tree on by default** (`SANDY_HANDOFF_DIRS` default `0` → `1`), plus new `peer/` (`:ro`) and `relay/` (rw) directories. A host-side process can be pointed at any sandbox with no per-sandbox enabling step.
- **Cross-session inbound** (`SANDY_CROSS_SESSION_INBOUND`) wired to a workspace-supplied **relay** (`SANDY_HANDOFF_RELAY`, privileged). The conditional default resolves to `accept` only when a relay is configured *and* will actually start this launch; a configured relay that cannot start fails the launch.
- **`SANDY_CLAUDE_AUTH=auto|api_key|oauth`** — Claude was the only wrapped agent without an auth knob.
- Proxy built from the local checkout rather than a `git clone` of a mutable remote ref.
- codex `config.toml` `sandbox_mode` repaired by value; `codex login --device-auth` documented as the in-container login.

## Verification

`crossSessionInbound` was measured against the Claude Code **2.1.263** binary the image ships, by running a receiver and injecting into it — `accept` routes and the model acts, `hold` holds with `cause=explicit-setting`, `refuse` drops. Recorded in `docs/security/CROSS_SESSION_INBOUND.md` §6a.

## Known gap, stated rather than glossed

CI covers the pure-script suite. The **Docker acceptance harnesses have not been run on a host from this line** — `acceptance-uds-delivery.sh` (criterion 7.4, three cases) and `acceptance-handoff-dirs.sh` Phase E cover exactly the runtime behaviour this release is about. A maintainer run is worth doing before tagging.

`SANDY_SANDBOX_MIN_COMPAT` stays `0.7.10`, unchanged and well under the `1.0.0` ceiling the forward-compat promise imposes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)