### PR TITLE
docs(readme): add the --exec and --validate-config flag rows, and ratchet the flags table

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Only allowlisted `KEY=VALUE` lines are parsed (not sourced as a shell script). U
 | `--start` | Start a detached [daemon session](#daemon-mode) and return once attachable |
 | `--attach` | Attach an interactive client to a running daemon session |
 | `--stop` | Stop a running daemon session (full teardown) |
+| `--exec [-- CMD]` | Shell (or run `CMD`) inside this workspace's running container, **as the host uid**. Do not hand-roll it: `docker exec -u claude` resolves the name against the *image*, where the user is uid 1001, so it runs as the wrong owner and prints `I have no name!`. Sub-options: `--workspace PATH`, `--dry-run`. See [Getting a shell inside a running sandbox](#getting-a-shell-inside-a-running-sandbox-sandy---exec) |
 | `--stop-all` | **Fleet emergency stop** — stop every daemon session on the host via the hardened per-session teardown. Sub-options: `--dry-run`, `--yes` |
 | `--prune-orphans` | Reap orphaned `sandy_*` Docker networks and exit |
 | `--update-sessions` | Fleet image refresh + rolling restart across every daemon session on the host (scope to one with `--workspace PATH`). See "Fleet updates" above. Sub-options: `--dry-run`, `--yes`, `--idle-for <minutes>`, `--rebuild`, `--workspace` |
@@ -262,7 +263,7 @@ Only allowlisted `KEY=VALUE` lines are parsed (not sourced as a shell script). U
 | `--provision` | Non-interactively create one workspace's sandbox by running the **real launch path** once (start a detached session, confirm it's up, stop it) — never a flag that fabricates state. Safe no-op against a live session. Needs Docker. Sub-options: `--workspace PATH`, `--dry-run`, `--yes` |
 | `--doctor` | Host + runtime readiness check (git/curl/docker/PATH/credentials, plus image staleness and orphaned resources). Exit `0` iff every required host check passes; runtime findings are warnings. Sub-options: `--fix` (clear a dead lock, reap orphaned networks), `--yes` |
 | `--gc` | One-shot global reclaim of leaked sandy Docker resources: dead-owner containers, orphaned `sandy_*` networks, orphaned per-project/skill images, dangling images. Sub-options: `--dry-run`, `--yes` |
-| `--print-state` / `--print-schema` / `--print-version` | Machine-readable JSON introspection (runtime state / static schema / version). Fast-path, no Docker needed for schema/version. See [`SPEC_INTROSPECTION.md`](SPEC_INTROSPECTION.md) |
+| `--print-state` / `--print-schema` / `--print-version` / `--validate-config` | Machine-readable JSON introspection (runtime state / static schema / version). Fast-path, no Docker needed for schema/version. See [`SPEC_INTROSPECTION.md`](SPEC_INTROSPECTION.md) |
 
 **`--start` exit codes:** `0` = ready, `6` = refused before launch (an approval couldn't be granted — answer it once interactively), `7` = container crash-looping, `8` = timed out waiting for the session.
 

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -12292,6 +12292,30 @@ _S119_COUNT="$("$SANDY_SCRIPT" --print-schema 2>/dev/null | tr ',' '\n' \
 check "§119(2) the key extractor found a plausible number of keys (>40), so (1) cannot pass vacuously" \
     bash -c '[ "$1" -gt 40 ]' -- "$_S119_COUNT"
 
+# The CLI-flag half of the same idea. §91 already diffs cli_flags against the
+# parsers and against --help; nothing tied it to README, and `--exec` shipped
+# with a how-to section but no row in the flags table -- exactly the reader who
+# then hand-rolls `docker exec -u claude`. Same failure as SANDY_CLAUDE_AUTH
+# missing from the config table: prose and schema updated, reference table not.
+# Scoped to the FLAGS TABLE, not the whole file. A first cut grepped all of
+# README and was satisfied by prose: `--exec` had a how-to section, so the check
+# passed while the table row -- the thing a reader scans -- was still missing.
+# That is the same vacuity trap as §120's dry-run-only checks.
+# --help/--version are exempt: universal CLI conventions, and this table
+# documents sandy-specific behaviour rather than restating them.
+_S119_FLAG_EXEMPT="--help --version"
+_S119_FLAGROWS="$(grep '^| `--' "$_S119_README" || true)"
+_S119_FLAGS_MISSING="$("$SANDY_SCRIPT" --print-schema 2>/dev/null | tr ',' '\n' \
+    | sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"\(--[a-z-]*\)".*/\1/p' | sort -u \
+    | while IFS= read -r _f; do
+          case " $_S119_FLAG_EXEMPT " in *" $_f "*) continue ;; esac
+          printf '%s' "$_S119_FLAGROWS" | grep -q -- "\`$_f" || printf '%s ' "$_f"
+      done)"
+check "§119(4) every cli_flag has a row in README.md's flags TABLE (prose does not count)${_S119_FLAGS_MISSING:+ — missing: $_S119_FLAGS_MISSING}" \
+    bash -c '[ -z "$1" ]' -- "$_S119_FLAGS_MISSING"
+check "§119(5) the flag extractor found a plausible number of flags (>15), so (4) cannot pass vacuously" \
+    bash -c '[ "$("$2" --print-schema 2>/dev/null | tr "," "\n" | sed -n "s/.*\"name\"[[:space:]]*:[[:space:]]*\"\(--[a-z-]*\)\".*/\1/p" | sort -u | wc -l)" -gt 15 ]' -- "" "$SANDY_SCRIPT"
+
 check "§119(3) the two 1.10.0 keys this guard was written for are present" \
     bash -c 'grep -q SANDY_CLAUDE_AUTH "$1" && grep -q SANDY_CROSS_SESSION_INBOUND "$1"' -- "$_S119_README"
 


### PR DESCRIPTION
`--exec` had a how-to section but **no row in README's CLI flags table** — where `--start`/`--attach`/`--stop`/`--provision` all live. `--validate-config` was absent from README entirely.

Same shape as the `SANDY_CLAUDE_AUTH` miss: prose and schema updated, reference table not.

## The ratchet, and why the first cut was wrong

§91 diffs `cli_flags` against the parsers and `--help`; §119 ratchets config keys against README. Nothing tied CLI flags to README — §119(4–5) does.

My first version grepped **all of README** and passed, because the `--exec` how-to section mentions ```--exec``` in prose. It would not have caught the gap it exists for. Now scoped to the flags table.

Mutation-tested: removing only the table row while leaving the prose fails with `missing: --exec`. §119(5) asserts >15 flags found, so (4) can't pass vacuously.

`--help`/`--version` exempt, reason stated in-line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)