### PR TITLE
chore: bump to 1.10.1-dev after cutting 1.10.0

### DIFF
--- a/sandy
+++ b/sandy
@@ -17,7 +17,7 @@ set -euo pipefail
 #   sandy --agent claude,gemini   Override agent selection for this run
 # =============================================================================
 
-SANDY_VERSION="1.10.0"
+SANDY_VERSION="1.10.1-dev"
 SANDY_COMMIT=""  # baked in by install.sh; empty = detect from git at runtime
 
 # Schema contract version for --print-schema / --print-state / --validate-config.


### PR DESCRIPTION
Post-release bump per the versioning discipline in `CLAUDE.md`: immediately after cutting a release the dev channel moves to `X.Y.(Z+1)-dev`, so nothing built from `main` claims to be the released 1.10.0.

`_ver_lt()` strips everything after the first `-` and the update check uses `releases/latest`, so 1.10.1-dev users are not nagged toward 1.10.0 and stable users are never nagged toward a dev build.

Version-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)