### PR TITLE
fix(claude): validate CLAUDE_CODE_SUBAGENT_MODEL — .sandy/config does not strip inline comments

### DIFF
--- a/sandy
+++ b/sandy
@@ -11811,6 +11811,18 @@ if [ -n "$SANDY_MODEL" ] && ! [[ "$SANDY_MODEL" =~ ^[a-zA-Z0-9._-]+$ ]]; then
     error "Invalid SANDY_MODEL: $SANDY_MODEL (only alphanumeric, hyphens, dots, underscores allowed)"
     exit 1
 fi
+# Same validation for the SUBAGENT model, and for a sharper reason than symmetry.
+# The config parser does NOT strip inline comments -- `KEY=value   # note` yields
+# the literal "value   # note" -- so a copy-pasted line with a trailing comment
+# silently produces a bogus model ID. SANDY_MODEL has caught that since 0.x; this
+# key shipped without it, and an unvalidated subagent model fails in the worst
+# way available: the orchestrator runs on the pinned model, the fan-out quietly
+# does not, and nothing in the transcript says so.
+if [ -n "${CLAUDE_CODE_SUBAGENT_MODEL:-}" ] && ! [[ "$CLAUDE_CODE_SUBAGENT_MODEL" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+    error "Invalid CLAUDE_CODE_SUBAGENT_MODEL: $CLAUDE_CODE_SUBAGENT_MODEL (only alphanumeric, hyphens, dots, underscores allowed)"
+    error "  Note: .sandy/config does not strip inline comments — put '# ...' on its own line, not after a value."
+    exit 1
+fi
 # Validate SANDY_EFFORT — Claude Code reasoning effort (claude only), applied as
 # `claude --effort <level>` in build_claude_cmd. Empty = Claude Code's own default
 # (currently 'high'). Cleared when claude isn't in the agent set so it's never a

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -12502,6 +12502,37 @@ check "§121(3) the sibling MAX_OUTPUT_TOKENS forwarding is unaffected" \
 check "§121(4) the key is PASSIVE (a model ID is not a capability)" \
     bash -c 'awk "/^SANDY_PASSIVE_KEYS=\(/,/^\)/" "$1" | grep -qx "    CLAUDE_CODE_SUBAGENT_MODEL"' -- "$SANDY_SCRIPT"
 
+# The config parser does NOT strip inline comments: `KEY=v   # note` yields the
+# literal "v   # note". SANDY_MODEL has rejected that for years; this key shipped
+# without the check, so a copy-pasted line with a trailing comment silently
+# mis-pinned the fan-out. Driven through the REAL extracted validation block --
+# the introspection flags are fast-path handlers that exit long before it, so a
+# `sandy --print-version` probe would pass vacuously no matter what the code did.
+_S121_VBLK="$(awk '/^# Same validation for the SUBAGENT model/,/^fi$/' "$SANDY_SCRIPT")"
+check "§121(5pre) extracted the validation block (mutation: a reword fails HERE, not vacuously below)" \
+    bash -c 'printf "%s" "$1" | grep -q "Invalid CLAUDE_CODE_SUBAGENT_MODEL" && printf "%s" "$1" | bash -n' -- "$_S121_VBLK"
+
+_s121_validate() {   # $1 = value -> "rc=<n> <stderr>"
+    S121_VBLK="$_S121_VBLK" CLAUDE_CODE_SUBAGENT_MODEL="$1" bash -c '
+        set -u
+        error() { printf "%s\n" "$*" >&2; }
+        rc=0
+        # SUBSHELL: the block ends in `exit 1`, which would otherwise take this
+        # probe shell with it and the rc line would never print.
+        ( eval "$S121_VBLK" ) 2>&1 || rc=$?
+        printf "rc=%s\n" "$rc"
+    ' 2>&1
+}
+_S121_BAD="$(trap - ERR; _s121_validate "claude-mythos-5-1   # new")"
+check "§121(5) a value carrying an inline comment is REJECTED (exit 1), naming the comment trap" \
+    bash -c 'printf "%s" "$1" | grep -q "^rc=1$" && printf "%s" "$1" | grep -q "Invalid CLAUDE_CODE_SUBAGENT_MODEL" && printf "%s" "$1" | grep -q "inline comments"' -- "$_S121_BAD"
+_S121_OK="$(trap - ERR; _s121_validate claude-mythos-5-1)"
+check "§121(6) a legitimate model ID is accepted (rc=0, no error)" \
+    bash -c 'printf "%s" "$1" | grep -q "^rc=0$" && ! printf "%s" "$1" | grep -q Invalid' -- "$_S121_OK"
+_S121_EMPTY="$(trap - ERR; _s121_validate "")"
+check "§121(7) unset/empty is accepted — the key is optional, not required" \
+    bash -c 'printf "%s" "$1" | grep -q "^rc=0$"' -- "$_S121_EMPTY"
+
 # ============================================================
 # WHY. The Summary block below used to sit in the MIDDLE of this file: sections
 # appended afterwards ran, counted, and then nothing printed a final tally. A


### PR DESCRIPTION
`.sandy/config` splits on the first `=` and strips only a trailing CR and surrounding quotes. It does **not** strip inline comments, so

```
CLAUDE_CODE_SUBAGENT_MODEL=claude-mythos-5-1   # new
```

exports the literal `claude-mythos-5-1   # new`. `SANDY_MODEL` has rejected that for years; the subagent key shipped one commit ago without it.

Worst-case failure for this key specifically: an invalid *orchestrator* model fails loudly on the first request, but an invalid *subagent* model means the orchestrator runs on the pinned model while the fan-out quietly doesn't — the exact symptom the key was added to fix.

Error message names the comment trap, since the offending value doesn't look wrong until you know the parser keeps everything after the `=`.

Guarded by §121(5–7), driving the real extracted block — a `sandy --print-version` probe would pass vacuously because the introspection flags are fast-path handlers that exit before this check. Mutation-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)